### PR TITLE
feat(vfs): prevent page unload during active write mutations

### DIFF
--- a/src/app/MainApp.vue
+++ b/src/app/MainApp.vue
@@ -10,6 +10,7 @@ import { provideOverlayContainer } from '@shared/ui/Overlay';
 import { useMainContentAriaHidden } from '@shared/ui/AriaHidden';
 import { useFocusIndicator } from '@shared/ui/State/useFocusIndicator';
 import { setupMetaThemeColor } from '@shared/lib/metaThemeColor';
+import { usePreventUnloadDuringActiveWrites } from '@feature/preventUnloadDuringActiveWrites';
 
 const { addSnackbar } = useSnackbar();
 
@@ -31,6 +32,7 @@ const { settings } = useLocalSettings();
 const mainAriaHidden = useMainContentAriaHidden();
 
 useFocusIndicator();
+usePreventUnloadDuringActiveWrites();
 
 setupMetaThemeColor();
 </script>

--- a/src/features/preventUnloadDuringActiveWrites/index.ts
+++ b/src/features/preventUnloadDuringActiveWrites/index.ts
@@ -1,0 +1,1 @@
+export { usePreventUnloadDuringActiveWrites } from './usePreventUnloadDuringActiveWrites';

--- a/src/features/preventUnloadDuringActiveWrites/usePreventUnloadDuringActiveWrites.test.ts
+++ b/src/features/preventUnloadDuringActiveWrites/usePreventUnloadDuringActiveWrites.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { computed, effectScope, ref } from 'vue';
+import type { VfsActivityState } from '@shared/lib/virtualFileSystem';
+import {
+  shouldPreventUnloadDuringActiveWrites,
+  useBeforeUnloadGuard,
+} from './usePreventUnloadDuringActiveWrites';
+
+class MockBeforeUnloadTarget {
+  public readonly addEventListener = vi.fn(
+    (_type: 'beforeunload', listener: (event: BeforeUnloadEvent) => void) => {
+      this.listener = listener;
+    },
+  );
+
+  public readonly removeEventListener = vi.fn(
+    (_type: 'beforeunload', listener: (event: BeforeUnloadEvent) => void) => {
+      if (this.listener === listener) {
+        this.listener = undefined;
+      }
+    },
+  );
+
+  public listener: ((event: BeforeUnloadEvent) => void) | undefined;
+}
+
+const createState = (overrides: Partial<VfsActivityState> = {}): VfsActivityState => ({
+  status: 'idle',
+  activeCount: 0,
+  ...overrides,
+});
+
+describe('shouldPreventUnloadDuringActiveWrites', () => {
+  it('returns false when there are no active mutations', () => {
+    expect(shouldPreventUnloadDuringActiveWrites(createState({ activeCount: 0 }))).toBe(false);
+  });
+
+  it('returns true when there is at least one active mutation', () => {
+    expect(shouldPreventUnloadDuringActiveWrites(createState({ activeCount: 1 }))).toBe(true);
+    expect(shouldPreventUnloadDuringActiveWrites(createState({ activeCount: 2 }))).toBe(true);
+  });
+
+  it('ignores lastError when there are no active mutations', () => {
+    expect(
+      shouldPreventUnloadDuringActiveWrites(
+        createState({
+          activeCount: 0,
+          lastError: {
+            acknowledged: false,
+            message: 'write failed',
+            occurredAt: Date.now(),
+            operationType: 'writeFile',
+            path: '/notes/today.md',
+          },
+          status: 'error',
+        }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('useBeforeUnloadGuard', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('adds one listener when the guard becomes active', async () => {
+    const isBlocked = ref(false);
+    const target = new MockBeforeUnloadTarget();
+    const scope = effectScope();
+
+    scope.run(() => {
+      useBeforeUnloadGuard(
+        computed(() => isBlocked.value),
+        target,
+      );
+    });
+
+    expect(target.addEventListener).not.toHaveBeenCalled();
+
+    isBlocked.value = true;
+    await Promise.resolve();
+
+    expect(target.addEventListener).toHaveBeenCalledTimes(1);
+    expect(target.addEventListener).toHaveBeenCalledWith('beforeunload', expect.any(Function));
+
+    scope.stop();
+  });
+
+  it('prevents unload and sets the browser-managed return value while active', () => {
+    const isBlocked = ref(true);
+    const target = new MockBeforeUnloadTarget();
+    const scope = effectScope();
+
+    scope.run(() => {
+      useBeforeUnloadGuard(
+        computed(() => isBlocked.value),
+        target,
+      );
+    });
+
+    const event = new BeforeUnloadEvent();
+    const preventDefault = vi.spyOn(event, 'preventDefault');
+
+    target.listener?.(event);
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- The guard must set returnValue for browser prompts.
+    expect(event.returnValue).toBe('');
+
+    scope.stop();
+  });
+
+  it('removes the listener when the guard becomes inactive', async () => {
+    const isBlocked = ref(true);
+    const target = new MockBeforeUnloadTarget();
+    const scope = effectScope();
+
+    scope.run(() => {
+      useBeforeUnloadGuard(
+        computed(() => isBlocked.value),
+        target,
+      );
+    });
+
+    const listener = target.listener;
+
+    isBlocked.value = false;
+    await Promise.resolve();
+
+    expect(target.removeEventListener).toHaveBeenCalledTimes(1);
+    expect(target.removeEventListener).toHaveBeenCalledWith('beforeunload', listener);
+    expect(target.listener).toBeUndefined();
+
+    scope.stop();
+  });
+
+  it('does not add a second listener when activity count grows while already active', async () => {
+    const activeCount = ref(1);
+    const target = new MockBeforeUnloadTarget();
+    const scope = effectScope();
+
+    scope.run(() => {
+      useBeforeUnloadGuard(
+        computed(() => activeCount.value > 0),
+        target,
+      );
+    });
+
+    expect(target.addEventListener).toHaveBeenCalledTimes(1);
+
+    activeCount.value = 2;
+    await Promise.resolve();
+
+    expect(target.addEventListener).toHaveBeenCalledTimes(1);
+
+    scope.stop();
+  });
+
+  it('removes the listener when the effect scope stops', () => {
+    const isBlocked = ref(true);
+    const target = new MockBeforeUnloadTarget();
+    const scope = effectScope();
+
+    scope.run(() => {
+      useBeforeUnloadGuard(
+        computed(() => isBlocked.value),
+        target,
+      );
+    });
+
+    const listener = target.listener;
+
+    scope.stop();
+
+    expect(target.removeEventListener).toHaveBeenCalledTimes(1);
+    expect(target.removeEventListener).toHaveBeenCalledWith('beforeunload', listener);
+    expect(target.listener).toBeUndefined();
+  });
+});

--- a/src/features/preventUnloadDuringActiveWrites/usePreventUnloadDuringActiveWrites.test.ts
+++ b/src/features/preventUnloadDuringActiveWrites/usePreventUnloadDuringActiveWrites.test.ts
@@ -9,20 +9,30 @@ import {
 class MockBeforeUnloadTarget {
   public readonly addEventListener = vi.fn(
     (_type: 'beforeunload', listener: (event: BeforeUnloadEvent) => void) => {
-      this.listener = listener;
+      this.listeners.add(listener);
     },
   );
 
   public readonly removeEventListener = vi.fn(
     (_type: 'beforeunload', listener: (event: BeforeUnloadEvent) => void) => {
-      if (this.listener === listener) {
-        this.listener = undefined;
-      }
+      this.listeners.delete(listener);
     },
   );
 
-  public listener: ((event: BeforeUnloadEvent) => void) | undefined;
+  public readonly listeners = new Set<(event: BeforeUnloadEvent) => void>();
 }
+
+const getRequiredListener = (
+  target: MockBeforeUnloadTarget,
+): ((event: BeforeUnloadEvent) => void) => {
+  const [listener] = [...target.listeners];
+
+  if (listener === undefined) {
+    throw new Error('Expected a beforeunload listener to be registered.');
+  }
+
+  return listener;
+};
 
 const createState = (overrides: Partial<VfsActivityState> = {}): VfsActivityState => ({
   status: 'idle',
@@ -102,7 +112,8 @@ describe('useBeforeUnloadGuard', () => {
     const event = new BeforeUnloadEvent();
     const preventDefault = vi.spyOn(event, 'preventDefault');
 
-    target.listener?.(event);
+    const listener = getRequiredListener(target);
+    listener(event);
 
     expect(preventDefault).toHaveBeenCalledTimes(1);
     // eslint-disable-next-line @typescript-eslint/no-deprecated -- The guard must set returnValue for browser prompts.
@@ -123,14 +134,14 @@ describe('useBeforeUnloadGuard', () => {
       );
     });
 
-    const listener = target.listener;
+    const listener = getRequiredListener(target);
 
     isBlocked.value = false;
     await Promise.resolve();
 
     expect(target.removeEventListener).toHaveBeenCalledTimes(1);
     expect(target.removeEventListener).toHaveBeenCalledWith('beforeunload', listener);
-    expect(target.listener).toBeUndefined();
+    expect(target.listeners.size).toBe(0);
 
     scope.stop();
   });
@@ -169,12 +180,70 @@ describe('useBeforeUnloadGuard', () => {
       );
     });
 
-    const listener = target.listener;
+    const listener = getRequiredListener(target);
 
     scope.stop();
 
     expect(target.removeEventListener).toHaveBeenCalledTimes(1);
     expect(target.removeEventListener).toHaveBeenCalledWith('beforeunload', listener);
-    expect(target.listener).toBeUndefined();
+    expect(target.listeners.size).toBe(0);
+  });
+
+  it('keeps multiple guard listeners independent on the same target', () => {
+    const target = new MockBeforeUnloadTarget();
+    const firstScope = effectScope();
+    const secondScope = effectScope();
+
+    firstScope.run(() => {
+      useBeforeUnloadGuard(
+        computed(() => true),
+        target,
+      );
+    });
+
+    secondScope.run(() => {
+      useBeforeUnloadGuard(
+        computed(() => true),
+        target,
+      );
+    });
+
+    expect(target.addEventListener).toHaveBeenCalledTimes(2);
+
+    const firstListener = target.addEventListener.mock.calls[0]?.[1];
+    const secondListener = target.addEventListener.mock.calls[1]?.[1];
+
+    expect(firstListener).toEqual(expect.any(Function));
+    expect(secondListener).toEqual(expect.any(Function));
+
+    if (firstListener === undefined || secondListener === undefined) {
+      throw new Error('Expected both beforeunload listeners to be registered.');
+    }
+
+    expect(firstListener).not.toBe(secondListener);
+    expect(target.listeners.has(firstListener)).toBe(true);
+    expect(target.listeners.has(secondListener)).toBe(true);
+
+    firstScope.stop();
+
+    expect(target.removeEventListener).toHaveBeenCalledTimes(1);
+    expect(target.removeEventListener).toHaveBeenCalledWith('beforeunload', firstListener);
+    expect(target.listeners.has(firstListener)).toBe(false);
+    expect(target.listeners.has(secondListener)).toBe(true);
+
+    const event = new BeforeUnloadEvent();
+    const preventDefault = vi.spyOn(event, 'preventDefault');
+
+    secondListener(event);
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- The guard must set returnValue for browser prompts.
+    expect(event.returnValue).toBe('');
+
+    secondScope.stop();
+
+    expect(target.removeEventListener).toHaveBeenCalledTimes(2);
+    expect(target.removeEventListener).toHaveBeenLastCalledWith('beforeunload', secondListener);
+    expect(target.listeners.size).toBe(0);
   });
 });

--- a/src/features/preventUnloadDuringActiveWrites/usePreventUnloadDuringActiveWrites.ts
+++ b/src/features/preventUnloadDuringActiveWrites/usePreventUnloadDuringActiveWrites.ts
@@ -1,0 +1,58 @@
+import { useVfsActivity } from '@entity/vfsActivity';
+import type { VfsActivityState } from '@shared/lib/virtualFileSystem';
+import { computed, watch, type ComputedRef } from 'vue';
+
+interface BeforeUnloadTarget {
+  addEventListener(type: 'beforeunload', listener: (event: BeforeUnloadEvent) => void): void;
+  removeEventListener(type: 'beforeunload', listener: (event: BeforeUnloadEvent) => void): void;
+}
+
+const onBeforeUnload = (event: BeforeUnloadEvent) => {
+  event.preventDefault();
+  // eslint-disable-next-line @typescript-eslint/no-deprecated -- Browser unload prompts still rely on returnValue.
+  event.returnValue = '';
+};
+
+/**
+ * Returns whether active VFS mutations should block page unload.
+ * @param state - Current VFS activity state.
+ * @returns `true` when one or more write mutations are still in flight.
+ */
+export const shouldPreventUnloadDuringActiveWrites = (state: VfsActivityState): boolean =>
+  state.activeCount > 0;
+
+/**
+ * Attaches a `beforeunload` listener only while the provided block flag is active.
+ * @param isBlocked - Reactive flag that controls whether page unload should be prevented.
+ * @param target - Event target used to register the browser `beforeunload` listener.
+ */
+export const useBeforeUnloadGuard = (
+  isBlocked: ComputedRef<boolean>,
+  target: BeforeUnloadTarget,
+): void => {
+  watch(
+    isBlocked,
+    (blocked, _previous, onCleanup) => {
+      if (!blocked) {
+        return;
+      }
+
+      target.addEventListener('beforeunload', onBeforeUnload);
+
+      onCleanup(() => {
+        target.removeEventListener('beforeunload', onBeforeUnload);
+      });
+    },
+    { immediate: true },
+  );
+};
+
+/**
+ * Prevents closing or reloading the page while VFS write mutations are still active.
+ */
+export const usePreventUnloadDuringActiveWrites = (): void => {
+  const { state } = useVfsActivity();
+  const isBlocked = computed(() => shouldPreventUnloadDuringActiveWrites(state.value));
+
+  useBeforeUnloadGuard(isBlocked, window);
+};

--- a/src/features/preventUnloadDuringActiveWrites/usePreventUnloadDuringActiveWrites.ts
+++ b/src/features/preventUnloadDuringActiveWrites/usePreventUnloadDuringActiveWrites.ts
@@ -7,12 +7,6 @@ interface BeforeUnloadTarget {
   removeEventListener(type: 'beforeunload', listener: (event: BeforeUnloadEvent) => void): void;
 }
 
-const onBeforeUnload = (event: BeforeUnloadEvent) => {
-  event.preventDefault();
-  // eslint-disable-next-line @typescript-eslint/no-deprecated -- Browser unload prompts still rely on returnValue.
-  event.returnValue = '';
-};
-
 /**
  * Returns whether active VFS mutations should block page unload.
  * @param state - Current VFS activity state.
@@ -30,6 +24,12 @@ export const useBeforeUnloadGuard = (
   isBlocked: ComputedRef<boolean>,
   target: BeforeUnloadTarget,
 ): void => {
+  const onBeforeUnload = (event: BeforeUnloadEvent): void => {
+    event.preventDefault();
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- Browser unload prompts still rely on returnValue.
+    event.returnValue = '';
+  };
+
   watch(
     isBlocked,
     (blocked, _previous, onCleanup) => {
@@ -54,5 +54,7 @@ export const usePreventUnloadDuringActiveWrites = (): void => {
   const { state } = useVfsActivity();
   const isBlocked = computed(() => shouldPreventUnloadDuringActiveWrites(state.value));
 
-  useBeforeUnloadGuard(isBlocked, window);
+  if (typeof window !== 'undefined') {
+    useBeforeUnloadGuard(isBlocked, window);
+  }
 };


### PR DESCRIPTION
- implement usePreventUnloadDuringActiveWrites to manage beforeunload events
- add tests for shouldPreventUnloadDuringActiveWrites and useBeforeUnloadGuard