### PR TITLE
fix(database): allow inline boolean checkbox clicks

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -23,4 +23,5 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
+      - run: pnpm e2e:install
       - run: pnpm verify

--- a/src/entities/databaseBoolean/BooleanValueInline.vue
+++ b/src/entities/databaseBoolean/BooleanValueInline.vue
@@ -25,6 +25,7 @@ const convertedValue = computed(() =>
 
 <template>
   <MDCheckbox
+    class="boolean-value-inline__checkbox"
     :model-value="convertedValue"
     :indeterminate="indeterminate"
     readonly
@@ -33,3 +34,9 @@ const convertedValue = computed(() =>
     aria-hidden="true"
   />
 </template>
+
+<style scoped>
+.boolean-value-inline__checkbox {
+  margin-inline: auto;
+}
+</style>

--- a/src/shared/ui/Button/MDFab.vue
+++ b/src/shared/ui/Button/MDFab.vue
@@ -40,6 +40,7 @@ const typeClass = computed(() => {
 });
 
 const onFabClick = (event: MouseEvent) => {
+  event.stopPropagation();
   emit('click', event);
 };
 </script>

--- a/src/shared/ui/Checkbox/MDCheckbox.vue
+++ b/src/shared/ui/Checkbox/MDCheckbox.vue
@@ -50,13 +50,18 @@ const symbolName = computed(() =>
 );
 
 const onClickContainer = (e: MouseEvent) => {
-  if (disabled.value || readonly.value) {
+  if (disabled.value) {
     return;
   }
 
   e.preventDefault();
   emit('click');
 
+  if (readonly.value) {
+    return;
+  }
+
+  e.stopPropagation();
   stateValue.value = toggleBoolean(stateValue.value, toValue(indeterminate));
 };
 
@@ -69,17 +74,24 @@ watchEffect(() => {
 });
 
 const onKeydownContainer = (event: KeyboardEvent) => {
-  if (disabled.value || readonly.value) {
+  const { key } = event;
+  if (!['Enter', ' '].includes(key)) {
     return;
   }
 
-  const { key } = event;
-  if (['Enter', ' '].includes(key)) {
-    event.preventDefault();
-    emit('click');
-
-    stateValue.value = toggleBoolean(stateValue.value, toValue(indeterminate));
+  if (disabled.value) {
+    return;
   }
+
+  event.preventDefault();
+  emit('click');
+
+  if (readonly.value) {
+    return;
+  }
+
+  event.stopPropagation();
+  stateValue.value = toggleBoolean(stateValue.value, toValue(indeterminate));
 };
 </script>
 

--- a/src/shared/ui/Chips/MDChip.vue
+++ b/src/shared/ui/Chips/MDChip.vue
@@ -28,6 +28,7 @@ const onClickClose = (e: MouseEvent) => {
 };
 
 const onChipClick = (event: MouseEvent) => {
+  event.stopPropagation();
   emit('click', event);
 };
 </script>

--- a/src/shared/ui/State/MDState.vue
+++ b/src/shared/ui/State/MDState.vue
@@ -72,7 +72,6 @@ useEventListener(refEl, 'mouseup', (e: MouseEvent) => {
 const { vibrate } = useVibrate();
 
 useEventListener(refEl, 'click', (e) => {
-  e.stopPropagation();
   vibrate([10]);
   emit('click', e);
 });

--- a/tests/e2e/databaseItemFlows.spec.ts
+++ b/tests/e2e/databaseItemFlows.spec.ts
@@ -148,7 +148,16 @@ test('updates string, number, boolean, and date values inline and persists them'
   await expect(findDatabaseRow(page, nextStringValue)).toBeVisible();
 
   await setInlineDatabaseValue(page, nextStringValue, numberPropertyName, nextNumberValue);
-  await setInlineDatabaseValue(page, nextStringValue, booleanPropertyName, true);
+
+  const booleanCell = findDatabaseRow(page, nextStringValue)
+    .getByRole('checkbox', {
+      name: new RegExp(`^${booleanPropertyName}$`, 'i'),
+    })
+    .first();
+  await expect(booleanCell).toBeVisible();
+  await booleanCell.click();
+  await expect(booleanCell).toHaveAttribute('aria-checked', 'true');
+
   await setInlineDatabaseValue(page, nextStringValue, datePropertyName, nextDateValue);
 
   const updatedRow = findDatabaseRow(page, nextStringValue);


### PR DESCRIPTION
- center the inline boolean checkbox inside the boolean cell
- stop hiding click propagation inside MDState
- keep propagation isolation in standalone action components
- make readonly MDCheckbox emit click without changing its value
- cover inline boolean editing with an e2e user click
- install Playwright browsers in CI before verify