### PR TITLE
docs: add agent workflow skills

### DIFF
--- a/.agents/skills/byterover/SKILL.md
+++ b/.agents/skills/byterover/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: byterover
-description: 'Use this skill before broad repository exploration to recall project knowledge with brv search, and before the final response after non-trivial implementation to decide whether durable knowledge must be captured with brv curate. Prefer brv search before brv query. Curate reusable lessons, pitfalls, decisions, and corrected mistakes, not transient task details.'
+description: "Use this skill before broad repository exploration to recall project knowledge with brv search, and before the final response after non-trivial implementation to decide whether durable knowledge must be captured with brv curate. Prefer brv search before brv query. Curate reusable lessons, pitfalls, decisions, and corrected mistakes, not transient task details."
 ---
 
 # ByteRover knowledge workflow
@@ -79,18 +79,23 @@ Use this structure when saving a corrected mistake, pitfall, or reusable workflo
 # Lesson: <short name>
 
 ## Trigger
+
 When this lesson applies.
 
 ## Mistake to avoid
+
 What the agent did wrong, nearly did wrong, or might incorrectly assume.
 
 ## Correct approach
+
 What future agents should do instead in this project.
 
 ## Verification
+
 How to check the correct behavior or avoid regression.
 
 ## Applies to
+
 Relevant paths, layers, commands, skills, or task types.
 ```
 

--- a/.agents/skills/byterover/SKILL.md
+++ b/.agents/skills/byterover/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: byterover
-description: 'Use this skill before broad repository exploration to recall project knowledge with brv search, and before the final response after non-trivial implementation to decide whether durable knowledge must be captured with brv curate. Prefer brv search before brv query. Do not curate transient task details.'
+description: 'Use this skill before broad repository exploration to recall project knowledge with brv search, and before the final response after non-trivial implementation to decide whether durable knowledge must be captured with brv curate. Prefer brv search before brv query. Curate reusable lessons, pitfalls, decisions, and corrected mistakes, not transient task details.'
 ---
 
 # ByteRover knowledge workflow
@@ -48,12 +48,14 @@ Run `brv curate` when the task produced any of these:
 - a reusable implementation rule;
 - a decision that should guide future agents;
 - a repeated user correction;
+- a mistake the agent made or nearly made, plus the corrected approach;
 - a verified third-party or tool behavior that was previously uncertain;
-- a non-obvious testing, verification, CRDT, storage, UI, or FSD lesson.
+- a non-obvious testing, verification, CRDT, storage, UI, FSD, or performance lesson.
 
 Do not run `brv curate` for:
 
 - transient task progress;
+- task summaries or commit summaries;
 - obvious facts already documented;
 - one-off implementation details unlikely to repeat;
 - general knowledge unrelated to this project;
@@ -65,16 +67,58 @@ When unsure, run `brv search` first to avoid duplicate memory:
 brv search "<candidate memory topic>" --limit 5
 ```
 
-Then curate only if the knowledge is new or meaningfully updated:
+Then curate only if the knowledge is new or meaningfully updated.
+
+## Lesson format
+
+Curate experience as lessons, not as task history.
+
+Use this structure when saving a corrected mistake, pitfall, or reusable workflow:
+
+```md
+# Lesson: <short name>
+
+## Trigger
+When this lesson applies.
+
+## Mistake to avoid
+What the agent did wrong, nearly did wrong, or might incorrectly assume.
+
+## Correct approach
+What future agents should do instead in this project.
+
+## Verification
+How to check the correct behavior or avoid regression.
+
+## Applies to
+Relevant paths, layers, commands, skills, or task types.
+```
+
+Example curation command:
 
 ```bash
-brv curate "<durable project knowledge>"
+brv curate "# Lesson: Prefer browser checks for DOM-dependent Vue behavior
+
+## Trigger
+Changing Vue UI behavior involving focus, teleport, scroll, overlays, pointer/touch input, responsive layout, or Material visual states.
+
+## Mistake to avoid
+Do not add Vue component unit tests for behavior that depends on real browser layout or interaction semantics.
+
+## Correct approach
+Use the ui-browser-behavior skill and verify with Playwright/e2e or a reproducible browser smoke check. Extract pure state transitions to composables/helpers only when they can be tested without browser semantics.
+
+## Verification
+Run the focused Playwright spec or document the browser smoke check, then run final pnpm verify.
+
+## Applies to
+Vue components in pages, widgets, features, entities UI, and shared UI."
 ```
 
 Include source files only when they add important context, with at most five project-scoped files:
 
 ```bash
-brv curate "<durable project knowledge>" -f src/example/file.ts
+brv curate "<lesson content>" -f src/example/file.ts
 ```
 
 ## Capture quality
@@ -83,9 +127,11 @@ Curated knowledge must be short, reusable, and project-specific.
 
 Good entries include:
 
-- what was learned;
+- the trigger that makes the lesson relevant;
+- the mistake, pitfall, or wrong assumption to avoid;
+- the correct project-specific approach;
+- the verification method;
 - where it applies;
-- what future agents should do or avoid;
 - source files when needed.
 
 Bad entries include:
@@ -93,7 +139,8 @@ Bad entries include:
 - task summaries;
 - commit summaries;
 - vague statements such as "fixed tests";
-- duplicated rules already present in `AGENTS.md` or skills.
+- duplicated rules already present in `AGENTS.md` or skills;
+- implementation details without a reusable lesson.
 
 ## Final response requirement
 

--- a/.agents/skills/byterover/SKILL.md
+++ b/.agents/skills/byterover/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: byterover
-description: "Use this skill before broad repository exploration to recall project knowledge with brv search, and before the final response after non-trivial implementation to decide whether durable knowledge must be captured with brv curate. Prefer brv search before brv query. Curate reusable lessons, pitfalls, decisions, and corrected mistakes, not transient task details."
+description: 'Use this skill before broad repository exploration to recall project knowledge with brv search, and before the final response after non-trivial implementation to decide whether durable knowledge must be captured with brv curate. Prefer brv search before brv query. Curate reusable lessons, pitfalls, decisions, and corrected mistakes, not transient task details.'
 ---
 
 # ByteRover knowledge workflow
@@ -99,28 +99,33 @@ How to check the correct behavior or avoid regression.
 Relevant paths, layers, commands, skills, or task types.
 ```
 
-Example curation command:
+Example lesson content:
 
-```bash
-brv curate "# Lesson: Prefer browser checks for DOM-dependent Vue behavior
+```md
+# Lesson: Prefer browser checks for DOM-dependent Vue behavior
 
 ## Trigger
+
 Changing Vue UI behavior involving focus, teleport, scroll, overlays, pointer/touch input, responsive layout, or Material visual states.
 
 ## Mistake to avoid
+
 Do not add Vue component unit tests for behavior that depends on real browser layout or interaction semantics.
 
 ## Correct approach
+
 Use the ui-browser-behavior skill and verify with Playwright/e2e or a reproducible browser smoke check. Extract pure state transitions to composables/helpers only when they can be tested without browser semantics.
 
 ## Verification
+
 Run the focused Playwright spec or document the browser smoke check, then run final pnpm verify.
 
 ## Applies to
-Vue components in pages, widgets, features, entities UI, and shared UI."
+
+Vue components in pages, widgets, features, entities UI, and shared UI.
 ```
 
-Include source files only when they add important context, with at most five project-scoped files:
+Curate the lesson content, optionally with source files when they add important context. Include at most five project-scoped files:
 
 ```bash
 brv curate "<lesson content>" -f src/example/file.ts

--- a/.agents/skills/byterover/SKILL.md
+++ b/.agents/skills/byterover/SKILL.md
@@ -1,598 +1,139 @@
 ---
 name: byterover
-description: 'You MUST use this for gathering contexts before any work. This is a knowledge management workflow for AI agents. Use `brv` to store and retrieve project patterns, decisions, and architectural rules in `.brv/context-tree`. `brv search` works without an LLM provider; `brv query` and `brv curate` require a configured provider.'
+description: 'Use this skill before broad repository exploration to recall project knowledge with brv search, and before the final response after non-trivial implementation to decide whether durable knowledge must be captured with brv curate. Prefer brv search before brv query. Do not curate transient task details.'
 ---
 
-# ByteRover Knowledge Management
+# ByteRover knowledge workflow
 
-Use the `brv` CLI to manage your project's long-term memory.
-Install: `npm install -g byterover-cli`
-Knowledge is stored in `.brv/context-tree/` as human-readable Markdown files.
+Use `brv` to retrieve and maintain project knowledge in `.brv/context-tree`.
 
-`brv search` works locally without an LLM provider. `brv query` and `brv curate` require a configured provider, and some providers may require authentication before they can be used. Treat provider and auth requirements as CLI-version-dependent behavior and verify with `brv providers` when in doubt.
+`brv search` is local BM25 search and does not require an LLM provider. `brv query` and `brv curate` require a configured provider and may require authentication.
 
 In Codex, run `brv` outside the default sandbox. `brv` starts a local daemon and uses global state directories, so sandboxed runs can hang or fail even when the project `.brv` tree is present.
 
-## Workflow
+## Activation
 
-1.  **Before Broad Exploration:** Run `brv search` first to find relevant stored context without LLM synthesis.
-2.  **When Search Is Insufficient:** Use `brv query` only when local search results are insufficient or a synthesized answer is needed.
-3.  **After Implementing:** Use `brv curate` only for durable decisions, confirmed pitfalls, or reusable project rules.
+Use this skill in two places:
 
-## Commands
+1. **Before broad exploration** when project decisions, prior pitfalls, architecture rules, or implementation patterns may already exist.
+2. **Before the final response after non-trivial implementation** to decide whether new durable knowledge should be saved.
 
-### 1. Query Knowledge
+Do not use this skill for trivial edits when all needed context is already present and no reusable knowledge was created.
 
-**Overview:** Retrieve relevant context from your project's knowledge base. Uses a configured LLM provider to synthesize answers from `.brv/context-tree/` content.
+## Start-of-task retrieval
 
-**Use this skill when:**
-
-- The user wants you to recall something
-- Your context does not contain information you need
-- You need to recall your capabilities or past actions
-- Before performing any action, to check for relevant rules, criteria, or preferences
-
-**Do NOT use this skill when:**
-
-- The information is already present in your current context
-- The query is about general knowledge, not stored memory
+Before broad repository exploration, run local search first:
 
 ```bash
-brv query "How is authentication implemented?"
+brv search "<topic>" --limit 5
 ```
 
-### 2. Search Context Tree
+Use focused queries that include the domain, behavior, or component being changed.
 
-**Overview:** Retrieve a ranked list of matching files from `.brv/context-tree/` via pure BM25 lookup. Unlike `brv query`, this does NOT call an LLM — no synthesis, no token cost, no provider setup needed. Returns structured results with paths, scores, and excerpts.
-
-**Use this skill when:**
-
-- You need file paths to read rather than a synthesized answer
-- You want fast, cheap retrieval with no LLM overhead
-- You're in an automated pipeline that consumes structured results
-
-**Do NOT use this skill when:**
-
-- You need a natural-language answer synthesized from multiple files — use `brv query` instead
-- The information is already present in your current context
+Use `brv query` only when search results are insufficient and a synthesized answer is needed:
 
 ```bash
-brv search "authentication patterns"
-brv search "JWT tokens" --limit 5 --scope "auth/"
-brv search "auth" --format json
+brv query "<specific project question>"
 ```
 
-**Flags:** `--limit N` (1-50, default 10), `--scope "domain/"` (path prefix filter), `--format json` (structured output for automation).
+Prefer reading the matched `.brv/context-tree` files directly when `brv search` returns enough context.
 
-### 3. Curate Context
+## End-of-task capture gate
 
-**Overview:** Analyze and save knowledge to the local knowledge base. Uses a configured LLM provider to categorize and structure the context you provide.
+Before the final response after non-trivial implementation, explicitly decide whether the task produced durable project knowledge.
 
-**Use this skill when:**
+Run `brv curate` when the task produced any of these:
 
-- The user wants you to remember something
-- The user intentionally curates memory or knowledge
-- There are meaningful memories from user interactions that should be persisted
-- There are important facts about what you do, what you know, or what decisions and actions you have taken
+- a confirmed project pitfall;
+- a reusable implementation rule;
+- a decision that should guide future agents;
+- a repeated user correction;
+- a verified third-party or tool behavior that was previously uncertain;
+- a non-obvious testing, verification, CRDT, storage, UI, or FSD lesson.
 
-**Do NOT use this skill when:**
+Do not run `brv curate` for:
 
-- The information is already stored and unchanged
-- The information is transient or only relevant to the current task, or just general knowledge
+- transient task progress;
+- obvious facts already documented;
+- one-off implementation details unlikely to repeat;
+- general knowledge unrelated to this project;
+- information that is already present and unchanged in `.brv/context-tree`.
+
+When unsure, run `brv search` first to avoid duplicate memory:
 
 ```bash
-brv curate "Auth uses JWT with 24h expiry. Tokens stored in httpOnly cookies via authMiddleware.ts"
+brv search "<candidate memory topic>" --limit 5
 ```
 
-**Include source files** (max 5, project-scoped only):
+Then curate only if the knowledge is new or meaningfully updated:
 
 ```bash
-brv curate "Authentication middleware details" -f src/middleware/auth.ts
+brv curate "<durable project knowledge>"
 ```
 
-**View curate history:** to check past curations
-
-- Show recent entries (last 10)
+Include source files only when they add important context, with at most five project-scoped files:
 
 ```bash
-brv curate view
+brv curate "<durable project knowledge>" -f src/example/file.ts
 ```
 
-- Full detail for a specific entry: all files and operations performed (logId is printed by `brv curate` on completion, e.g. `cur-1739700001000`)
+## Capture quality
 
-```bash
-brv curate view cur-1739700001000
+Curated knowledge must be short, reusable, and project-specific.
+
+Good entries include:
+
+- what was learned;
+- where it applies;
+- what future agents should do or avoid;
+- source files when needed.
+
+Bad entries include:
+
+- task summaries;
+- commit summaries;
+- vague statements such as "fixed tests";
+- duplicated rules already present in `AGENTS.md` or skills.
+
+## Final response requirement
+
+After implementation work, include a BRV result in the final response:
+
+```text
+BRV RESULT
+status: curated | skipped | failed | not available
+reason:
 ```
 
-- List entries with file operations visible (no logId needed)
+Use:
 
-```bash
-brv curate view detail
-```
+- `curated` when `brv curate` saved or proposed durable knowledge;
+- `skipped` when you intentionally decided no durable knowledge was produced;
+- `failed` when `brv` should have been used but failed;
+- `not available` when `brv` is not installed, not authenticated, unavailable in the environment, or cannot run outside the sandbox.
 
-- Filter by time and status
+## Review pending changes
 
-```bash
-brv curate view --since 1h --status completed
-```
-
-- For all filter options
-
-```bash
-brv curate view --help
-```
-
-### 4. Review Pending Changes
-
-**Overview:** After a curate operation, some changes may require human review before being applied. Use `brv review` to list, approve, or reject pending operations.
-
-**Use this when:**
-
-- A curate operation reports pending reviews (shown in curate output)
-- The user wants to check, approve, or reject pending changes
-
-**Do NOT use this skill when:**
-
-- There are no pending reviews (check with `brv review pending` first)
-
-**Commands:**
-
-List all pending reviews for the current project:
+If `brv curate` reports pending review operations, inspect them before final response:
 
 ```bash
 brv review pending
 ```
 
-Sample output:
+Do not approve or reject critical pending memory changes without user approval.
 
-```
-2 operations pending review
+## Version control and sync
 
-  Task: ddcb3dc6-d957-4a56-b9c3-d0bdc04317f3
-  [UPSERT · HIGH IMPACT] - path: architecture/context/context_compression_pipeline.md
-  Why:    Documenting switch to token-budget sliding window
-  After:  Context compression pipeline switching from reactive-overflow to token-budget sliding window in src/agent/infra/llm/context/compression/
+The project may sync `.brv/context-tree` through Codex hooks. Do not manually run `brv vc push`, `brv vc pull`, or remote sync commands unless the user explicitly asks or a BRV sync task requires it.
 
-  [UPSERT · HIGH IMPACT] - path: architecture/tools/agent_tool_registry.md
-  Why:    Documenting tool registry rewrite with capability-based permissions
-  After:  Agent tool registry rewrite in src/agent/infra/tools/tool-registry.ts using capability-based permissions
+## Error handling
 
-  To approve all:  brv review approve ddcb3dc6-d957-4a56-b9c3-d0bdc04317f3
-  To reject all:   brv review reject ddcb3dc6-d957-4a56-b9c3-d0bdc04317f3
-  Per file:        brv review <approve|reject> ddcb3dc6-d957-4a56-b9c3-d0bdc04317f3 --file <path> [--file <path>]
-```
+If `brv` fails:
 
-Each pending task shows: operation type (ADD/UPDATE/DELETE/MERGE/UPSERT), file path, reason, and before/after summaries. High-impact operations are flagged.
+- `Not authenticated` or `Token has expired`: report that authentication is required.
+- `No provider connected`: run `brv providers` if available and report the missing provider.
+- `Connection failed` or daemon crash: report that the user should stop the stale `brv` process.
+- Missing arguments: run `brv <command> --help` and retry with corrected arguments.
+- File errors: use project-relative paths and include no more than five files.
 
-Approve all operations for a task (applies the changes):
-
-```bash
-brv review approve <taskId>
-```
-
-Reject all operations for a task (discards pending changes; restores backup for UPDATE/DELETE operations):
-
-```bash
-brv review reject <taskId>
-```
-
-Approve or reject specific files within a task:
-
-```bash
-brv review approve <taskId> --file <path> --file <path>
-brv review reject <taskId> --file <path>
-```
-
-File paths are relative to context tree (as shown in `brv review pending` output).
-
-**Note**: Always ask the user before approving or rejecting critical changes.
-
-**JSON output** (useful for agent-driven workflows):
-
-```bash
-brv review pending --format json
-brv review approve <taskId> --format json
-brv review reject <taskId> --format json
-```
-
-### 5. LLM Provider Setup
-
-`brv query` and `brv curate` require a configured LLM provider. Check the current provider first:
-
-```bash
-brv providers
-```
-
-Connect the ByteRover provider if available in your environment:
-
-```bash
-brv providers connect byterover
-```
-
-If the CLI asks you to authenticate, complete that step first:
-
-```bash
-brv login
-brv providers connect byterover
-```
-
-To use a different provider (e.g., OpenAI, Anthropic, Google), list available options and connect with your own API key:
-
-```bash
-brv providers list
-brv providers connect openai --api-key sk-xxx --model gpt-4.1
-```
-
-### 6. Project Locations
-
-**Overview:** List registered projects and their context tree paths. Returns project metadata including initialization status and active state. Use `-f json` for machine-readable output.
-
-**Use this when:**
-
-- You need to find a project's context tree path
-- You need to check which projects are registered
-- You need to verify if a project is initialized
-
-**Do NOT use this when:**
-
-- You already know the project path from your current context
-- You need project content rather than metadata — use `brv query` instead
-
-```bash
-brv locations -f json
-```
-
-JSON fields: `projectPath`, `contextTreePath`, `isCurrent`, `isActive`, `isInitialized`.
-
-### 7. Version Control
-
-**Overview:** `brv vc` provides git-based version control for your context tree. It uses standard git semantics — branching, committing, merging, history, and conflict resolution — all working locally with no authentication required. Remote sync with a team is optional. The legacy `brv push`, `brv pull`, and `brv space` commands are deprecated — use `brv vc push`, `brv vc pull`, and `brv vc clone`/`brv vc remote add` instead.
-
-**Use this when:**
-
-- The user wants to track, commit, or inspect changes to the knowledge base
-- The user wants to branch, merge, or undo knowledge changes
-- The user wants to sync knowledge with a team (push/pull)
-- The user wants to connect to or clone a team space
-- The user asks about knowledge history or diffs
-
-**Do NOT use this when:**
-
-- The user wants to query or curate knowledge — use `brv query`/`brv curate` instead
-- The user wants to review pending curate operations — use `brv review` instead
-- Version control is not initialized and the user didn't ask to set it up
-
-**Commands:**
-
-Available commands: `init`, `status`, `add`, `commit`, `reset`, `log`, `branch`, `checkout`, `merge`, `config`, `clone`, `remote`, `fetch`, `push`, `pull`.
-
-#### First-Time Setup
-
-**Setup — local (no auth needed):**
-
-```bash
-brv vc init
-brv vc config user.name "Your Name"
-brv vc config user.email "you@example.com"
-```
-
-**Setup — clone a team space (requires `brv login`):**
-
-```bash
-brv login --api-key sample-key-string
-brv vc clone https://byterover.dev/<team>/<space>.git
-```
-
-**Setup — connect existing project to a remote (requires `brv login`):**
-
-```bash
-brv login --api-key sample-key-string
-brv vc remote add origin https://byterover.dev/<team>/<space>.git
-```
-
-#### Local Workflow
-
-**Check status:**
-
-```bash
-brv vc status
-```
-
-**Stage and commit:**
-
-```bash
-brv vc add .                     # stage all
-brv vc add notes.md docs/        # stage specific files
-brv vc commit -m "add authentication patterns"
-```
-
-**View history:**
-
-```bash
-brv vc log
-brv vc log --limit 20
-brv vc log --all
-```
-
-**Unstage or undo:**
-
-```bash
-brv vc reset                     # unstage all files
-brv vc reset <file>              # unstage a specific file
-brv vc reset --soft HEAD~1       # undo last commit, keep changes staged
-brv vc reset --hard HEAD~1       # discard last commit and changes
-```
-
-#### Branch Management
-
-```bash
-brv vc branch                    # list branches
-brv vc branch feature/auth       # create a branch
-brv vc branch -a                 # list all (including remote-tracking)
-brv vc branch -d feature/auth    # delete a branch
-brv vc checkout feature/auth     # switch branch
-brv vc checkout -b feature/new   # create and switch
-```
-
-**Merge:**
-
-```bash
-brv vc merge feature/auth        # merge into current branch
-brv vc merge --continue          # continue after resolving conflicts
-brv vc merge --abort             # abort a conflicted merge
-```
-
-**Set upstream tracking:**
-
-```bash
-brv vc branch --set-upstream-to origin/main
-```
-
-#### Cloud Sync (Remote Operations)
-
-Requires ByteRover authentication (`brv login`) and a configured remote.
-
-**Manage remotes:**
-
-```bash
-brv vc remote                    # show current remote
-brv vc remote add origin <url>   # add a remote
-brv vc remote set-url origin <url>  # update remote URL
-```
-
-**Fetch, pull, and push:**
-
-```bash
-brv vc fetch                     # fetch remote refs
-brv vc pull                      # fetch + merge remote commits
-brv vc push                      # push commits to cloud
-brv vc push -u origin main       # push and set upstream tracking
-```
-
-**Clone a space:**
-
-```bash
-brv vc clone https://byterover.dev/<team>/<space>.git
-```
-
-### 8. Swarm Query
-
-**Overview:** Search across all active memory providers simultaneously — ByteRover context tree, Obsidian vault, Local Markdown folders, GBrain, and Memory Wiki. Results are fused via Reciprocal Rank Fusion (RRF) and ranked by provider weight and relevance. No LLM call — pure algorithmic search.
-
-**Use this skill when:**
-
-- You need to search across multiple knowledge sources at once
-- The user has configured multiple memory providers (check with `brv swarm status`)
-- You want results from Obsidian notes, GBrain entities, or wiki pages alongside ByteRover context
-
-**Do NOT use this skill when:**
-
-- The user only has ByteRover configured — use `brv query` instead (it synthesizes via LLM)
-- You need an LLM-synthesized answer — `brv swarm query` returns raw search results, not synthesized text
-
-```bash
-brv swarm query "How does JWT refresh work?"
-```
-
-Output:
-
-```
-Swarm Query: "How does JWT refresh work?"
-Type: factual | Providers: 4 queried | Latency: 398ms
-──────────────────────────────────────────────────
-1. [memory-wiki] sources/jwt-token-lifecycle.md    score: 0.0150  [keyword]
-   # JWT Token Lifecycle ...
-2. [obsidian] SwarmTestData/Authentication System.md    score: 0.0142  [keyword]
-   # Authentication System ...
-3. [gbrain] alex-chen    score: 0.0117  [semantic]
-   # Alex Chen — Senior Backend Engineer ...
-```
-
-**With explain mode** (shows classification, provider selection, enrichment):
-
-```bash
-brv swarm query "authentication patterns" --explain
-```
-
-Output:
-
-```
-Classification: factual
-Provider selection: 4 of 4 available
-  ✓ byterover    (healthy, selected, 0 results, 14ms)
-  ✓ obsidian    (healthy, selected, 5 results, 91ms)
-  ✓ memory-wiki    (healthy, selected, 2 results, 15ms)
-  ✓ gbrain    (healthy, selected, 1 results, 260ms)
-Enrichment:
-  byterover → obsidian
-  byterover → memory-wiki
-Results: 8 raw → 7 after RRF fusion + precision filtering
-```
-
-**JSON output:**
-
-```bash
-brv swarm query "rate limiting" --format json
-```
-
-Output:
-
-```json
-{
-  "meta": {
-    "queryType": "factual",
-    "totalLatencyMs": 340,
-    "providers": {
-      "byterover": { "selected": true, "resultCount": 0 },
-      "obsidian": { "selected": true, "resultCount": 5 },
-      "gbrain": { "selected": true, "resultCount": 1 },
-      "memory-wiki": { "selected": true, "resultCount": 1 }
-    }
-  },
-  "results": [
-    {
-      "provider": "memory-wiki",
-      "providerType": "memory-wiki",
-      "score": 0.015,
-      "content": "# Rate Limiting ..."
-    }
-  ]
-}
-```
-
-**Limit results:**
-
-```bash
-brv swarm query "testing strategy" -n 5
-```
-
-**Flags:** `--explain` (show routing details), `--format json` (structured output), `-n <value>` (max results).
-
-### 9. Swarm Curate
-
-**Overview:** Store knowledge in the best available external memory provider. ByteRover automatically classifies the content type and routes accordingly: entities (people, orgs) go to GBrain, notes (meeting notes, TODOs) go to Local Markdown, general content goes to the first writable provider. Falls back to ByteRover context tree if no external providers are available.
-
-**Use this skill when:**
-
-- You want to store knowledge in an external provider (GBrain, Local Markdown, Memory Wiki)
-- The user has configured writable swarm providers
-
-**Do NOT use this skill when:**
-
-- You want to store in ByteRover's context tree specifically — use `brv curate` instead
-- No swarm providers are configured — use `brv curate` instead
-
-```bash
-brv swarm curate "Jane Smith is the CTO of TechCorp"
-```
-
-Output:
-
-```
-Stored to gbrain as concept/jane-smith-cto
-```
-
-**Target a specific provider:**
-
-```bash
-brv swarm curate "meeting notes: decided on JWT" --provider local-markdown:notes
-```
-
-Output:
-
-```
-Stored to local-markdown:notes as note-1776052527043.md
-```
-
-```bash
-brv swarm curate "Architecture uses event sourcing" --provider gbrain
-```
-
-Output:
-
-```
-Stored to gbrain as concept/event-sourcing-architecture
-```
-
-**JSON output:**
-
-```bash
-brv swarm curate "Test content" --format json
-```
-
-Output:
-
-```json
-{
-  "id": "note-1776052594462.md",
-  "provider": "local-markdown:project-docs",
-  "success": true,
-  "latencyMs": 1
-}
-```
-
-**Flags:** `--provider <id>` (target specific provider), `--format json` (structured output).
-
-### 10. Swarm Status
-
-**Overview:** Check provider health and write targets before running swarm query or curate. Use this to verify which providers are available and operational.
-
-**Use this skill when:**
-
-- Before running `brv swarm query` or `brv swarm curate` to check available providers
-- Diagnosing why swarm results are missing from a specific provider
-
-```bash
-brv swarm status
-```
-
-Output:
-
-```
-Memory Swarm Health Check
-════════════════════════════════════════
-  ✓ ByteRover       context-tree (always on)
-  ✓ Obsidian        /Users/you/Documents/MyObsidian
-  ✓ Local .md       1 folder(s)
-  ✓ GBrain          /Users/you/workspaces/gbrain
-  ✓ Memory Wiki     /Users/you/.openclaw/wiki/main
-
-Write Targets:
-  gbrain (entity, general)
-  local-markdown:project-docs (note, general)
-
-Swarm is operational (5/5 providers configured).
-```
-
-## Data Handling
-
-**Storage**: All knowledge is stored as Markdown files in `.brv/context-tree/` within the project directory. Files are human-readable and version-controllable.
-
-**File access**: The `-f` flag on `brv curate` reads files from the current project directory only. Paths outside the project root are rejected. Maximum 5 files per command, text and document formats only.
-
-**LLM usage**: `brv query` and `brv curate` send context to a configured LLM provider for processing. The LLM sees the query or curate text and any included file contents. No data is sent to ByteRover servers unless you explicitly use a ByteRover cloud feature such as `brv login` plus remote sync commands.
-
-**Cloud sync**: `brv vc push` and `brv vc pull` require authentication (`brv login`) and sync knowledge with ByteRover's cloud service via git. Other commands may still require authentication depending on the configured provider, so rely on `brv providers` and real CLI output rather than assuming anonymous access.
-
-## Error Handling
-
-**User Action Required:**
-You MUST show this troubleshooting guide to users when errors occur.
-
-"Not authenticated" | Run `brv login --help` for more details.
-"No provider connected" | Run `brv providers` to inspect the active provider, then connect one with `brv providers connect <provider>`.
-"Connection failed" / "Instance crashed" | User should kill brv process.
-"Token has expired" / "Token is invalid" | Run `brv login` again to re-authenticate.
-"Billing error" / "Rate limit exceeded" | User should check account credits or wait before retrying.
-
-**Agent-Fixable Errors:**
-You MUST handle these errors gracefully and retry the command after fixing.
-
-"Missing required argument(s)." | Run `brv <command> --help` to see usage instructions.
-"Maximum 5 files allowed" | Reduce to 5 or fewer `-f` flags per curate.
-"File does not exist" | Verify path with `ls`, use relative paths from project root.
-"File type not supported" | Only text, image, PDF, and office files are supported.
-
-### Quick Diagnosis
-
-Run `brv status` to check authentication, project, and provider state.
+Do not block task completion solely because optional curation failed, but report the failure in `BRV RESULT`.

--- a/.agents/skills/crdt-storage/SKILL.md
+++ b/.agents/skills/crdt-storage/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: crdt-storage
+description: 'Use this skill for Automerge/CRDT changes, repo or document handle lifecycle, storage helpers, VFS behavior, subscriptions, listeners, workers, timers, caches, file handles, or blob URLs. Keep writes inside owning change callbacks and lifecycle-manage resources.'
+---
+
+# CRDT and storage workflow
+
+Use this skill for changes that affect Automerge documents, repo/document handles, storage helpers, VFS behavior, or lifecycle-managed resources.
+
+## Activation check
+
+Use this workflow when the task touches any of these areas:
+
+- Automerge or CRDT-backed state;
+- repo, document handles, subscriptions, or observable query flows;
+- storage helpers, VFS, file handles, blob URLs, or cache behavior;
+- background services or proxy clients that read/write persisted state;
+- migrations, normalization, or data repair for persisted documents;
+- workers, listeners, timers, or other resources that need cleanup.
+
+## Core invariants
+
+- Mutate live nested CRDT objects only inside the owning change callback.
+- Never assign a live document object back into the same document.
+- Prefer shared write helpers such as `put`, `patch`, `deepPutJsonObject`, and `deepPatchJsonObject` when they match the write shape.
+- Do not bypass entity or service APIs with direct storage access or ad hoc document mutation.
+- Treat subscriptions, listeners, workers, timers, caches, file handles, and blob URLs as lifecycle-managed resources.
+
+## Workflow
+
+1. Identify the owner of the persisted behavior: schema/service, entity, feature, widget, or shared helper.
+2. Read only the task-relevant files plus direct imports before editing.
+3. Reuse existing storage, matching, parsing, filtering, normalization, or CRDT write helpers before creating new ones.
+4. Keep writes small and scoped to the owning change callback.
+5. Ensure subscriptions and handles recover from legitimate transient states such as missing documents when that is expected behavior.
+6. Add cleanup or finalization for resources that can outlive the caller.
+7. Add or update focused tests for storage semantics, migrations, normalization, CRDT write helpers, or lifecycle behavior when the change affects behavior.
+8. Consider the `mutation-testing` skill after focused unit/integration tests pass for high-risk pure data logic.
+9. Run the narrowest relevant verification, then follow the final verification rule from `AGENTS.md`.
+
+## Testing guidance
+
+Use focused unit or integration tests for:
+
+- CRDT write helpers;
+- storage helpers;
+- migrations;
+- normalization and validation;
+- subscription recovery behavior;
+- lifecycle cleanup;
+- cache invalidation or reuse contracts;
+- VFS behavior that can be tested without real browser interaction.
+
+Use Playwright/e2e or a browser smoke check only when the behavior requires real browser APIs, file picker behavior, user interaction, or UI integration.
+
+## Cache and lifecycle checks
+
+When adding or changing caches:
+
+- define the cache key explicitly;
+- define invalidation, cleanup, or finalization behavior;
+- avoid unbounded retention;
+- ensure stale negative lookups do not hide newly created files or documents;
+- document or test recovery when underlying documents appear after an initial miss.
+
+When adding or changing subscriptions:
+
+- preserve expected error-as-state behavior when the subscription is meant to recover;
+- do not convert recoverable states into terminal stream failures;
+- clean up listeners and handles when subscribers are gone;
+- avoid duplicate subscriptions that do the same work for the same key.
+
+## Limits
+
+- Do not introduce direct background service imports into UI-facing layers.
+- Do not spread storage write semantics across widgets or pages.
+- Do not add local type assertions to force record iteration typing when typed collection helpers exist.
+- Do not change production semantics only to satisfy a weak test or mutation score.

--- a/.agents/skills/mutation-testing/SKILL.md
+++ b/.agents/skills/mutation-testing/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: mutation-testing
+description: 'Use this skill after focused unit/integration tests pass for high-risk pure logic, schemas, migrations, storage helpers, CRDT write helpers, validation, normalization, filtering, sorting, matching, service logic, or data transformations. Do not use it for UI component behavior, Playwright/e2e-only flows, refactors, type-only edits, formatting, comments, renames, or documentation.'
+---
+
+# Mutation testing workflow
+
+Use this skill to check whether focused unit or integration tests are strong enough to catch incorrect implementations.
+
+Mutation testing is an expensive quality check. Use it narrowly and only after the relevant normal tests pass.
+
+## Do not use this skill
+
+Do not use this skill for UI component behavior, Playwright/e2e-only flows, refactors, type-only edits, formatting, comments, renames, documentation, or internal cleanup with no observable behavior change.
+
+Do not use this skill before the focused unit or integration tests for the touched behavior pass.
+
+Do not use a full mutation run by default.
+
+## Activation check
+
+Use this workflow only when all conditions are true:
+
+1. The task changes high-risk pure logic, schemas, migrations, storage helpers, CRDT write helpers, validation, normalization, filtering, sorting, matching, service logic, or data transformations.
+2. Focused unit or integration tests were added or changed for that behavior.
+3. The focused tests already pass.
+4. A narrow mutation scope can be selected for the changed source files or glob.
+
+If any condition is false, skip mutation testing and use the normal verification rules from `AGENTS.md`.
+
+## Workflow
+
+1. Run the focused unit or integration tests first and confirm they pass.
+2. Select the narrowest changed source file or glob for mutation testing.
+3. Run Stryker against that narrow scope.
+4. Inspect survived mutants.
+5. Strengthen tests only when a survived mutant exposes a missing behavior assertion.
+6. Treat equivalent or irrelevant mutants as analysis findings, not as a reason to add brittle tests.
+7. Do not change production behavior only to kill a mutant.
+8. Rerun the focused tests after test changes.
+9. Rerun the same narrow mutation scope when the test was strengthened.
+10. Run the final `pnpm verify` check required by `AGENTS.md` before reporting completion.
+
+## Commands
+
+Check that Stryker can run without active mutations:
+
+```bash
+pnpm exec stryker run --dryRunOnly
+```
+
+Preferred narrow run:
+
+```bash
+pnpm exec stryker run -m "<changed-source-file-or-glob>"
+```
+
+Examples:
+
+```bash
+pnpm exec stryker run -m "src/shared/lib/**/*.ts"
+pnpm exec stryker run -m "src/entities/databaseData/**/*.ts"
+```
+
+Full mutation run is allowed only when explicitly requested or before a high-risk merge:
+
+```bash
+pnpm test:mutate
+```
+
+## Reading results
+
+- `Killed` means the tests caught the mutation.
+- `Survived` means the tests did not catch the changed behavior.
+- `No coverage` means no relevant test executed the mutated code.
+- `Timeout` or runner failures need investigation before drawing conclusions.
+
+## Handling survived mutants
+
+For each meaningful survived mutant:
+
+1. Identify the behavior that should have failed.
+2. Add or tighten the smallest relevant assertion.
+3. Keep the assertion behavior-focused, not implementation-focused.
+4. Rerun the focused test.
+5. Rerun the same narrow mutation scope.
+
+For equivalent or irrelevant mutants:
+
+- Do not add brittle tests.
+- State why the mutant is equivalent or irrelevant in the final response.
+- Use Stryker disable comments only when explicitly requested or when the project already uses them nearby.
+
+## Limits
+
+- Do not use mutation testing as a replacement for focused tests, type-checking, linting, e2e checks, or final `pnpm verify`.
+- Do not broaden mutation scope to unrelated files to improve the score.
+- Do not chase mutation score by testing implementation details.
+- Do not run full mutation testing automatically during small tasks.

--- a/.agents/skills/test-first/SKILL.md
+++ b/.agents/skills/test-first/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: test-first
+description: 'Use this skill when a task changes observable behavior, fixes a reproducible bug, changes migration logic, transforms data, changes storage semantics, or changes a user-facing UI flow, and the expected outcome can be reproduced by a focused test or smoke check.'
+---
+
+# Test-first workflow
+
+Use this skill to make behavior changes safer without turning every task into full TDD.
+
+## Do not use this skill
+
+Do not use this skill for refactors, type-only edits, formatting, comments, renames, documentation, or internal cleanup with no observable behavior change.
+
+Do not use this skill when the only way to proceed is to create a new test layer, broad speculative coverage, or fragile UI component unit tests.
+
+## Activation check
+
+Before production edits, decide whether all conditions are true:
+
+1. The task changes observable behavior, fixes a reproducible bug, changes migration logic, transforms data, changes storage semantics, or changes a user-facing UI flow.
+2. The expected outcome can be covered by an existing focused test target or reproducible browser smoke check.
+3. The focused check can be added quickly without expanding the task scope.
+
+If any condition is false, skip test-first and use the normal verification rules from `AGENTS.md`.
+
+## Workflow
+
+1. Identify the smallest existing verification target that should own the changed behavior.
+2. Add or update one focused test or smoke check for that behavior before production edits.
+3. Run only that target and confirm it fails for the expected reason.
+4. If a focused failing check cannot be produced quickly, stop expanding coverage and state the risk in the final response.
+5. Implement the minimal production change.
+6. Rerun the same target and confirm it passes.
+7. Run the narrowest additional verification required by `AGENTS.md`.
+8. Run the final `pnpm verify` check required by `AGENTS.md` before reporting completion.
+
+## Choosing the check
+
+- Use focused unit tests for composables, pure helpers, schemas, migrations, services, storage helpers, CRDT write helpers, state transitions, validation, normalization, and pure transformations.
+- Use Playwright/e2e or a reproducible browser smoke check for Vue component behavior that depends on real DOM layout, focus, keyboard navigation, pointer or touch input, teleport, overlays, scrolling, responsive styling, browser APIs, or Material state visuals.
+- Use component unit tests only for small render or wiring contracts that do not depend on browser layout or interaction semantics.
+
+## Targeted command patterns
+
+Use project scripts first:
+
+```bash
+pnpm test:run <test-file-or-pattern>
+pnpm e2e <test-file-or-pattern>
+```
+
+Use direct runner flags only when the project script cannot express the narrow target:
+
+```bash
+pnpm vitest run <test-file-or-pattern>
+pnpm playwright test <test-file-or-pattern>
+```
+
+Keep targeted checks narrow. Do not replace the final `pnpm verify` requirement.
+
+## Limits
+
+- Do not create a new testing approach just to satisfy test-first.
+- Do not broaden coverage beyond the behavior changed by the task.
+- Do not keep a test that only documents implementation details instead of behavior.
+- Do not skip final verification when the task changes code.

--- a/.agents/skills/ui-browser-behavior/SKILL.md
+++ b/.agents/skills/ui-browser-behavior/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: ui-browser-behavior
+description: 'Use this skill for UI changes involving real DOM layout, focus, keyboard navigation, pointer or touch input, teleport, overlays, scrolling, responsive styling, browser APIs, Material state visuals, or mobile behavior. Prefer Playwright/e2e or browser smoke checks over Vue component unit tests for these behaviors.'
+---
+
+# UI browser behavior workflow
+
+Use this skill when a UI change depends on browser behavior rather than only pure state or simple rendering.
+
+## Do not use this skill
+
+Do not use this skill for pure helpers, schemas, migrations, services, storage helpers, CRDT write helpers, validation, normalization, or pure transformations. Use unit tests for those instead.
+
+Do not add Vue component unit tests for behavior that depends on layout, focus, keyboard navigation, pointer or touch input, teleport, overlays, scrolling, responsive styling, browser APIs, or Material state visuals.
+
+## Activation check
+
+Use this workflow when the change touches any of these areas:
+
+- layout or rendered hierarchy;
+- focus, keyboard navigation, or accessibility interactions;
+- pointer, mouse, drag, touch, or mobile interactions;
+- teleport, dialog, sheet, menu, tooltip, or overlay wiring;
+- scroll containers, sticky/fixed surfaces, or viewport sizing;
+- responsive styling or Material state visuals;
+- browser APIs or DOM measurements;
+- page, pane, widget, feature, or shared UI components with observable user behavior.
+
+## Workflow
+
+1. Identify the user-visible behavior and the owning layer.
+2. Check the rendered hierarchy before moving wrappers, teleports, scroll owners, or composition boundaries.
+3. Keep component contracts narrow: prefer explicit props, named handlers, explicit emits, and slots over service bags or large config objects.
+4. Move reusable state transitions or business rules into composables or pure helpers when they can be tested without the browser.
+5. Verify browser-dependent behavior with Playwright/e2e or a reproducible browser smoke check.
+6. Use component unit tests only for small render or wiring contracts that do not depend on browser semantics.
+7. Run the narrowest relevant UI verification, then follow the final verification rule from `AGENTS.md`.
+
+## Choosing verification
+
+Use Playwright/e2e when the behavior involves:
+
+- real focus movement;
+- keyboard navigation;
+- pointer/touch input;
+- scrolling;
+- overlays or teleport;
+- responsive layout;
+- browser APIs;
+- mobile behavior;
+- Material visual state behavior.
+
+Use focused unit tests only when the tested logic is extracted into a composable or helper, or the component check is a simple render/wiring contract.
+
+Use a reproducible browser smoke check when no suitable Playwright spec exists and adding one would be broader than the task.
+
+## Mobile-first checks
+
+Assume mobile browsers and low-end devices are important. Avoid solutions that rely on hover, precise pointer input, desktop viewport assumptions, or unbounded main-thread work.
+
+When progress is knowable, surface determinate progress instead of an indeterminate spinner.
+
+## Limits
+
+- Do not introduce broad e2e coverage when a focused browser smoke check is enough.
+- Do not bypass layer ownership by importing background services directly into UI-facing layers.
+- Do not move wrappers or composition boundaries without considering DOM parentage, focus, scroll ownership, teleport, and overlay contracts.
+- Do not treat the absence of a Vue component unit test as a regression when behavior is covered by e2e, browser smoke, or extracted helper/composable tests.

--- a/.agents/skills/verification/SKILL.md
+++ b/.agents/skills/verification/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: verification
+description: 'Use this skill when choosing targeted checks, using pnpm verify --fix, interpreting verification failures, avoiding duplicate verification runs, or preparing the final VERIFY RESULT report. Final completion after edits requires read-only pnpm verify.'
+---
+
+# Verification workflow
+
+Use this skill to verify changes without wasting time on duplicated or overly broad checks.
+
+## Core rule
+
+Before reporting completion after edits, run the read-only repository verification:
+
+```bash
+pnpm verify
+```
+
+Do not replace the final read-only check with manually selected commands. Do not use `--fix` for the final check.
+
+## When to use fix mode
+
+Use fix mode only when automatic formatting or lint fixes are useful:
+
+```bash
+pnpm verify --fix
+```
+
+Do not run fix mode just because a task is complete. Do not run fix mode and then immediately repeat the same broad manual commands unless the output shows a specific failure that needs targeted follow-up.
+
+## During implementation
+
+Use the narrowest useful check for the current change:
+
+- run focused unit tests for touched logic with sibling tests;
+- run focused Playwright specs for changed e2e files or UI flows;
+- run `pnpm type-check` for TypeScript, Vue, config, package, or test changes;
+- run targeted lint/format commands only when editing code style or fixing lint output.
+
+Prefer the project `pnpm verify` script when it can infer the changed-file scope. It already runs changed-file formatting, lint, type-check, focused Vitest, changed Playwright specs, and narrow Stryker scope when applicable.
+
+## Failure handling
+
+If `pnpm verify` fails:
+
+1. Identify the exact failed command from the VERIFY RESULT summary.
+2. Fix the failure if it is caused by the current change.
+3. Rerun the narrow failed command when possible.
+4. Rerun final `pnpm verify` before reporting completion.
+5. If the failure is unrelated or cannot be fixed, report the exact failing command and relevant output.
+6. Do not claim the task is complete while final verification is failing.
+
+## Avoid duplicate checks
+
+Do not run the same broad verification twice without a code or documentation change between runs.
+
+Do not run `pnpm verify --fix` after a passing `pnpm verify` unless a new edit was made.
+
+Do not run full e2e, full lint, or full mutation checks manually when the task only needs the inferred changed-file scope, unless explicitly requested or required by the failure.
+
+## Final response
+
+Always include this block after edits:
+
+```text
+VERIFY RESULT
+command: pnpm verify
+status: passed | failed | not run
+reason if not run:
+```
+
+Use `not run` only when no repository verification could reasonably be run, such as documentation-only changes made through a remote editor. State the reason plainly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,14 @@ reason if not run:
 - When progress is knowable, surface progress instead of falling back to an indeterminate spinner.
 - Keep unit tests colocated with the source file they verify, using sibling `*.test.ts` files. Do not introduce `__tests__` directories.
 
+## Test-first changes
+
+- Use test-first only for behavior changes, bug fixes, migrations, data transformations, storage semantics, or UI flows where the expected outcome can be reproduced by an existing focused test or smoke check.
+- Before production edits, add or update the smallest relevant existing test or smoke check, then run only that target and confirm it fails for the expected reason. If a focused failing check cannot be produced quickly, stop expanding and state the risk instead of creating broad speculative coverage.
+- After the minimal implementation, rerun the same target, then follow the verification rules above.
+- Skip test-first for refactors, type-only changes, formatting, comments, renames, documentation, and internal cleanup with no observable behavior change.
+- Do not create a new test layer or broaden coverage beyond the changed behavior just to satisfy test-first. Follow `Testing UI and Components` when choosing between e2e, browser smoke, unit, composable, helper, schema, service, or storage tests.
+
 ## Testing UI and Components
 
 - Do not use unit tests as the default verification method for Vue UI components.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,27 +4,23 @@ Applies to the whole repository unless a deeper `AGENTS.md` overrides it.
 
 ## Mandatory verification
 
-During implementation, use this command when automatic formatting or lint fixes are useful:
+Use the `verification` skill when choosing targeted checks, using fix mode, interpreting failures, or preparing the final verification report.
+
+During implementation, use this command only when automatic formatting or lint fixes are useful:
 
 ```bash
 pnpm verify --fix
 ```
 
-Before reporting completion, always run the read-only check:
+Before reporting completion after edits, always run the read-only check:
 
 ```bash
 pnpm verify
 ```
 
-Do not replace this command with manually selected checks.
+Do not replace the final read-only check with manually selected checks. The final verification must not use `--fix`.
 
-The final verification must not use `--fix`.
-
-If `pnpm verify` fails:
-
-- fix the failure if it is caused by the change;
-- otherwise report the exact failing command and output;
-- do not claim the task is complete.
+If `pnpm verify` fails, fix failures caused by the change. Otherwise report the exact failing command and output, and do not claim the task is complete.
 
 Final response must include:
 
@@ -58,16 +54,15 @@ reason if not run:
 - Do not use test-first for refactors, type-only changes, formatting, comments, renames, documentation, or internal cleanup with no observable behavior change.
 - Use the `mutation-testing` skill for high-risk changes to pure logic, schemas, migrations, storage helpers, CRDT write helpers, validation, normalization, filtering, sorting, matching, service logic, or data transformations when focused unit/integration tests were added or changed.
 - Do not use mutation testing for UI component behavior, Playwright/e2e-only flows, refactors, type-only changes, formatting, comments, renames, or documentation.
+- Use the `ui-browser-behavior` skill for UI changes involving real DOM layout, focus, keyboard navigation, pointer or touch input, teleport, overlays, scrolling, responsive styling, browser APIs, Material state visuals, or mobile behavior.
+- Use the `crdt-storage` skill for Automerge/CRDT changes, repo or document handle lifecycle, storage helpers, VFS behavior, subscriptions, listeners, workers, timers, caches, file handles, or blob URLs.
 - Verify third-party semantics from official docs or installed source before relying on ambiguous helpers, options, or return values. If the behavior is still unverified, say so.
-- Treat DOM parentage, scroll ownership, focus, teleport, and overlay wiring as concrete runtime contracts. Check the rendered hierarchy before moving wrappers or composition boundaries.
 - Keep the UI aligned with Material 3 expectations and optimize for mobile browsers first. Assume large datasets and low-end devices, and keep main-thread work bounded.
 - Keep component and composable contracts narrow. Prefer IDs, primitive values, small display records, and explicit emits or slots over service bags, deeply nested configs, or mixed read/write models.
 - Keep TSDoc on every public API accurate and complete. If you touch a public export that is missing TSDoc or has stale TSDoc, update it as part of the same change.
 - Prefer explicit component props and named handlers over object-literal `v-bind` bags and inline template callbacks. Keep template contracts readable and mechanically checkable.
 - Keep validation, parsing, and extraction close to the contract or boundary that defines them.
-- Treat subscriptions, listeners, workers, timers, caches, file handles, and blob URLs as lifecycle-managed resources.
 - Prefer typed collection helpers over raw `Object.keys`, `Object.values`, and `Object.entries` when iterating typed records. Do not add local type assertions just to paper over iteration typing outside rare boundary adapters.
-- For CRDT-backed state, mutate live nested objects inside the owning change callback, never assign a live document object back into the same document, and prefer shared helpers such as `put`, `patch`, `deepPutJsonObject`, and `deepPatchJsonObject` when they match the write shape.
 - When progress is knowable, surface progress instead of falling back to an indeterminate spinner.
 - Keep unit tests colocated with the source file they verify, using sibling `*.test.ts` files. Do not introduce `__tests__` directories.
 
@@ -79,6 +74,11 @@ reason if not run:
 - Unit tests remain the preferred verification method for composables, pure helpers, schemas, migrations, services, storage helpers, CRDT write helpers, state transitions, validation, normalization, and pure transformations.
 - Component unit tests are allowed for small render or wiring contracts that do not depend on browser layout or interaction semantics.
 - The absence or removal of a Vue component unit test is not a regression by itself when the behavior is covered by Playwright/e2e, a reproducible browser smoke check, or focused tests for extracted composable or helper logic.
+
+## CRDT and lifecycle invariants
+
+- For CRDT-backed state, mutate live nested objects inside the owning change callback, never assign a live document object back into the same document, and prefer shared helpers such as `put`, `patch`, `deepPutJsonObject`, and `deepPatchJsonObject` when they match the write shape.
+- Treat subscriptions, listeners, workers, timers, caches, file handles, and blob URLs as lifecycle-managed resources.
 
 ## Anti-patterns
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,8 @@ reason if not run:
 - Preserve FSD boundaries: `pages` compose screens, `widgets` compose larger sections, `features` own user actions, `entities` own domain reads and derived state, and `shared` stays upper-layer-free.
 - When existing code already owns a non-trivial matching, parsing, filtering, or storage algorithm, reuse that implementation or extract a shared helper first; do not reimplement the same algorithm in another layer and let it drift.
 - Keep ByteRover usage details in the `byterover` skill. Use `AGENTS.md` for stable repo policy, not step-by-step `brv` runbooks.
+- Use the `test-first` skill for behavior changes, bug fixes, migrations, data transformations, storage semantics, and UI flows when the expected outcome can be reproduced by a focused test or smoke check.
+- Do not use test-first for refactors, type-only changes, formatting, comments, renames, documentation, or internal cleanup with no observable behavior change.
 - Verify third-party semantics from official docs or installed source before relying on ambiguous helpers, options, or return values. If the behavior is still unverified, say so.
 - Treat DOM parentage, scroll ownership, focus, teleport, and overlay wiring as concrete runtime contracts. Check the rendered hierarchy before moving wrappers or composition boundaries.
 - Keep the UI aligned with Material 3 expectations and optimize for mobile browsers first. Assume large datasets and low-end devices, and keep main-thread work bounded.
@@ -66,14 +68,6 @@ reason if not run:
 - For CRDT-backed state, mutate live nested objects inside the owning change callback, never assign a live document object back into the same document, and prefer shared helpers such as `put`, `patch`, `deepPutJsonObject`, and `deepPatchJsonObject` when they match the write shape.
 - When progress is knowable, surface progress instead of falling back to an indeterminate spinner.
 - Keep unit tests colocated with the source file they verify, using sibling `*.test.ts` files. Do not introduce `__tests__` directories.
-
-## Test-first changes
-
-- Use test-first only for behavior changes, bug fixes, migrations, data transformations, storage semantics, or UI flows where the expected outcome can be reproduced by an existing focused test or smoke check.
-- Before production edits, add or update the smallest relevant existing test or smoke check, then run only that target and confirm it fails for the expected reason. If a focused failing check cannot be produced quickly, stop expanding and state the risk instead of creating broad speculative coverage.
-- After the minimal implementation, rerun the same target, then follow the verification rules above.
-- Skip test-first for refactors, type-only changes, formatting, comments, renames, documentation, and internal cleanup with no observable behavior change.
-- Do not create a new test layer or broaden coverage beyond the changed behavior just to satisfy test-first. Follow `Testing UI and Components` when choosing between e2e, browser smoke, unit, composable, helper, schema, service, or storage tests.
 
 ## Testing UI and Components
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,8 @@ reason if not run:
 - Keep ByteRover usage details in the `byterover` skill. Use `AGENTS.md` for stable repo policy, not step-by-step `brv` runbooks.
 - Use the `test-first` skill for behavior changes, bug fixes, migrations, data transformations, storage semantics, and UI flows when the expected outcome can be reproduced by a focused test or smoke check.
 - Do not use test-first for refactors, type-only changes, formatting, comments, renames, documentation, or internal cleanup with no observable behavior change.
+- Use the `mutation-testing` skill for high-risk changes to pure logic, schemas, migrations, storage helpers, CRDT write helpers, validation, normalization, filtering, sorting, matching, service logic, or data transformations when focused unit/integration tests were added or changed.
+- Do not use mutation testing for UI component behavior, Playwright/e2e-only flows, refactors, type-only changes, formatting, comments, renames, or documentation.
 - Verify third-party semantics from official docs or installed source before relying on ambiguous helpers, options, or return values. If the behavior is still unverified, say so.
 - Treat DOM parentage, scroll ownership, focus, teleport, and overlay wiring as concrete runtime contracts. Check the rendered hierarchy before moving wrappers or composition boundaries.
 - Keep the UI aligned with Material 3 expectations and optimize for mobile browsers first. Assume large datasets and low-end devices, and keep main-thread work bounded.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,8 @@ Do not replace the final read-only check with manually selected checks. The fina
 
 If `pnpm verify` fails, fix failures caused by the change. Otherwise report the exact failing command and output, and do not claim the task is complete.
 
+Before the final response after non-trivial implementation, use the `byterover` skill end-of-task capture gate to decide whether durable project knowledge should be curated.
+
 Final response must include:
 
 ```text
@@ -29,6 +31,10 @@ VERIFY RESULT
 command: pnpm verify
 status: passed | failed | not run
 reason if not run:
+
+BRV RESULT
+status: curated | skipped | failed | not available
+reason:
 ```
 
 ## Contains


### PR DESCRIPTION
## Summary

- Add dedicated agent skills for `test-first`, `mutation-testing`, `verification`, `ui-browser-behavior`, and `crdt-storage` workflows.
- Update the existing `byterover` skill with an end-of-task capture gate, required `BRV RESULT` reporting after non-trivial implementation, and a reusable `Lesson` format for corrected mistakes and project experience.
- Keep `AGENTS.md` focused on mandatory repo policy, stable invariants, and short skill activation triggers.
- Move procedural guidance for verification, UI browser checks, CRDT/storage work, test-first work, mutation checks, and BRV memory capture into skill playbooks.
- Limit expensive or specialized workflows to cases where they add signal and avoid broad/default usage.

## Verification

Not run: documentation-only change.