### PR TITLE
fix: remove path information from error reporting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,15 @@ reason:
 - For CRDT-backed state, mutate live nested objects inside the owning change callback, never assign a live document object back into the same document, and prefer shared helpers such as `put`, `patch`, `deepPutJsonObject`, and `deepPatchJsonObject` when they match the write shape.
 - Treat subscriptions, listeners, workers, timers, caches, file handles, and blob URLs as lifecycle-managed resources.
 
+## Privacy-safe errors
+
+- Any error that can reach `reportHandledError` must be privacy-safe by construction.
+- Do not include local paths, virtual paths, file names, folder names, document names, document ids, file ids, Google Drive file ids, record values, document contents, or raw external error text in `Error.message`, `DomainError.message`, or `DomainError.cause.message` when the error may be reported.
+- Do not write `new Error(\`Failed for ${path}\`)`, `new DomainError(\`Could not remove ${name}\`)`, or similar path/name/id-bearing messages in reportable flows.
+- Do not pass raw browser, filesystem, File API, File System API, Google API, IndexedDB, VFS, Automerge, Zod, or other low-level external errors as `cause` when the error may be reported. Wrap them in a project-controlled safe technical cause message instead.
+- Do not pass path, name, id, URL parameters, or other user-controlled values to `reportHandledError` options, Sentry `extra`, or Sentry `tags`.
+- Prefer stable domain error codes, safe user-facing messages, safe technical cause messages, and `feature` or `action` metadata.
+
 ## Anti-patterns
 
 - Do not pull dependencies upward against the intended layer direction.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,8 @@ reason:
 ## Privacy-safe errors
 
 - Any error that can reach `reportHandledError` must be privacy-safe by construction.
+- Raw `Error` may be preserved in reportable flows only when its message is project-controlled and does not include user-controlled values.
+- Errors from browser APIs, storage, network, Google API, File API, Automerge/repo internals, Zod, or any external library are untrusted by default and must be wrapped with a safe project-controlled cause message before they can reach handled diagnostics.
 - Do not include local paths, virtual paths, file names, folder names, document names, document ids, file ids, Google Drive file ids, record values, document contents, or raw external error text in `Error.message`, `DomainError.message`, or `DomainError.cause.message` when the error may be reported.
 - Do not write `new Error(\`Failed for ${path}\`)`, `new DomainError(\`Could not remove ${name}\`)`, or similar path/name/id-bearing messages in reportable flows.
 - Do not pass raw browser, filesystem, File API, File System API, Google API, IndexedDB, VFS, Automerge, Zod, or other low-level external errors as `cause` when the error may be reported. Wrap them in a project-controlled safe technical cause message instead.

--- a/src/features/diagnosticsConsentRequest/useDiagnosticsConsentRequest.test.ts
+++ b/src/features/diagnosticsConsentRequest/useDiagnosticsConsentRequest.test.ts
@@ -115,7 +115,7 @@ describe('useDiagnosticsConsentRequest', () => {
     expect(confirmMock).toHaveBeenCalledWith({
       headline: 'Help improve Mioframe?',
       supportingText:
-        'Mioframe can send technical error reports when something breaks. This helps developers find and fix crashes. Document contents are not intentionally included.',
+        'Mioframe can send technical error reports when something breaks. This helps developers find and fix crashes. Reports do not include document contents, record values, document names, folder names, local folder paths, document ids, or file ids.',
       confirmLabel: 'Allow',
       cancelLabel: 'Not now',
     });

--- a/src/features/diagnosticsConsentRequest/useDiagnosticsConsentRequest.ts
+++ b/src/features/diagnosticsConsentRequest/useDiagnosticsConsentRequest.ts
@@ -31,7 +31,7 @@ export const useDiagnosticsConsentRequest = () => {
         const diagnosticsEnabled = await confirm({
           headline: 'Help improve Mioframe?',
           supportingText:
-            'Mioframe can send technical error reports when something breaks. This helps developers find and fix crashes. Document contents are not intentionally included.',
+            'Mioframe can send technical error reports when something breaks. This helps developers find and fix crashes. Reports do not include document contents, record values, document names, folder names, local folder paths, document ids, or file ids.',
           confirmLabel: 'Allow',
           cancelLabel: 'Not now',
         });

--- a/src/features/documentManage/DocumentManageMenuButton.vue
+++ b/src/features/documentManage/DocumentManageMenuButton.vue
@@ -71,7 +71,6 @@ const onClickMenuAction = async ({ key }: { key: DocumentContextEvent }) => {
           reportHandledError(error, {
             feature: 'documentExport',
             action: 'exportDocumentJson',
-            path: directoryPath.value,
           });
         }
       }

--- a/src/features/entryManage/FSEntryManageMenuButton.test.ts
+++ b/src/features/entryManage/FSEntryManageMenuButton.test.ts
@@ -1,0 +1,185 @@
+/* eslint-disable vue/one-component-per-file -- This test file intentionally defines inline stubs and a small harness component. */
+import { flushPromises, mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h, ref } from 'vue';
+
+const importJsonFileMock = vi.fn();
+const reportHandledErrorMock = vi.fn();
+const addSnackbarMock = vi.fn();
+
+vi.mock('@entity/directory/useDirectory', () => ({
+  useDirectory: () => ({
+    data: ref([['target', { type: 2 }]]),
+  }),
+}));
+
+vi.mock('@entity/fsEntry', () => ({
+  useFSNodeStat: () => ({
+    data: ref({
+      capabilities: {
+        canChangePath: true,
+        canDelete: true,
+        canEditChildren: true,
+      },
+    }),
+  }),
+}));
+
+vi.mock('@feature/directoryCreate', () => ({
+  DirectoryCreateDialog: defineComponent({
+    name: 'DirectoryCreateDialogStub',
+    setup() {
+      return () => null;
+    },
+  }),
+}));
+
+vi.mock('@feature/documentCreate', () => ({
+  DocumentCreationDialog: defineComponent({
+    name: 'DocumentCreationDialogStub',
+    setup() {
+      return () => null;
+    },
+  }),
+}));
+
+vi.mock('@feature/entryRemove', () => ({
+  useRemoveFSEntry: () => ({
+    remove: vi.fn(),
+  }),
+}));
+
+vi.mock('@feature/entryRename', () => ({
+  FSEntryRenameDialog: defineComponent({
+    name: 'FSEntryRenameDialogStub',
+    setup() {
+      return () => null;
+    },
+  }),
+}));
+
+vi.mock('@feature/importDocument', async () => {
+  const actual =
+    await vi.importActual<typeof import('@feature/importDocument')>('@feature/importDocument');
+
+  return {
+    ...actual,
+    useImportDocument: () => ({
+      importJsonFile: importJsonFileMock,
+    }),
+  };
+});
+
+vi.mock('@shared/lib/reportHandledError', () => ({
+  reportHandledError: reportHandledErrorMock,
+}));
+
+vi.mock('@shared/ui/Snackbar', () => ({
+  useSnackbar: () => ({
+    addSnackbar: addSnackbarMock,
+  }),
+}));
+
+vi.mock('@shared/ui/Menu', () => ({
+  MDContextMenuButton: defineComponent({
+    name: 'MDContextMenuButtonStub',
+    props: {
+      btns: {
+        type: Array,
+        required: true,
+      },
+      tooltip: {
+        type: String,
+        required: true,
+      },
+    },
+    emits: ['click'],
+    setup(props, { emit }) {
+      return () =>
+        h(
+          'button',
+          {
+            type: 'button',
+            onClick: () => {
+              emit(
+                'click',
+                props.btns.find(
+                  (button) =>
+                    typeof button === 'object' &&
+                    button !== null &&
+                    'label' in button &&
+                    button.label === 'Import JSON',
+                ) ?? props.btns[0],
+              );
+            },
+          },
+          props.tooltip,
+        );
+    },
+  }),
+  defineMenuButtonList: <T>(buttons: T[]) => buttons,
+}));
+
+vi.mock('@shared/ui/Menu/defineMenuButtonList', () => ({
+  defineMenuButton: <T extends object>(button: T) => button,
+}));
+
+describe('FSEntryManageMenuButton', () => {
+  beforeEach(() => {
+    importJsonFileMock.mockReset();
+    reportHandledErrorMock.mockReset();
+    addSnackbarMock.mockReset();
+  });
+
+  it('does not report invalid Beaver document format import errors', async () => {
+    const { DomainError } = await import('@shared/lib/error');
+    const { ImportDocumentErrorCode } = await import('@feature/importDocument');
+    const { default: FSEntryManageMenuButton } = await import('./FSEntryManageMenuButton.vue');
+
+    importJsonFileMock.mockRejectedValue(
+      new DomainError('Invalid Beaver document', {
+        cause: new Error('zod details'),
+        code: ImportDocumentErrorCode.invalidDocumentFormat,
+      }),
+    );
+
+    const wrapper = mount(FSEntryManageMenuButton, {
+      props: {
+        path: '/target',
+      },
+    });
+
+    await wrapper.get('button').trigger('click');
+    await flushPromises();
+
+    expect(reportHandledErrorMock).not.toHaveBeenCalled();
+    expect(addSnackbarMock).toHaveBeenCalledWith({
+      text: 'Invalid Beaver document',
+    });
+  });
+
+  it('still reports unexpected import errors', async () => {
+    const { default: FSEntryManageMenuButton } = await import('./FSEntryManageMenuButton.vue');
+    const error = new Error('unexpected failure');
+
+    importJsonFileMock.mockRejectedValue(error);
+
+    const wrapper = mount(FSEntryManageMenuButton, {
+      props: {
+        path: '/target',
+      },
+    });
+
+    await wrapper.get('button').trigger('click');
+    await flushPromises();
+
+    expect(reportHandledErrorMock).toHaveBeenCalledWith(error, {
+      action: 'importDocumentJson',
+      feature: 'documentImport',
+    });
+    expect(addSnackbarMock).toHaveBeenCalledWith({
+      text: 'Could not import the document',
+    });
+  });
+});
+/* eslint-enable vue/one-component-per-file -- Re-enable the rule after the inline test stubs used in this file. */

--- a/src/features/entryManage/FSEntryManageMenuButton.vue
+++ b/src/features/entryManage/FSEntryManageMenuButton.vue
@@ -159,7 +159,6 @@ const onClickMenuAction = async ({ key }: { key: FSEntryContextEvent }) => {
             reportHandledError(error, {
               feature: 'documentImport',
               action: 'importDocumentJson',
-              path: path.value,
             });
           }
         }

--- a/src/features/entryManage/FSEntryManageMenuButton.vue
+++ b/src/features/entryManage/FSEntryManageMenuButton.vue
@@ -119,7 +119,9 @@ const { addSnackbar } = useSnackbar();
 
 const shouldSkipImportErrorReport = (error: unknown) =>
   isUserFileSelectionCancel(error) ||
-  (error instanceof DomainError && error.code === ImportDocumentErrorCode.invalidJson);
+  (error instanceof DomainError &&
+    (error.code === ImportDocumentErrorCode.invalidJson ||
+      error.code === ImportDocumentErrorCode.invalidDocumentFormat));
 
 const onClickMenuAction = async ({ key }: { key: FSEntryContextEvent }) => {
   switch (key) {

--- a/src/features/entryRemove/useRemoveFSEntry.test.ts
+++ b/src/features/entryRemove/useRemoveFSEntry.test.ts
@@ -43,7 +43,7 @@ describe('useRemoveFSEntry', () => {
   });
 
   it('shows a snackbar, reports, and does not rethrow when non-recursive remove fails', async () => {
-    const error = new Error('remove failed');
+    const error = new Error('Failed to remove /docs/file.json for gd-123');
     confirmMock.mockResolvedValueOnce(true);
     removeEntryMock.mockRejectedValueOnce(error);
 
@@ -55,6 +55,32 @@ describe('useRemoveFSEntry', () => {
     expect(addSnackbarMock).toHaveBeenCalledWith({
       text: 'Could not remove the item',
     });
+    expect(reportHandledErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Could not remove the item',
+        cause: expect.objectContaining({
+          message: 'File system remove operation failed',
+        }),
+      }),
+      {
+        feature: 'entryRemove',
+        action: 'removeEntry',
+      },
+    );
+  });
+
+  it('reports a trusted VfsError directly for non-recursive removal failures', async () => {
+    const error = new VfsError(
+      FileSystemError.NoPermissions,
+      'File system delete operation is not allowed',
+    );
+    confirmMock.mockResolvedValueOnce(true);
+    removeEntryMock.mockRejectedValueOnce(error);
+
+    const { remove } = useRemoveFSEntry();
+
+    await expect(remove('/docs/file.json')).resolves.toBeUndefined();
+
     expect(reportHandledErrorMock).toHaveBeenCalledWith(error, {
       feature: 'entryRemove',
       action: 'removeEntry',
@@ -85,6 +111,32 @@ describe('useRemoveFSEntry', () => {
       feature: 'entryRemove',
       action: 'removeEntryRecursive',
     });
+  });
+
+  it('wraps untrusted recursive removal errors before reporting', async () => {
+    const directoryNotEmptyError = new VfsError(FileSystemError.DirectoryNotEmpty);
+    const recursiveError = new Error('Failed to remove /docs/folder/private for gd-456');
+    confirmMock.mockResolvedValueOnce(true).mockResolvedValueOnce(true);
+    removeEntryMock
+      .mockRejectedValueOnce(directoryNotEmptyError)
+      .mockRejectedValueOnce(recursiveError);
+
+    const { remove } = useRemoveFSEntry();
+
+    await expect(remove('/docs/folder')).resolves.toBeUndefined();
+
+    expect(reportHandledErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Could not remove the directory',
+        cause: expect.objectContaining({
+          message: 'File system recursive remove operation failed',
+        }),
+      }),
+      {
+        feature: 'entryRemove',
+        action: 'removeEntryRecursive',
+      },
+    );
   });
 
   it('does not remove or report when the user cancels confirmation', async () => {

--- a/src/features/entryRemove/useRemoveFSEntry.test.ts
+++ b/src/features/entryRemove/useRemoveFSEntry.test.ts
@@ -58,7 +58,6 @@ describe('useRemoveFSEntry', () => {
     expect(reportHandledErrorMock).toHaveBeenCalledWith(error, {
       feature: 'entryRemove',
       action: 'removeEntry',
-      path: '/docs/file.json',
     });
   });
 
@@ -85,7 +84,6 @@ describe('useRemoveFSEntry', () => {
     expect(reportHandledErrorMock).toHaveBeenCalledWith(recursiveError, {
       feature: 'entryRemove',
       action: 'removeEntryRecursive',
-      path: '/docs/folder',
     });
   });
 

--- a/src/features/entryRemove/useRemoveFSEntry.ts
+++ b/src/features/entryRemove/useRemoveFSEntry.ts
@@ -1,9 +1,19 @@
 import { useFileSystem } from '@entity/mountedDirectories';
-import { DomainError } from '@shared/lib/error';
+import { createSafeErrorCause, DomainError } from '@shared/lib/error';
 import { reportHandledError } from '@shared/lib/reportHandledError';
 import { PathUtils, VfsError, FileSystemError } from '@shared/lib/virtualFileSystem';
 import { useDialog } from '@shared/ui/Dialog';
 import { useSnackbar } from '@shared/ui/Snackbar';
+
+const toReportedRemoveError = (error: unknown, message: string, causeMessage: string) => {
+  if (error instanceof DomainError || error instanceof VfsError) {
+    return error;
+  }
+
+  return new DomainError(message, {
+    cause: createSafeErrorCause(causeMessage),
+  });
+};
 
 /**
  * Creates a remove action that shows user-facing feedback for file-system entry deletion.
@@ -45,23 +55,35 @@ export const useRemoveFSEntry = () => {
             try {
               await removeEntry(path, true);
             } catch (recursiveError) {
+              const reportedError = toReportedRemoveError(
+                recursiveError,
+                'Could not remove the directory',
+                'File system recursive remove operation failed',
+              );
+
               addSnackbar({
                 text:
                   recursiveError instanceof DomainError
                     ? recursiveError.message
                     : 'Could not remove the directory',
               });
-              reportHandledError(recursiveError, {
+              reportHandledError(reportedError, {
                 feature: 'entryRemove',
                 action: 'removeEntryRecursive',
               });
             }
           }
         } else {
+          const reportedError = toReportedRemoveError(
+            error,
+            'Could not remove the item',
+            'File system remove operation failed',
+          );
+
           addSnackbar({
             text: error instanceof DomainError ? error.message : 'Could not remove the item',
           });
-          reportHandledError(error, {
+          reportHandledError(reportedError, {
             feature: 'entryRemove',
             action: 'removeEntry',
           });

--- a/src/features/entryRemove/useRemoveFSEntry.ts
+++ b/src/features/entryRemove/useRemoveFSEntry.ts
@@ -54,7 +54,6 @@ export const useRemoveFSEntry = () => {
               reportHandledError(recursiveError, {
                 feature: 'entryRemove',
                 action: 'removeEntryRecursive',
-                path,
               });
             }
           }
@@ -65,7 +64,6 @@ export const useRemoveFSEntry = () => {
           reportHandledError(error, {
             feature: 'entryRemove',
             action: 'removeEntry',
-            path,
           });
         }
       }

--- a/src/features/exportDocument/useExportDocument.test.ts
+++ b/src/features/exportDocument/useExportDocument.test.ts
@@ -53,7 +53,7 @@ describe('useExportDocument', () => {
   });
 
   it('preserves the original cause when fetching the document state fails', async () => {
-    const cause = new Error('Fetch failed');
+    const cause = new Error('Could not load the document for export');
     fetchMock.mockRejectedValueOnce(cause);
 
     const { saveJsonFile } = useExportDocument();
@@ -123,7 +123,7 @@ describe('useExportDocument', () => {
   });
 
   it('does not treat non-AbortError save failures as user cancellation', async () => {
-    const cause = new DOMException('Permission denied', 'NotAllowedError');
+    const cause = new DOMException('Could not save the exported file', 'NotAllowedError');
     fileSaveMock.mockRejectedValueOnce(cause);
 
     const { saveJsonFile } = useExportDocument();
@@ -136,6 +136,25 @@ describe('useExportDocument', () => {
     expect(error).toMatchObject({
       message: 'Could not export the document',
       cause,
+    });
+  });
+
+  it('preserves a safe cause message for reporting when export loading fails', async () => {
+    const cause = new Error('Could not load the document for export');
+    fetchMock.mockRejectedValueOnce(cause);
+
+    const { saveJsonFile } = useExportDocument();
+
+    const error = await saveJsonFile('/documents', documentId).catch(
+      (caughtError: unknown) => caughtError,
+    );
+
+    expect(error).toBeInstanceOf(DomainError);
+    expect(error).toMatchObject({
+      message: 'Could not export the document',
+      cause: expect.objectContaining({
+        message: 'Could not load the document for export',
+      }),
     });
   });
 

--- a/src/features/exportDocument/useExportDocument.test.ts
+++ b/src/features/exportDocument/useExportDocument.test.ts
@@ -52,9 +52,11 @@ describe('useExportDocument', () => {
     expect(fileSaveMock).not.toHaveBeenCalled();
   });
 
-  it('preserves the original cause when fetching the document state fails', async () => {
-    const cause = new Error('Could not load the document for export');
-    fetchMock.mockRejectedValueOnce(cause);
+  it('replaces raw document load failure details with a safe cause', async () => {
+    const rawCause = new Error(
+      'Could not load /Device files/Private/Tax 2025/document.json for document-id 4Z1fFANPScpDsLXmC1KsBCn4mWYu',
+    );
+    fetchMock.mockRejectedValueOnce(rawCause);
 
     const { saveJsonFile } = useExportDocument();
 
@@ -65,8 +67,12 @@ describe('useExportDocument', () => {
     expect(error).toBeInstanceOf(DomainError);
     expect(error).toMatchObject({
       message: 'Could not export the document',
-      cause,
+      code: 'document-export-failed',
+      cause: expect.objectContaining({
+        message: 'Document repository read operation failed',
+      }),
     });
+    expect(error).not.toHaveProperty('cause.message', rawCause.message);
     expect(fileSaveMock).not.toHaveBeenCalled();
   });
 
@@ -123,8 +129,11 @@ describe('useExportDocument', () => {
   });
 
   it('does not treat non-AbortError save failures as user cancellation', async () => {
-    const cause = new DOMException('Could not save the exported file', 'NotAllowedError');
-    fileSaveMock.mockRejectedValueOnce(cause);
+    const rawCause = new DOMException(
+      'Could not save /Device files/Private/Tax 2025/4Z1fFANPScpDsLXmC1KsBCn4mWYu.json',
+      'NotAllowedError',
+    );
+    fileSaveMock.mockRejectedValueOnce(rawCause);
 
     const { saveJsonFile } = useExportDocument();
 
@@ -135,13 +144,18 @@ describe('useExportDocument', () => {
     expect(error).toBeInstanceOf(DomainError);
     expect(error).toMatchObject({
       message: 'Could not export the document',
-      cause,
+      code: 'document-export-failed',
+      cause: expect.objectContaining({
+        message: 'Selected file save operation failed',
+      }),
     });
+    expect(error).not.toHaveProperty('cause.message', rawCause.message);
   });
 
   it('preserves a safe cause message for reporting when export loading fails', async () => {
-    const cause = new Error('Could not load the document for export');
-    fetchMock.mockRejectedValueOnce(cause);
+    fetchMock.mockRejectedValueOnce(
+      new Error('Could not load /Device files/Private/Tax 2025/document.json'),
+    );
 
     const { saveJsonFile } = useExportDocument();
 
@@ -153,7 +167,7 @@ describe('useExportDocument', () => {
     expect(error).toMatchObject({
       message: 'Could not export the document',
       cause: expect.objectContaining({
-        message: 'Could not load the document for export',
+        message: 'Document repository read operation failed',
       }),
     });
   });

--- a/src/features/exportDocument/useExportDocument.ts
+++ b/src/features/exportDocument/useExportDocument.ts
@@ -1,5 +1,5 @@
 import type { AMDocumentId } from '@shared/lib/automerge';
-import { DomainError } from '@shared/lib/error';
+import { createSafeErrorCause, DomainError } from '@shared/lib/error';
 import { isUserFileSelectionCancel } from '@shared/lib/fileSystem';
 import { useMainServiceClient } from '@shared/service';
 import { stringify } from 'safe-stable-stringify';
@@ -35,7 +35,7 @@ export const useExportDocument = () => {
       }
 
       throw new DomainError('Could not export the document', {
-        cause: error,
+        cause: createSafeErrorCause('Document repository read operation failed'),
         code: ExportDocumentErrorCode.documentExportFailed,
       });
     }
@@ -70,7 +70,7 @@ export const useExportDocument = () => {
       }
 
       throw new DomainError('Could not export the document', {
-        cause: error,
+        cause: createSafeErrorCause('Selected file save operation failed'),
         code: ExportDocumentErrorCode.documentExportFailed,
       });
     }

--- a/src/features/importDocument/useImportDocument.test.ts
+++ b/src/features/importDocument/useImportDocument.test.ts
@@ -77,7 +77,7 @@ describe('useImportDocument', () => {
       ),
     });
 
-    const cause = new Error('Create failed');
+    const cause = new Error('Could not write the imported document');
     createDocumentMock.mockRejectedValueOnce(cause);
 
     const { importJsonFile } = useImportDocument();
@@ -141,7 +141,7 @@ describe('useImportDocument', () => {
   });
 
   it('wraps file read errors with a user-facing DomainError', async () => {
-    const cause = new Error('Read failed');
+    const cause = new Error('Could not read the selected file');
     fileOpenMock.mockResolvedValue({
       text: vi.fn().mockRejectedValue(cause),
     });
@@ -168,7 +168,7 @@ describe('useImportDocument', () => {
   });
 
   it('does not treat non-AbortError picker failures as user cancellation', async () => {
-    const cause = new DOMException('Permission denied', 'NotAllowedError');
+    const cause = new DOMException('Could not access the selected file', 'NotAllowedError');
     fileOpenMock.mockRejectedValueOnce(cause);
 
     const { importJsonFile } = useImportDocument();
@@ -181,5 +181,33 @@ describe('useImportDocument', () => {
       cause,
     });
     expect(createDocumentMock).not.toHaveBeenCalled();
+  });
+
+  it('preserves a safe cause message for reporting when document creation fails', async () => {
+    fileOpenMock.mockResolvedValue({
+      text: vi.fn().mockResolvedValue(
+        JSON.stringify({
+          body: {},
+          name: 'Doc',
+          type: 'note',
+          version: 1,
+        }),
+      ),
+    });
+
+    const cause = new Error('Could not write the imported document');
+    createDocumentMock.mockRejectedValueOnce(cause);
+
+    const { importJsonFile } = useImportDocument();
+
+    const error = await importJsonFile('/documents').catch((caughtError: unknown) => caughtError);
+
+    expect(error).toBeInstanceOf(DomainError);
+    expect(error).toMatchObject({
+      message: 'Could not import the document',
+      cause: expect.objectContaining({
+        message: 'Could not write the imported document',
+      }),
+    });
   });
 });

--- a/src/features/importDocument/useImportDocument.test.ts
+++ b/src/features/importDocument/useImportDocument.test.ts
@@ -65,7 +65,7 @@ describe('useImportDocument', () => {
     expect(createDocumentMock).not.toHaveBeenCalled();
   });
 
-  it('preserves the original cause when document creation fails', async () => {
+  it('replaces raw repository failure details with a safe cause when document creation fails', async () => {
     fileOpenMock.mockResolvedValue({
       text: vi.fn().mockResolvedValue(
         JSON.stringify({
@@ -77,8 +77,10 @@ describe('useImportDocument', () => {
       ),
     });
 
-    const cause = new Error('Could not write the imported document');
-    createDocumentMock.mockRejectedValueOnce(cause);
+    const rawCause = new Error(
+      'Failed to write /Device files/Private/Tax 2025/document.json for file-id gd-123',
+    );
+    createDocumentMock.mockRejectedValueOnce(rawCause);
 
     const { importJsonFile } = useImportDocument();
 
@@ -93,8 +95,12 @@ describe('useImportDocument', () => {
     expect(error).toBeInstanceOf(DomainError);
     expect(error).toMatchObject({
       message: 'Could not import the document',
-      cause,
+      code: 'document-import-failed',
+      cause: expect.objectContaining({
+        message: 'Document repository write operation failed',
+      }),
     });
+    expect(error).not.toHaveProperty('cause.message', rawCause.message);
   });
 
   it('creates a document from valid Beaver JSON and returns its id', async () => {
@@ -140,10 +146,10 @@ describe('useImportDocument', () => {
     await expect(importJsonFile('/documents')).rejects.toBe(cause);
   });
 
-  it('wraps file read errors with a user-facing DomainError', async () => {
-    const cause = new Error('Could not read the selected file');
+  it('wraps file read errors with a privacy-safe technical cause', async () => {
+    const rawCause = new Error('Could not read /Device files/Private/Tax 2025/document.json');
     fileOpenMock.mockResolvedValue({
-      text: vi.fn().mockRejectedValue(cause),
+      text: vi.fn().mockRejectedValue(rawCause),
     });
 
     const { importJsonFile } = useImportDocument();
@@ -153,8 +159,12 @@ describe('useImportDocument', () => {
     expect(error).toBeInstanceOf(DomainError);
     expect(error).toMatchObject({
       message: 'Could not import the document',
-      cause,
+      code: 'file-read-failed',
+      cause: expect.objectContaining({
+        message: 'Selected file read failed',
+      }),
     });
+    expect(error).not.toHaveProperty('cause.message', rawCause.message);
     expect(createDocumentMock).not.toHaveBeenCalled();
   });
 
@@ -168,8 +178,11 @@ describe('useImportDocument', () => {
   });
 
   it('does not treat non-AbortError picker failures as user cancellation', async () => {
-    const cause = new DOMException('Could not access the selected file', 'NotAllowedError');
-    fileOpenMock.mockRejectedValueOnce(cause);
+    const rawCause = new DOMException(
+      'Could not access /Device files/Private/Tax 2025/document.json',
+      'NotAllowedError',
+    );
+    fileOpenMock.mockRejectedValueOnce(rawCause);
 
     const { importJsonFile } = useImportDocument();
 
@@ -178,8 +191,12 @@ describe('useImportDocument', () => {
     expect(error).toBeInstanceOf(DomainError);
     expect(error).toMatchObject({
       message: 'Could not open the selected file',
-      cause,
+      code: 'file-open-failed',
+      cause: expect.objectContaining({
+        message: 'Selected file open operation failed',
+      }),
     });
+    expect(error).not.toHaveProperty('cause.message', rawCause.message);
     expect(createDocumentMock).not.toHaveBeenCalled();
   });
 
@@ -206,7 +223,7 @@ describe('useImportDocument', () => {
     expect(error).toMatchObject({
       message: 'Could not import the document',
       cause: expect.objectContaining({
-        message: 'Could not write the imported document',
+        message: 'Document repository write operation failed',
       }),
     });
   });

--- a/src/features/importDocument/useImportDocument.ts
+++ b/src/features/importDocument/useImportDocument.ts
@@ -1,4 +1,4 @@
-import { DomainError } from '@shared/lib/error';
+import { createSafeErrorCause, DomainError } from '@shared/lib/error';
 import { isUserFileSelectionCancel } from '@shared/lib/fileSystem';
 import { useMainServiceClient } from '@shared/service';
 import { fileOpen } from 'browser-fs-access';
@@ -38,7 +38,7 @@ export const useImportDocument = () => {
       }
 
       throw new DomainError('Could not open the selected file', {
-        cause: error,
+        cause: createSafeErrorCause('Selected file open operation failed'),
         code: ImportDocumentErrorCode.fileOpenFailed,
       });
     }
@@ -47,9 +47,9 @@ export const useImportDocument = () => {
 
     try {
       text = await file.text();
-    } catch (error) {
+    } catch {
       throw new DomainError('Could not import the document', {
-        cause: error,
+        cause: createSafeErrorCause('Selected file read failed'),
         code: ImportDocumentErrorCode.fileReadFailed,
       });
     }
@@ -86,7 +86,7 @@ export const useImportDocument = () => {
       }
 
       throw new DomainError('Could not import the document', {
-        cause: error,
+        cause: createSafeErrorCause('Document repository write operation failed'),
         code: ImportDocumentErrorCode.documentImportFailed,
       });
     }

--- a/src/features/localDirectoryPick/usePickLocalDirectory.test.ts
+++ b/src/features/localDirectoryPick/usePickLocalDirectory.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DomainError } from '@shared/lib/error';
+import { usePickLocalDirectory } from './usePickLocalDirectory';
+
+const {
+  addDeviceDirectoryMock,
+  addSnackbarMock,
+  alertMock,
+  reportHandledErrorMock,
+  showDirectoryPickerMock,
+} = vi.hoisted(() => ({
+  addDeviceDirectoryMock: vi.fn(),
+  addSnackbarMock: vi.fn(),
+  alertMock: vi.fn(),
+  reportHandledErrorMock: vi.fn(),
+  showDirectoryPickerMock: vi.fn(),
+}));
+
+vi.mock('@entity/mountedDirectories', () => ({
+  useFileSystem: () => ({
+    addDeviceDirectory: addDeviceDirectoryMock,
+  }),
+}));
+
+vi.mock('@shared/ui/Dialog', () => ({
+  useDialog: () => ({
+    alert: alertMock,
+  }),
+}));
+
+vi.mock('@shared/ui/Snackbar', () => ({
+  useSnackbar: () => ({
+    addSnackbar: addSnackbarMock,
+  }),
+}));
+
+vi.mock('@shared/lib/reportHandledError', () => ({
+  reportHandledError: reportHandledErrorMock,
+}));
+
+describe('usePickLocalDirectory', () => {
+  beforeEach(() => {
+    addDeviceDirectoryMock.mockReset();
+    addSnackbarMock.mockReset();
+    alertMock.mockReset();
+    reportHandledErrorMock.mockReset();
+    showDirectoryPickerMock.mockReset();
+    alertMock.mockResolvedValue(undefined);
+    addDeviceDirectoryMock.mockResolvedValue(undefined);
+    Object.defineProperty(window, 'showDirectoryPicker', {
+      configurable: true,
+      value: showDirectoryPickerMock,
+    });
+  });
+
+  it('reports a privacy-safe DomainError when the directory picker fails with a raw path message', async () => {
+    const rawCause = new DOMException(
+      'Could not access /Device files/Private/Taxes 2025',
+      'NotAllowedError',
+    );
+    showDirectoryPickerMock.mockRejectedValueOnce(rawCause);
+
+    const { pickLocalDirectory } = usePickLocalDirectory();
+
+    await expect(pickLocalDirectory()).resolves.toBeUndefined();
+
+    expect(addSnackbarMock).toHaveBeenCalledWith({
+      text: 'Could not add the folder',
+    });
+    expect(reportHandledErrorMock).toHaveBeenCalledTimes(1);
+    const [reportedError, options] = reportHandledErrorMock.mock.calls[0] ?? [];
+    expect(options).toEqual({
+      feature: 'localDirectoryPick',
+      action: 'pickLocalDirectory',
+    });
+    expect(reportedError).toBeInstanceOf(DomainError);
+    expect(reportedError).toMatchObject({
+      message: 'Could not add the folder',
+      cause: expect.objectContaining({
+        message: 'Directory picker operation failed',
+      }),
+    });
+    if (!(reportedError instanceof DomainError)) {
+      throw new Error('Expected DomainError');
+    }
+    expect(reportedError.cause).not.toMatchObject({
+      message: rawCause.message,
+    });
+  });
+});

--- a/src/features/localDirectoryPick/usePickLocalDirectory.ts
+++ b/src/features/localDirectoryPick/usePickLocalDirectory.ts
@@ -1,5 +1,5 @@
 import { useFileSystem } from '@entity/mountedDirectories';
-import { DomainError } from '@shared/lib/error';
+import { createSafeErrorCause, DomainError } from '@shared/lib/error';
 import { isUserFileSelectionCancel } from '@shared/lib/fileSystem';
 import { isFunction } from 'es-toolkit';
 import { ref, toRef } from 'vue';
@@ -57,10 +57,17 @@ export const usePickLocalDirectory = () => {
       await addDeviceDirectory(directoryHandle);
     } catch (error) {
       if (!isUserFileSelectionCancel(error)) {
+        const reportedError =
+          error instanceof DomainError
+            ? error
+            : new DomainError('Could not add the folder', {
+                cause: createSafeErrorCause('Directory picker operation failed'),
+              });
+
         addSnackbar({
-          text: error instanceof DomainError ? error.message : 'Could not add the folder',
+          text: reportedError.message,
         });
-        reportHandledError(error, {
+        reportHandledError(reportedError, {
           feature: 'localDirectoryPick',
           action: 'pickLocalDirectory',
         });

--- a/src/pages/DataStoragePrivacyPane/DataStoragePrivacyPane.test.ts
+++ b/src/pages/DataStoragePrivacyPane/DataStoragePrivacyPane.test.ts
@@ -54,8 +54,15 @@ it('renders the local-first and privacy help content in-app', async () => {
   expect(root.textContent).toContain('You can use the app without creating a Mioframe account.');
   expect(root.textContent).toContain('Error diagnostics');
   expect(root.textContent).toContain('Error diagnostics are optional');
-  expect(root.textContent).toContain('Document contents are not intentionally included');
-  expect(root.textContent).toContain('stack traces, browser details, or the current app URL');
+  expect(root.textContent).toContain(
+    'Mioframe sends technical error reports only after an error happens.',
+  );
+  expect(root.textContent).toContain(
+    'do not include document contents, record values, document names, folder names, local folder paths, document ids, or file ids.',
+  );
+  expect(root.textContent).toContain(
+    'stack traces, browser details, app version or build information, error type or code, and a safe application error message.',
+  );
 
   app.unmount();
   root.remove();

--- a/src/pages/DataStoragePrivacyPane/DataStoragePrivacyPane.test.ts
+++ b/src/pages/DataStoragePrivacyPane/DataStoragePrivacyPane.test.ts
@@ -61,7 +61,7 @@ it('renders the local-first and privacy help content in-app', async () => {
     'do not include document contents, record values, document names, folder names, local folder paths, document ids, or file ids.',
   );
   expect(root.textContent).toContain(
-    'stack traces, browser details, app version or build information, error type or code, and a safe application error message.',
+    'stack traces, app version or build information, error type or code, and a safe application error message.',
   );
 
   app.unmount();

--- a/src/pages/DataStoragePrivacyPane/DataStoragePrivacyPane.vue
+++ b/src/pages/DataStoragePrivacyPane/DataStoragePrivacyPane.vue
@@ -54,12 +54,16 @@ defineSlots<{
           breaks so developers can investigate crashes and unexpected failures.
         </p>
         <p>
-          You can enable or disable error diagnostics in Settings at any time. Document contents are
-          not intentionally included in these reports.
+          You can enable or disable error diagnostics in Settings at any time. When enabled,
+          Mioframe sends technical error reports only after an error happens.
         </p>
         <p>
-          Technical reports may still include metadata such as stack traces, browser details, or the
-          current app URL when an error happens.
+          These reports do not include document contents, record values, document names, folder
+          names, local folder paths, document ids, or file ids.
+        </p>
+        <p>
+          Technical reports may still include stack traces, browser details, app version or build
+          information, error type or code, and a safe application error message.
         </p>
       </section>
     </div>

--- a/src/pages/DataStoragePrivacyPane/DataStoragePrivacyPane.vue
+++ b/src/pages/DataStoragePrivacyPane/DataStoragePrivacyPane.vue
@@ -62,8 +62,8 @@ defineSlots<{
           names, local folder paths, document ids, or file ids.
         </p>
         <p>
-          Technical reports may still include stack traces, browser details, app version or build
-          information, error type or code, and a safe application error message.
+          Technical reports may still include stack traces, app version or build information, error
+          type or code, and a safe application error message.
         </p>
       </section>
     </div>

--- a/src/shared/lib/error/createSafeErrorCause.ts
+++ b/src/shared/lib/error/createSafeErrorCause.ts
@@ -1,0 +1,8 @@
+/**
+ * Creates a privacy-safe technical cause error for diagnostics reporting.
+ * Use this instead of propagating raw browser, filesystem, API, or library errors
+ * when the cause may be reported through handled diagnostics.
+ * @param message - Stable project-controlled technical cause message.
+ * @returns Error with a safe message for diagnostics.
+ */
+export const createSafeErrorCause = (message: string): Error => new Error(message);

--- a/src/shared/lib/error/index.ts
+++ b/src/shared/lib/error/index.ts
@@ -75,3 +75,4 @@ export class DomainError<TCode extends PropertyKey = string> extends Error {
 }
 
 export { HttpStatusCode } from './httpStatus';
+export { createSafeErrorCause } from './createSafeErrorCause';

--- a/src/shared/lib/fileSystem/utils.ts
+++ b/src/shared/lib/fileSystem/utils.ts
@@ -2,7 +2,6 @@ import { from } from 'ix/Ix.asynciterable';
 import type { DirectoryFSEntry, WritableDirectoryFSEntry } from './DirectoryFSEntry';
 import type { FileFSEntry } from './FileFSEntry';
 import { isEqual } from 'es-toolkit';
-import { pathToString } from '@shared/service/directories';
 import { DomainError } from '../error';
 import { FileSystemDomainErrorCode } from './fileSystemErrorCode';
 
@@ -22,9 +21,7 @@ export const moveDirectoryTo = async (
   if (isNestedPath(dest.path, currentDirectoryEntry.path)) {
     throw new DomainError('Could not move the directory', {
       code: FileSystemDomainErrorCode.directoryMoveFailed,
-      cause: new Error(
-        `impossible to move "${currentDirectoryEntry.name}" from "${currentDirectoryEntry.path.slice(0, -1).join('/')}" to "${dest.path.join('/')}"`,
-      ),
+      cause: new Error('Cannot move a directory into itself or one of its subdirectories'),
     });
   }
 
@@ -34,14 +31,14 @@ export const moveDirectoryTo = async (
     if (!('moveTo' in entry)) {
       throw new DomainError('Could not move the item', {
         code: FileSystemDomainErrorCode.entryMoveFailed,
-        cause: new Error(`"${pathToString(entry.path)}" don't have moveTo method`),
+        cause: new Error('The selected item does not support moving'),
       });
     }
 
     if (!('createDirectory' in newDirectoryEntry)) {
       throw new DomainError('Could not move the directory', {
         code: FileSystemDomainErrorCode.directoryMoveFailed,
-        cause: new Error(`"${pathToString(newDirectoryEntry.path)}" don't writable directory`),
+        cause: new Error('The destination directory is not writable'),
       });
     }
 
@@ -51,7 +48,7 @@ export const moveDirectoryTo = async (
   if (!('remove' in currentDirectoryEntry)) {
     throw new DomainError('Could not remove the directory', {
       code: FileSystemDomainErrorCode.directoryRemoveFailed,
-      cause: new Error(`"${pathToString(currentDirectoryEntry.path)}" don't have remove method`),
+      cause: new Error('The selected directory does not support removal'),
     });
   }
 
@@ -77,7 +74,7 @@ export const copyDirectoryTo = async (
   if (isNestedPath(destPath, currentPath)) {
     throw new DomainError('Could not copy the directory', {
       code: FileSystemDomainErrorCode.directoryCopyFailed,
-      cause: new Error(`impossible to copy "${currentPath.join('/')}" to "${destPath.join('/')}"`),
+      cause: new Error('Cannot copy a directory into itself or one of its subdirectories'),
     });
   }
 
@@ -89,14 +86,14 @@ export const copyDirectoryTo = async (
     if (!('copyTo' in entry)) {
       throw new DomainError('Could not copy the item', {
         code: FileSystemDomainErrorCode.entryCopyFailed,
-        cause: new Error(`"${pathToString(entry.path)}" don't have copyTo method`),
+        cause: new Error('The selected item does not support copying'),
       });
     }
 
     if (!('createDirectory' in newDirectoryEntry)) {
       throw new DomainError('Could not copy the directory', {
         code: FileSystemDomainErrorCode.directoryCopyFailed,
-        cause: new Error(`"${pathToString(newDirectoryEntry.path)}" don't writable directory`),
+        cause: new Error('The destination directory is not writable'),
       });
     }
 

--- a/src/shared/lib/googleDrive/api/simplifiedAPI.error.test.ts
+++ b/src/shared/lib/googleDrive/api/simplifiedAPI.error.test.ts
@@ -78,6 +78,10 @@ describe('simplifiedAPI error handling', () => {
     ).rejects.toMatchObject({
       code: HttpStatusCode.NOT_FOUND,
       name: 'GoogleDriveError',
+      message: 'Google Drive request failed',
+      cause: expect.objectContaining({
+        message: 'Google Drive API request failed',
+      }),
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -103,6 +107,10 @@ describe('simplifiedAPI error handling', () => {
     await expect(update({ ACCESS_TOKEN: 'token' }, 'file-id', {})).rejects.toMatchObject({
       code: HttpStatusCode.FORBIDDEN,
       name: 'GoogleDriveError',
+      message: 'Google Drive request failed',
+      cause: expect.objectContaining({
+        message: 'Google Drive API request failed',
+      }),
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -130,6 +138,10 @@ describe('simplifiedAPI error handling', () => {
     ).rejects.toMatchObject({
       code: HttpStatusCode.UNAUTHORIZED,
       name: 'GoogleDriveError',
+      message: 'Google Drive request failed',
+      cause: expect.objectContaining({
+        message: 'Google Drive API request failed',
+      }),
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -155,8 +167,46 @@ describe('simplifiedAPI error handling', () => {
     await expect(upload({ ACCESS_TOKEN: 'token' }, 'file-id', 'content')).rejects.toMatchObject({
       code: HttpStatusCode.PAYLOAD_TOO_LARGE,
       name: 'GoogleDriveError',
+      message: 'Google Drive request failed',
+      cause: expect.objectContaining({
+        message: 'Google Drive API request failed',
+      }),
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not preserve raw Google API messages that may contain file ids or names', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: {
+            code: HttpStatusCode.NOT_FOUND,
+            message: 'File gd-123 "Tax 2025" was not found in folder Private',
+          },
+        }),
+        { status: HttpStatusCode.NOT_FOUND },
+      ),
+    );
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { getGFileMetaList } = await import('./simplifiedAPI');
+
+    const error = await getGFileMetaList(
+      { ACCESS_TOKEN: 'token' },
+      { q: {}, spaces: [], fetchAll: true },
+    ).catch((caughtError: unknown) => caughtError);
+
+    expect(error).toMatchObject({
+      message: 'Google Drive request failed',
+      cause: expect.objectContaining({
+        message: 'Google Drive API request failed',
+      }),
+    });
+    expect(error).not.toHaveProperty(
+      'message',
+      'File gd-123 "Tax 2025" was not found in folder Private',
+    );
   });
 });

--- a/src/shared/lib/googleDrive/api/simplifiedAPI.kyErrorHandling.test.ts
+++ b/src/shared/lib/googleDrive/api/simplifiedAPI.kyErrorHandling.test.ts
@@ -54,10 +54,9 @@ describe('simplifiedAPI ky error normalization', () => {
       getGFileMetaList({ ACCESS_TOKEN: 'token' }, { q: {}, spaces: [], fetchAll: true }),
     ).rejects.toMatchObject({
       code: HttpStatusCode.FORBIDDEN,
-      message: 'Permission denied',
+      message: 'Google Drive request failed',
       cause: expect.objectContaining({
-        code: HttpStatusCode.FORBIDDEN,
-        message: 'Permission denied',
+        message: 'Google Drive API request failed',
       }),
     });
 
@@ -85,10 +84,9 @@ describe('simplifiedAPI ky error normalization', () => {
       getGFileMetaList({ ACCESS_TOKEN: 'token' }, { q: {}, spaces: [], fetchAll: true }),
     ).rejects.toMatchObject({
       code: HttpStatusCode.TOO_MANY_REQUESTS,
-      message: 'Rate limited',
+      message: 'Google Drive request failed',
       cause: expect.objectContaining({
-        code: HttpStatusCode.TOO_MANY_REQUESTS,
-        message: 'Rate limited',
+        message: 'Google Drive API request failed',
       }),
     });
 

--- a/src/shared/lib/googleDrive/api/simplifiedAPI.ts
+++ b/src/shared/lib/googleDrive/api/simplifiedAPI.ts
@@ -7,6 +7,7 @@ import type { ZodMiniType } from 'zod/v4-mini';
 import { z } from 'zod/v4-mini';
 import { HttpStatusCode } from '../../error/httpStatus';
 import { GoogleDriveError } from '../error';
+import { createSafeErrorCause } from '../../error';
 import { dedupe } from '../../dedupe';
 import type {
   CreateResource,
@@ -63,15 +64,14 @@ const googleRequest = async (url: Input, options?: ApiOptions): Promise<Response
 
       const { error: googleError } = zodGoogleErrorResponse.parse(errorBody);
 
-      const { code, message } = googleError;
+      const { code } = googleError;
 
       throw new GoogleDriveError(
         {
           code,
-          message,
-          details: googleError,
+          message: 'Google Drive request failed',
         },
-        { cause: googleError },
+        { cause: createSafeErrorCause('Google Drive API request failed') },
       );
     }
 
@@ -85,15 +85,14 @@ const googleRequest = async (url: Input, options?: ApiOptions): Promise<Response
 
       const { error: googleError } = zodGoogleErrorResponse.parse(errorBody);
 
-      const { code, message } = googleError;
+      const { code } = googleError;
 
       throw new GoogleDriveError(
         {
           code,
-          message,
-          details: googleError,
+          message: 'Google Drive request failed',
         },
-        { cause: googleError },
+        { cause: createSafeErrorCause('Google Drive API request failed') },
       );
     }
 
@@ -453,7 +452,7 @@ export const create = async (auth: GoogleAuthParams, resource: CreateResource) =
   if (resource.parents.length === 0) {
     throw new GoogleDriveError({
       code: HttpStatusCode.FORBIDDEN,
-      message: 'Parents array cannot be empty',
+      message: 'Google Drive create operation requires a parent directory',
     });
   }
 
@@ -487,7 +486,7 @@ export const createWithContent = async (
   if (resource.parents.length === 0) {
     throw new GoogleDriveError({
       code: HttpStatusCode.FORBIDDEN,
-      message: 'Parents array cannot be empty',
+      message: 'Google Drive create operation requires a parent directory',
     });
   }
 

--- a/src/shared/lib/googleDrive/error.ts
+++ b/src/shared/lib/googleDrive/error.ts
@@ -7,12 +7,10 @@ import { HttpStatusCode } from '../error/httpStatus';
 type GoogleDriveErrorInit = {
   /** HTTP-like Google Drive error code. */
   code: HttpStatusCode;
-  /** User-facing error message. */
+  /** Project-controlled error message safe for diagnostics. */
   message: string;
   /** Underlying cause preserved for debugging. */
   cause?: unknown;
-  /** Additional API details attached to the failure. */
-  details?: Record<string, unknown> | undefined;
 };
 
 /**
@@ -30,9 +28,6 @@ export class GoogleDriveError extends DomainError<HttpStatusCode> {
   override name = 'GoogleDriveError';
   /** HTTP-like Google Drive error code. */
   override code: HttpStatusCode;
-  /** Additional API details attached to the failure. */
-  details?: Record<string, unknown> | undefined;
-
   /**
    * Creates a Google Drive error from either an init object or a plain message.
    * @param options - Full error details or a fallback message.
@@ -43,10 +38,9 @@ export class GoogleDriveError extends DomainError<HttpStatusCode> {
       super(options, { cause });
       this.code = HttpStatusCode.INTERNAL_SERVER_ERROR;
     } else {
-      const { code, message, details } = options;
+      const { code, message } = options;
       super(message, { cause });
       this.code = code;
-      this.details = details;
     }
   }
 }

--- a/src/shared/lib/googleDrive/gDriveEntry.ts
+++ b/src/shared/lib/googleDrive/gDriveEntry.ts
@@ -28,7 +28,7 @@ export const createGDriveEntry = (
 
     if (!('removeByName' in parentEntry)) {
       throw new DomainError('Could not remove the item', {
-        cause: new Error(`don't have "removeByName" method in ${parentEntry.path.join('/')}`),
+        cause: new Error('The parent entry does not support removal by name'),
       });
     }
     await parentEntry.removeByName(currentName);

--- a/src/shared/lib/googleDrive/gDriveEntry.ts
+++ b/src/shared/lib/googleDrive/gDriveEntry.ts
@@ -37,7 +37,7 @@ export const createGDriveEntry = (
   const rename = async (newName: string): Promise<void> => {
     if (!fileId) {
       throw new DomainError('Could not rename the item', {
-        cause: new Error('You cannot rename an entry without a fileId.'),
+        cause: new Error('The selected item does not support renaming'),
       });
     }
     await update(auth, fileId, {

--- a/src/shared/lib/googleDriveFileSystemProvider/googleDriveFileSystemProvider.test.ts
+++ b/src/shared/lib/googleDriveFileSystemProvider/googleDriveFileSystemProvider.test.ts
@@ -9,6 +9,7 @@ import {
 } from '@shared/lib/virtualFileSystem';
 import type { GDriveFileMeta } from '@shared/lib/googleDrive/api';
 import { DRIVE_GOOGLE_SCOPE } from '@shared/lib/googleApi';
+import { GoogleAuthError, GoogleAuthErrorCode } from '@shared/service/google/errors';
 
 const {
   createMock,
@@ -318,6 +319,65 @@ describe('googleDriveFileSystemProvider', () => {
       'cause.message',
       'Token request failed for user@example.com file gd-123 path /user@example.com/My Drive/Taxes',
     );
+  });
+
+  it('sanitizes Google authorization errors with account emails before they become VfsError causes', async () => {
+    const provider = googleDriveFileSystemProvider({
+      $sessions: new BehaviorSubject<string[]>(['user@example.com']),
+      requestToken: vi.fn().mockRejectedValueOnce(
+        new GoogleAuthError({
+          code: GoogleAuthErrorCode.reauthRequired,
+          expectedEmail: 'user@example.com',
+        }),
+      ),
+    });
+
+    const error = await provider
+      .stat('/user@example.com/My Drive/Taxes')
+      .catch((caughtError: unknown) => caughtError);
+
+    expect(error).toBeInstanceOf(VfsError);
+    expect(error).toMatchObject({
+      code: FileSystemError.FileNotFound,
+      message: 'Google Drive stat operation failed',
+      cause: expect.objectContaining({
+        message: 'Google Drive stat request failed',
+      }),
+    });
+
+    expect(error).not.toHaveProperty(
+      'cause.message',
+      'Google Drive access requires authorization for user@example.com',
+    );
+  });
+
+  it('sanitizes nested causes inside VfsError instances before rewrapping them', async () => {
+    const provider = googleDriveFileSystemProvider({
+      $sessions: new BehaviorSubject<string[]>(['user@example.com']),
+      requestToken: vi
+        .fn()
+        .mockRejectedValueOnce(
+          new VfsError(
+            FileSystemError.Unknown,
+            'Outer safe message',
+            new Error('raw /private/path gd-123'),
+          ),
+        ),
+    });
+
+    const error = await provider
+      .stat('/user@example.com/My Drive/Taxes')
+      .catch((caughtError: unknown) => caughtError);
+
+    expect(error).toBeInstanceOf(VfsError);
+    expect(error).toMatchObject({
+      code: FileSystemError.FileNotFound,
+      message: 'Google Drive stat operation failed',
+      cause: expect.objectContaining({
+        message: 'Google Drive stat request failed',
+      }),
+    });
+    expect(error).not.toHaveProperty('cause.message', 'Outer safe message');
   });
 
   it('sanitizes raw download failures while preserving the VfsError code', async () => {

--- a/src/shared/lib/googleDriveFileSystemProvider/googleDriveFileSystemProvider.test.ts
+++ b/src/shared/lib/googleDriveFileSystemProvider/googleDriveFileSystemProvider.test.ts
@@ -5,6 +5,7 @@ import {
   FSNodeType,
   VfsEventSource,
   VfsEventType,
+  VfsError,
 } from '@shared/lib/virtualFileSystem';
 import type { GDriveFileMeta } from '@shared/lib/googleDrive/api';
 import { DRIVE_GOOGLE_SCOPE } from '@shared/lib/googleApi';
@@ -288,6 +289,116 @@ describe('googleDriveFileSystemProvider', () => {
     });
   });
 
+  it('sanitizes raw stat failures from token or API boundaries', async () => {
+    const requestToken = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error(
+          'Token request failed for user@example.com file gd-123 path /user@example.com/My Drive/Taxes',
+        ),
+      );
+    const provider = googleDriveFileSystemProvider({
+      $sessions: new BehaviorSubject<string[]>(['user@example.com']),
+      requestToken,
+    });
+
+    const error = await provider
+      .stat('/user@example.com/My Drive/Taxes')
+      .catch((caughtError: unknown) => caughtError);
+
+    expect(error).toBeInstanceOf(VfsError);
+    expect(error).toMatchObject({
+      code: FileSystemError.FileNotFound,
+      message: 'Google Drive stat operation failed',
+      cause: expect.objectContaining({
+        message: 'Google Drive stat request failed',
+      }),
+    });
+    expect(error).not.toHaveProperty(
+      'cause.message',
+      'Token request failed for user@example.com file gd-123 path /user@example.com/My Drive/Taxes',
+    );
+  });
+
+  it('sanitizes raw download failures while preserving the VfsError code', async () => {
+    const provider = googleDriveFileSystemProvider({
+      $sessions: new BehaviorSubject<string[]>(['user@example.com']),
+      requestToken: vi.fn().mockResolvedValue('token'),
+    });
+    getGFileMetaListMock.mockResolvedValueOnce({
+      files: [
+        {
+          id: 'gd-123',
+          name: 'Taxes 2025.pdf',
+          mimeType: 'application/pdf',
+          modifiedTime: '2024-01-01T00:00:00.000Z',
+        } satisfies GDriveFileMeta,
+      ],
+    });
+    downloadMock.mockRejectedValueOnce(
+      new Error('Download failed for gd-123 at /user@example.com/My Drive/Taxes 2025.pdf'),
+    );
+
+    const error = await provider
+      .readFile('/user@example.com/My Drive/Taxes 2025.pdf')
+      .catch((caughtError: unknown) => caughtError);
+
+    expect(error).toBeInstanceOf(VfsError);
+    expect(error).toMatchObject({
+      code: FileSystemError.Unknown,
+      message: 'Google Drive download operation failed',
+      cause: expect.objectContaining({
+        message: 'Google Drive download request failed',
+      }),
+    });
+    expect(error).not.toHaveProperty(
+      'cause.message',
+      'Download failed for gd-123 at /user@example.com/My Drive/Taxes 2025.pdf',
+    );
+  });
+
+  it('sanitizes raw upload failures during rollback while preserving the VfsError code', async () => {
+    const provider = googleDriveFileSystemProvider({
+      $sessions: new BehaviorSubject<string[]>(['user@example.com']),
+      requestToken: vi.fn().mockResolvedValue('token'),
+    });
+    const largeContent = new Blob([new Uint8Array(5 * 1024 * 1024 + 1)], {
+      type: 'application/octet-stream',
+    });
+    getGFileMetaListMock.mockResolvedValueOnce({ files: [] });
+    createMock.mockResolvedValueOnce({
+      result: {
+        id: 'created-1',
+      },
+    });
+    uploadMock.mockRejectedValueOnce(
+      new Error(
+        'Upload failed for created-1 file gd-456 /user@example.com/My Drive/Taxes 2025.pdf',
+      ),
+    );
+    updateMock.mockResolvedValueOnce({ result: {} });
+
+    const error = await provider
+      .writeFile('/user@example.com/My Drive/Taxes 2025.pdf', largeContent, {
+        create: true,
+        overwrite: true,
+      })
+      .catch((caughtError: unknown) => caughtError);
+
+    expect(error).toBeInstanceOf(VfsError);
+    expect(error).toMatchObject({
+      code: FileSystemError.Unknown,
+      message: 'Google Drive upload operation failed',
+      cause: expect.objectContaining({
+        message: 'Google Drive upload request failed',
+      }),
+    });
+    expect(error).not.toHaveProperty(
+      'cause.message',
+      'Upload failed for created-1 file gd-456 /user@example.com/My Drive/Taxes 2025.pdf',
+    );
+  });
+
   it('wraps paths without an email in a not-found stat error', async () => {
     const provider = googleDriveFileSystemProvider({
       $sessions: new BehaviorSubject<string[]>(['user@example.com']),
@@ -447,7 +558,13 @@ describe('googleDriveFileSystemProvider', () => {
         create: true,
         overwrite: true,
       }),
-    ).rejects.toThrow('upload failed');
+    ).rejects.toMatchObject({
+      code: FileSystemError.Unknown,
+      message: 'Google Drive upload operation failed',
+      cause: expect.objectContaining({
+        message: 'Google Drive upload request failed',
+      }),
+    });
 
     expect(createMock).toHaveBeenCalledWith(
       {

--- a/src/shared/lib/googleDriveFileSystemProvider/googleDriveFileSystemProvider.ts
+++ b/src/shared/lib/googleDriveFileSystemProvider/googleDriveFileSystemProvider.ts
@@ -125,7 +125,7 @@ export const googleDriveFileSystemProvider = (
     const email = getGoogleDrivePathEmail(path);
 
     if (!email) {
-      throw new Error(`Google Drive path must start with an email: ${path}`);
+      throw new Error('Google Drive path must start with an account root');
     }
 
     return email;
@@ -223,16 +223,13 @@ export const googleDriveFileSystemProvider = (
       const file = result.files?.at(0);
 
       if (!file) {
-        throw new VfsError(
-          FileSystemError.FileNotFound,
-          `Entry not found: ${partName} in path ${rawPath}`,
-        );
+        throw new VfsError(FileSystemError.FileNotFound, 'Google Drive entry not found');
       }
 
       if (!isLast && file.mimeType !== GOOGLE_MIME_FOLDER) {
         throw new VfsError(
           FileSystemError.FileNotADirectory,
-          `Path segment is not a directory: ${partName}`,
+          'A Google Drive path segment is not a directory',
         );
       }
 
@@ -241,7 +238,7 @@ export const googleDriveFileSystemProvider = (
     }
 
     if (!currentEntry) {
-      throw new VfsError(FileSystemError.FileNotFound, `Path not found: ${rawPath}`);
+      throw new VfsError(FileSystemError.FileNotFound, 'Google Drive path not found');
     }
 
     return currentEntry;
@@ -340,7 +337,7 @@ export const googleDriveFileSystemProvider = (
       };
     } catch (e) {
       if (e instanceof VfsError) throw e;
-      throw new VfsError(FileSystemError.FileNotFound, `Stat failed for ${path}`, e);
+      throw new VfsError(FileSystemError.FileNotFound, 'Google Drive stat operation failed', e);
     }
   };
 
@@ -353,7 +350,10 @@ export const googleDriveFileSystemProvider = (
     const entry = await resolvePath(path);
 
     if (entry.mimeType === GOOGLE_MIME_FOLDER) {
-      throw new VfsError(FileSystemError.FileIsADirectory, `Cannot read directory: ${path}`);
+      throw new VfsError(
+        FileSystemError.FileIsADirectory,
+        'The selected Google Drive item is a directory',
+      );
     }
 
     const token = await getTokenForPath(path);
@@ -361,7 +361,7 @@ export const googleDriveFileSystemProvider = (
     try {
       return await download({ ACCESS_TOKEN: token }, entry.id);
     } catch (e) {
-      throw new VfsError(FileSystemError.Unknown, `Failed to download file: ${path}`, e);
+      throw new VfsError(FileSystemError.Unknown, 'Google Drive download operation failed', e);
     }
   };
 
@@ -386,19 +386,13 @@ export const googleDriveFileSystemProvider = (
       parentEntry = await resolvePath(parentPath);
     } catch (e) {
       if (e instanceof VfsError && e.code === FileSystemError.FileNotFound) {
-        throw new VfsError(
-          FileSystemError.FileNotFound,
-          `Parent directory not found: ${parentPath}`,
-        );
+        throw new VfsError(FileSystemError.FileNotFound, 'Parent directory not found');
       }
       throw e;
     }
 
     if (parentEntry.mimeType !== GOOGLE_MIME_FOLDER) {
-      throw new VfsError(
-        FileSystemError.FileNotADirectory,
-        `Parent is not a directory: ${parentPath}`,
-      );
+      throw new VfsError(FileSystemError.FileNotADirectory, 'The parent item is not a directory');
     }
 
     if (parentEntry.id === SHARED_WITH_ME_ID) {
@@ -421,12 +415,12 @@ export const googleDriveFileSystemProvider = (
     if (existingEntry) {
       // Update existing file
       if (!options.overwrite) {
-        throw new VfsError(FileSystemError.FileExists, `File exists: ${path}`);
+        throw new VfsError(FileSystemError.FileExists, 'File already exists');
       }
       if (existingEntry.mimeType === GOOGLE_MIME_FOLDER) {
         throw new VfsError(
           FileSystemError.FileIsADirectory,
-          `Cannot overwrite directory with file: ${path}`,
+          'Cannot overwrite a directory with a file',
         );
       }
 
@@ -446,7 +440,7 @@ export const googleDriveFileSystemProvider = (
       };
     } else {
       if (!options.create) {
-        throw new VfsError(FileSystemError.FileNotFound, `File not found: ${path}`);
+        throw new VfsError(FileSystemError.FileNotFound, 'File not found');
       }
 
       const auth = { ACCESS_TOKEN: await getTokenForPath(path) };
@@ -549,7 +543,7 @@ export const googleDriveFileSystemProvider = (
     const entry = await resolvePath(rawPath);
 
     if (entry.mimeType !== GOOGLE_MIME_FOLDER) {
-      throw new VfsError(FileSystemError.FileNotADirectory, `Not a directory: ${rawPath}`);
+      throw new VfsError(FileSystemError.FileNotADirectory, 'The selected item is not a directory');
     }
 
     const { space } = resolvePathSpace(rawPath);
@@ -603,7 +597,7 @@ export const googleDriveFileSystemProvider = (
   const createDirectory = async (path: string): Promise<void> => {
     try {
       await resolvePath(path);
-      throw new VfsError(FileSystemError.FileExists, `Directory already exists: ${path}`);
+      throw new VfsError(FileSystemError.FileExists, 'Directory already exists');
     } catch (e) {
       if (e instanceof VfsError && e.code === FileSystemError.FileExists) throw e;
       if (!(e instanceof VfsError && e.code === FileSystemError.FileNotFound)) throw e;
@@ -623,10 +617,7 @@ export const googleDriveFileSystemProvider = (
     }
 
     if (parentEntry.mimeType !== GOOGLE_MIME_FOLDER) {
-      throw new VfsError(
-        FileSystemError.FileNotADirectory,
-        `Parent is not a directory: ${parentPath}`,
-      );
+      throw new VfsError(FileSystemError.FileNotADirectory, 'The parent item is not a directory');
     }
 
     await create(
@@ -656,7 +647,7 @@ export const googleDriveFileSystemProvider = (
     if (getEntryCapabilities(entry)?.canDelete !== true) {
       throw new VfsError(
         FileSystemError.NoPermissions,
-        `Deletion is not allowed for path: ${path}`,
+        'File system delete operation is not allowed',
       );
     }
 
@@ -714,13 +705,13 @@ export const googleDriveFileSystemProvider = (
     if (getEntryCapabilities(sourceEntry)?.canChangePath !== true) {
       throw new VfsError(
         FileSystemError.NoPermissions,
-        `Path change is not allowed for path: ${oldPath}`,
+        'The selected item does not support moving',
       );
     }
 
     try {
       await resolvePath(normalizedNew);
-      throw new VfsError(FileSystemError.FileExists, `Destination exists: ${newPath}`);
+      throw new VfsError(FileSystemError.FileExists, 'Destination already exists');
     } catch (e) {
       if (e instanceof VfsError && e.code !== FileSystemError.FileNotFound) throw e;
     }
@@ -740,13 +731,13 @@ export const googleDriveFileSystemProvider = (
     if (destinationParentEntry.mimeType !== GOOGLE_MIME_FOLDER) {
       throw new VfsError(
         FileSystemError.FileNotADirectory,
-        `Destination parent is not a directory: ${newDirName}`,
+        'The destination parent is not a directory',
       );
     }
     if (getEntryCapabilities(destinationParentEntry)?.canEditChildren !== true) {
       throw new VfsError(
         FileSystemError.NoPermissions,
-        `Path change is not allowed inside directory: ${newDirName}`,
+        'The destination directory is not writable',
       );
     }
 

--- a/src/shared/lib/googleDriveFileSystemProvider/googleDriveFileSystemProvider.ts
+++ b/src/shared/lib/googleDriveFileSystemProvider/googleDriveFileSystemProvider.ts
@@ -28,7 +28,7 @@ import {
 import type { GOOGLE_SCOPE } from '@shared/lib/googleApi';
 import { DRIVE_GOOGLE_SCOPE } from '@shared/lib/googleApi';
 import { firstValueFrom, skip, type Observable } from 'rxjs';
-import { createSafeErrorCause, DomainError } from '@shared/lib/error';
+import { createSafeErrorCause } from '@shared/lib/error';
 import { GoogleDriveError } from '@shared/lib/googleDrive/error';
 import {
   getGoogleDrivePathEmail,
@@ -124,11 +124,11 @@ export const googleDriveFileSystemProvider = (
 ) => {
   const { requestToken, $sessions } = providerOptions;
   const toSafeGoogleDriveCause = (error: unknown, safeMessage: string) => {
-    if (
-      error instanceof VfsError ||
-      error instanceof GoogleDriveError ||
-      error instanceof DomainError
-    ) {
+    if (error instanceof GoogleDriveError) {
+      return error;
+    }
+
+    if (error instanceof VfsError && error.cause === undefined) {
       return error;
     }
 
@@ -349,11 +349,16 @@ export const googleDriveFileSystemProvider = (
         capabilities: getEntryCapabilities(entry),
       };
     } catch (e) {
-      if (e instanceof VfsError) throw e;
+      const safeCause = toSafeGoogleDriveCause(e, 'Google Drive stat request failed');
+
+      if (safeCause instanceof VfsError && safeCause.code !== FileSystemError.Unknown) {
+        throw safeCause;
+      }
+
       throw new VfsError(
         FileSystemError.FileNotFound,
         'Google Drive stat operation failed',
-        toSafeGoogleDriveCause(e, 'Google Drive stat request failed'),
+        safeCause,
       );
     }
   };

--- a/src/shared/lib/googleDriveFileSystemProvider/googleDriveFileSystemProvider.ts
+++ b/src/shared/lib/googleDriveFileSystemProvider/googleDriveFileSystemProvider.ts
@@ -28,6 +28,8 @@ import {
 import type { GOOGLE_SCOPE } from '@shared/lib/googleApi';
 import { DRIVE_GOOGLE_SCOPE } from '@shared/lib/googleApi';
 import { firstValueFrom, skip, type Observable } from 'rxjs';
+import { createSafeErrorCause, DomainError } from '@shared/lib/error';
+import { GoogleDriveError } from '@shared/lib/googleDrive/error';
 import {
   getGoogleDrivePathEmail,
   getGoogleDrivePathSpace,
@@ -121,6 +123,17 @@ export const googleDriveFileSystemProvider = (
   providerOptions: GoogleDriveFileSystemProviderOptions,
 ) => {
   const { requestToken, $sessions } = providerOptions;
+  const toSafeGoogleDriveCause = (error: unknown, safeMessage: string) => {
+    if (
+      error instanceof VfsError ||
+      error instanceof GoogleDriveError ||
+      error instanceof DomainError
+    ) {
+      return error;
+    }
+
+    return createSafeErrorCause(safeMessage);
+  };
   const extractEmailFromPath = (path: string): string => {
     const email = getGoogleDrivePathEmail(path);
 
@@ -337,7 +350,11 @@ export const googleDriveFileSystemProvider = (
       };
     } catch (e) {
       if (e instanceof VfsError) throw e;
-      throw new VfsError(FileSystemError.FileNotFound, 'Google Drive stat operation failed', e);
+      throw new VfsError(
+        FileSystemError.FileNotFound,
+        'Google Drive stat operation failed',
+        toSafeGoogleDriveCause(e, 'Google Drive stat request failed'),
+      );
     }
   };
 
@@ -361,7 +378,11 @@ export const googleDriveFileSystemProvider = (
     try {
       return await download({ ACCESS_TOKEN: token }, entry.id);
     } catch (e) {
-      throw new VfsError(FileSystemError.Unknown, 'Google Drive download operation failed', e);
+      throw new VfsError(
+        FileSystemError.Unknown,
+        'Google Drive download operation failed',
+        toSafeGoogleDriveCause(e, 'Google Drive download request failed'),
+      );
     }
   };
 
@@ -426,7 +447,15 @@ export const googleDriveFileSystemProvider = (
 
       const token = await getTokenForPath(path);
 
-      await upload({ ACCESS_TOKEN: token }, existingEntry.id, content);
+      try {
+        await upload({ ACCESS_TOKEN: token }, existingEntry.id, content);
+      } catch (e) {
+        throw new VfsError(
+          FileSystemError.Unknown,
+          'Google Drive upload operation failed',
+          toSafeGoogleDriveCause(e, 'Google Drive upload request failed'),
+        );
+      }
 
       return {
         stat: {
@@ -451,7 +480,16 @@ export const googleDriveFileSystemProvider = (
       } satisfies Parameters<typeof create>[1];
 
       if (contentSize <= GOOGLE_DRIVE_MULTIPART_UPLOAD_LIMIT) {
-        const created = await createWithContent(auth, resource, content);
+        let created;
+        try {
+          created = await createWithContent(auth, resource, content);
+        } catch (e) {
+          throw new VfsError(
+            FileSystemError.Unknown,
+            'Google Drive file create operation failed',
+            toSafeGoogleDriveCause(e, 'Google Drive create request failed'),
+          );
+        }
 
         return {
           stat: {
@@ -465,15 +503,37 @@ export const googleDriveFileSystemProvider = (
         };
       }
 
-      const created = await create(auth, resource);
+      let created;
+      try {
+        created = await create(auth, resource);
+      } catch (e) {
+        throw new VfsError(
+          FileSystemError.Unknown,
+          'Google Drive file create operation failed',
+          toSafeGoogleDriveCause(e, 'Google Drive create request failed'),
+        );
+      }
 
       try {
         await upload(auth, created.result.id, content);
       } catch (uploadError) {
-        await update(auth, created.result.id, {
-          trashed: true,
-        });
-        throw uploadError;
+        try {
+          await update(auth, created.result.id, {
+            trashed: true,
+          });
+        } catch {
+          throw new VfsError(
+            FileSystemError.Unknown,
+            'Google Drive upload rollback operation failed',
+            createSafeErrorCause('Google Drive upload rollback request failed'),
+          );
+        }
+
+        throw new VfsError(
+          FileSystemError.Unknown,
+          'Google Drive upload operation failed',
+          toSafeGoogleDriveCause(uploadError, 'Google Drive upload request failed'),
+        );
       }
 
       return {
@@ -620,16 +680,24 @@ export const googleDriveFileSystemProvider = (
       throw new VfsError(FileSystemError.FileNotADirectory, 'The parent item is not a directory');
     }
 
-    await create(
-      {
-        ACCESS_TOKEN: await getTokenForPath(path),
-      },
-      {
-        name: dirName,
-        parents: [parentEntry.id],
-        mimeType: GOOGLE_MIME_FOLDER,
-      },
-    );
+    try {
+      await create(
+        {
+          ACCESS_TOKEN: await getTokenForPath(path),
+        },
+        {
+          name: dirName,
+          parents: [parentEntry.id],
+          mimeType: GOOGLE_MIME_FOLDER,
+        },
+      );
+    } catch (e) {
+      throw new VfsError(
+        FileSystemError.Unknown,
+        'Google Drive directory create operation failed',
+        toSafeGoogleDriveCause(e, 'Google Drive create request failed'),
+      );
+    }
   };
 
   /**
@@ -678,15 +746,23 @@ export const googleDriveFileSystemProvider = (
       }
     }
 
-    await update(
-      {
-        ACCESS_TOKEN: await getTokenForPath(path),
-      },
-      entry.id,
-      {
-        trashed: true,
-      },
-    );
+    try {
+      await update(
+        {
+          ACCESS_TOKEN: await getTokenForPath(path),
+        },
+        entry.id,
+        {
+          trashed: true,
+        },
+      );
+    } catch (e) {
+      throw new VfsError(
+        FileSystemError.Unknown,
+        'Google Drive delete operation failed',
+        toSafeGoogleDriveCause(e, 'Google Drive update request failed'),
+      );
+    }
   };
 
   /**
@@ -744,18 +820,28 @@ export const googleDriveFileSystemProvider = (
     const currentParents = sourceEntry.parents ?? [];
     const removeParents = currentParents.filter((p) => p !== destinationParentEntry.id);
 
-    await update(
-      {
-        ACCESS_TOKEN: await getTokenForPath(oldPath),
-      },
-      sourceEntry.id,
-      {
-        name: newFileName,
-        addParents:
-          removeParents.length === currentParents.length ? [destinationParentEntry.id] : undefined,
-        removeParents: removeParents.length > 0 ? removeParents : undefined,
-      },
-    );
+    try {
+      await update(
+        {
+          ACCESS_TOKEN: await getTokenForPath(oldPath),
+        },
+        sourceEntry.id,
+        {
+          name: newFileName,
+          addParents:
+            removeParents.length === currentParents.length
+              ? [destinationParentEntry.id]
+              : undefined,
+          removeParents: removeParents.length > 0 ? removeParents : undefined,
+        },
+      );
+    } catch (e) {
+      throw new VfsError(
+        FileSystemError.Unknown,
+        'Google Drive move operation failed',
+        toSafeGoogleDriveCause(e, 'Google Drive update request failed'),
+      );
+    }
   };
 
   return {

--- a/src/shared/lib/reportHandledError.test.ts
+++ b/src/shared/lib/reportHandledError.test.ts
@@ -216,6 +216,26 @@ describe('reportHandledError', () => {
     );
   });
 
+  it('accepts only feature and action metadata, without path options', async () => {
+    ensureSentryMock.mockResolvedValue(realFacade);
+
+    const { reportHandledError } = await import('./reportHandledError');
+
+    reportHandledError(new Error('boom'), {
+      feature: 'documents',
+      action: 'save',
+    });
+
+    await vi.waitFor(() => {
+      expect(realFacade.captureException).toHaveBeenCalledWith(expect.any(Error));
+    });
+    expect(mockScope.setTag).toHaveBeenCalledWith('feature', 'documents');
+    expect(mockScope.setTag).toHaveBeenCalledWith('action', 'save');
+    expect(mockScope.setExtras).not.toHaveBeenCalledWith(
+      expect.objectContaining({ path: expect.anything() }),
+    );
+  });
+
   it('queues handled reports until lazy Sentry initialization completes', async () => {
     const gate = createDeferred<MockSentryFacade>();
     ensureSentryMock.mockReturnValue(gate.promise);

--- a/src/shared/lib/reportHandledError.test.ts
+++ b/src/shared/lib/reportHandledError.test.ts
@@ -134,7 +134,6 @@ describe('reportHandledError', () => {
       {
         feature: 'documents',
         action: 'save',
-        path: '/docs/a',
       },
     );
 
@@ -147,7 +146,6 @@ describe('reportHandledError', () => {
     });
 
     expect(mockScope.setExtras).toHaveBeenCalledWith({
-      path: '/docs/a',
       userMessage: 'Could not save',
       domainErrorCode: 'document-export-failed',
     });
@@ -170,7 +168,7 @@ describe('reportHandledError', () => {
     expect(mockScope.setExtras).not.toHaveBeenCalled();
   });
 
-  it('wraps a non-Error and preserves the original thrown value', async () => {
+  it('wraps a non-Error without preserving the original thrown value', async () => {
     ensureSentryMock.mockResolvedValue(realFacade);
 
     const { reportHandledError } = await import('./reportHandledError');
@@ -187,8 +185,35 @@ describe('reportHandledError', () => {
       message: 'Handled non-error exception',
     });
     expect(mockScope.setExtras).toHaveBeenCalledWith({
-      originalError: 'boom',
+      originalThrownType: 'string',
     });
+  });
+
+  it('does not send a user path in handled error extras', async () => {
+    ensureSentryMock.mockResolvedValue(realFacade);
+
+    const { DomainError } = await import('@shared/lib/error');
+    const { reportHandledError } = await import('./reportHandledError');
+
+    reportHandledError(
+      new DomainError('Could not save', {
+        cause: new Error('Could not save the document'),
+      }),
+      {
+        feature: 'documents',
+        action: 'save',
+      },
+    );
+
+    await vi.waitFor(() => {
+      expect(realFacade.captureException).toHaveBeenCalled();
+    });
+    expect(mockScope.setExtras).toHaveBeenCalledWith({
+      userMessage: 'Could not save',
+    });
+    expect(mockScope.setExtras).not.toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/docs/a' }),
+    );
   });
 
   it('queues handled reports until lazy Sentry initialization completes', async () => {

--- a/src/shared/lib/reportHandledError.ts
+++ b/src/shared/lib/reportHandledError.ts
@@ -4,7 +4,6 @@ import { ensureSentry, getSentryReportingState, isSentryConfigured } from './set
 type ReportHandledErrorOptions = {
   feature: string;
   action: string;
-  path?: string | undefined;
 };
 
 const HANDLED_NON_ERROR_MESSAGE = 'Handled non-error exception';
@@ -129,11 +128,8 @@ export const reportHandledError = (error: unknown, options: ReportHandledErrorOp
     reportedError = error;
   } else {
     reportedError = new Error(HANDLED_NON_ERROR_MESSAGE);
-    extras.originalError = error;
-  }
-
-  if (options.path !== undefined) {
-    extras.path = options.path;
+    extras.originalThrownType =
+      error === null ? 'null' : Array.isArray(error) ? 'array' : typeof error;
   }
 
   try {

--- a/src/shared/lib/setupSentry.test.ts
+++ b/src/shared/lib/setupSentry.test.ts
@@ -394,11 +394,45 @@ describe('setupSentry', () => {
 
     const initOptions = initMock.mock.calls[0]?.[0];
     const beforeSend = initOptions?.beforeSend;
-    const event = { message: 'test-event' };
+    const event = {
+      breadcrumbs: [{ message: 'user breadcrumb' }],
+      extra: {
+        domainErrorCode: 'document-export-failed',
+        originalThrownType: 'string',
+        path: '/docs/private',
+        userMessage: 'Could not export the document',
+      },
+      message: 'test-event',
+      request: {
+        url: 'https://app.example/doc/secret-id',
+      },
+      tags: {
+        action: 'exportDocumentJson',
+        feature: 'documentExport',
+        handled: 'true',
+        path: '/docs/private',
+      },
+      user: {
+        id: 'user-1',
+      },
+    };
 
     expect(beforeSend).toEqual(expect.any(Function));
     if (beforeSend instanceof Function) {
-      expect(beforeSend(event)).toBe(event);
+      expect(beforeSend(event)).toEqual({
+        extra: {
+          domainErrorCode: 'document-export-failed',
+          originalThrownType: 'string',
+          userMessage: 'Could not export the document',
+        },
+        message: 'test-event',
+        request: {},
+        tags: {
+          action: 'exportDocumentJson',
+          feature: 'documentExport',
+          handled: 'true',
+        },
+      });
     }
   });
 
@@ -413,11 +447,19 @@ describe('setupSentry', () => {
 
     const initOptions = initMock.mock.calls[0]?.[0];
     const beforeSend = initOptions?.beforeSend;
-    const event = { message: 'setup-event' };
+    const event = {
+      extra: { userMessage: 'Could not save', path: '/docs/private' },
+      message: 'setup-event',
+    };
 
     expect(beforeSend).toEqual(expect.any(Function));
     if (beforeSend instanceof Function) {
-      expect(beforeSend(event)).toBe(event);
+      expect(beforeSend(event)).toEqual({
+        extra: {
+          userMessage: 'Could not save',
+        },
+        message: 'setup-event',
+      });
     }
   });
 

--- a/src/shared/lib/setupSentry.test.ts
+++ b/src/shared/lib/setupSentry.test.ts
@@ -426,13 +426,232 @@ describe('setupSentry', () => {
           userMessage: 'Could not export the document',
         },
         message: 'test-event',
-        request: {},
         tags: {
           action: 'exportDocumentJson',
           feature: 'documentExport',
           handled: 'true',
         },
       });
+    }
+  });
+
+  it('beforeSend drops unsafe-only extra payloads', async () => {
+    const { initMock } = setupSentryMocks();
+    const { registerSentryConfig, ensureSentry, setSentryReportingEnabled } =
+      await import('./setupSentry');
+
+    registerSentryConfig({
+      dsn: 'https://example@sentry.io/123',
+      enabled: true,
+    });
+    setSentryReportingEnabled(true);
+
+    await ensureSentry();
+
+    const initOptions = initMock.mock.calls[0]?.[0];
+    const beforeSend = initOptions?.beforeSend;
+    const event = {
+      extra: {
+        documentId: 'secret',
+        path: '/private',
+      },
+      message: 'test-event',
+    };
+
+    expect(beforeSend).toEqual(expect.any(Function));
+    if (beforeSend instanceof Function) {
+      expect(beforeSend(event)).toEqual({
+        message: 'test-event',
+      });
+    }
+  });
+
+  it('beforeSend keeps only allowlisted extra keys from mixed payloads', async () => {
+    const { initMock } = setupSentryMocks();
+    const { registerSentryConfig, ensureSentry, setSentryReportingEnabled } =
+      await import('./setupSentry');
+
+    registerSentryConfig({
+      dsn: 'https://example@sentry.io/123',
+      enabled: true,
+    });
+    setSentryReportingEnabled(true);
+
+    await ensureSentry();
+
+    const initOptions = initMock.mock.calls[0]?.[0];
+    const beforeSend = initOptions?.beforeSend;
+    const event = {
+      extra: {
+        domainErrorCode: 'document-export-failed',
+        originalThrownType: 'string',
+        path: '/private',
+        userMessage: 'Could not export the document',
+      },
+      message: 'test-event',
+    };
+
+    expect(beforeSend).toEqual(expect.any(Function));
+    if (beforeSend instanceof Function) {
+      expect(beforeSend(event)).toEqual({
+        extra: {
+          domainErrorCode: 'document-export-failed',
+          originalThrownType: 'string',
+          userMessage: 'Could not export the document',
+        },
+        message: 'test-event',
+      });
+    }
+  });
+
+  it('beforeSend drops unsafe-only tags', async () => {
+    const { initMock } = setupSentryMocks();
+    const { registerSentryConfig, ensureSentry, setSentryReportingEnabled } =
+      await import('./setupSentry');
+
+    registerSentryConfig({
+      dsn: 'https://example@sentry.io/123',
+      enabled: true,
+    });
+    setSentryReportingEnabled(true);
+
+    await ensureSentry();
+
+    const initOptions = initMock.mock.calls[0]?.[0];
+    const beforeSend = initOptions?.beforeSend;
+    const event = {
+      message: 'test-event',
+      tags: {
+        path: '/private',
+      },
+    };
+
+    expect(beforeSend).toEqual(expect.any(Function));
+    if (beforeSend instanceof Function) {
+      expect(beforeSend(event)).toEqual({
+        message: 'test-event',
+      });
+    }
+  });
+
+  it('beforeSend keeps only allowlisted tags from mixed payloads', async () => {
+    const { initMock } = setupSentryMocks();
+    const { registerSentryConfig, ensureSentry, setSentryReportingEnabled } =
+      await import('./setupSentry');
+
+    registerSentryConfig({
+      dsn: 'https://example@sentry.io/123',
+      enabled: true,
+    });
+    setSentryReportingEnabled(true);
+
+    await ensureSentry();
+
+    const initOptions = initMock.mock.calls[0]?.[0];
+    const beforeSend = initOptions?.beforeSend;
+    const event = {
+      message: 'test-event',
+      tags: {
+        action: 'exportDocumentJson',
+        feature: 'documentExport',
+        handled: 'true',
+        path: '/private',
+      },
+    };
+
+    expect(beforeSend).toEqual(expect.any(Function));
+    if (beforeSend instanceof Function) {
+      expect(beforeSend(event)).toEqual({
+        message: 'test-event',
+        tags: {
+          action: 'exportDocumentJson',
+          feature: 'documentExport',
+          handled: 'true',
+        },
+      });
+    }
+  });
+
+  it('beforeSend removes request, contexts, breadcrumbs, and user entirely', async () => {
+    const { initMock } = setupSentryMocks();
+    const { registerSentryConfig, ensureSentry, setSentryReportingEnabled } =
+      await import('./setupSentry');
+
+    registerSentryConfig({
+      dsn: 'https://example@sentry.io/123',
+      enabled: true,
+    });
+    setSentryReportingEnabled(true);
+
+    await ensureSentry();
+
+    const initOptions = initMock.mock.calls[0]?.[0];
+    const beforeSend = initOptions?.beforeSend;
+    const event = {
+      breadcrumbs: [{ message: 'user breadcrumb' }],
+      contexts: {
+        browser: {
+          name: 'Chrome',
+        },
+      },
+      message: 'test-event',
+      request: {
+        method: 'POST',
+        url: 'https://app.example/doc/secret-id',
+      },
+      user: {
+        id: 'user-1',
+      },
+    };
+
+    expect(beforeSend).toEqual(expect.any(Function));
+    if (beforeSend instanceof Function) {
+      expect(beforeSend(event)).toEqual({
+        message: 'test-event',
+      });
+    }
+  });
+
+  it('beforeSend preserves core error event fields', async () => {
+    const { initMock } = setupSentryMocks();
+    const { registerSentryConfig, ensureSentry, setSentryReportingEnabled } =
+      await import('./setupSentry');
+
+    registerSentryConfig({
+      dsn: 'https://example@sentry.io/123',
+      enabled: true,
+    });
+    setSentryReportingEnabled(true);
+
+    await ensureSentry();
+
+    const initOptions = initMock.mock.calls[0]?.[0];
+    const beforeSend = initOptions?.beforeSend;
+    const event = {
+      environment: 'production',
+      exception: {
+        values: [
+          {
+            stacktrace: {
+              frames: [
+                {
+                  filename: 'src/shared/lib/reportHandledError.ts',
+                  function: 'reportHandledError',
+                },
+              ],
+            },
+            type: 'Error',
+            value: 'boom',
+          },
+        ],
+      },
+      message: 'test-event',
+      release: '1.2.3',
+    };
+
+    expect(beforeSend).toEqual(expect.any(Function));
+    if (beforeSend instanceof Function) {
+      expect(beforeSend(event)).toEqual(event);
     }
   });
 

--- a/src/shared/lib/setupSentry.ts
+++ b/src/shared/lib/setupSentry.ts
@@ -37,7 +37,7 @@ const pickEventTags = (source: Record<string, unknown> | undefined, keys: readon
   for (const key of keys) {
     const value = source[key];
 
-    if (isSentryTagValue(value)) {
+    if (value !== undefined && isSentryTagValue(value)) {
       result[key] = value;
     }
   }
@@ -308,24 +308,19 @@ export const ensureSentry = async (app?: App): Promise<SentryFacade> => {
 
         const {
           breadcrumbs: _breadcrumbs,
-          request: originalRequest,
+          contexts: _contexts,
+          extra,
+          request: _request,
+          tags,
           user: _user,
-          ...restEvent
+          ...safeEvent
         } = event;
-        const safeTags = pickEventTags(getSafeRecord(event.tags), SAFE_EVENT_TAG_KEYS);
-        const safeExtra = pickEventFields(getSafeRecord(event.extra), SAFE_EVENT_EXTRA_KEYS);
-        const safeRequest = getSafeRecord(originalRequest);
+        const safeTags = pickEventTags(getSafeRecord(tags), SAFE_EVENT_TAG_KEYS);
+        const safeExtra = pickEventFields(getSafeRecord(extra), SAFE_EVENT_EXTRA_KEYS);
 
         return {
-          ...restEvent,
+          ...safeEvent,
           ...(Object.keys(safeExtra).length > 0 ? { extra: safeExtra } : {}),
-          ...(safeRequest
-            ? {
-                request: Object.fromEntries(
-                  Object.entries(safeRequest).filter(([key]) => key !== 'url'),
-                ),
-              }
-            : {}),
           ...(Object.keys(safeTags).length > 0 ? { tags: safeTags } : {}),
         };
       },

--- a/src/shared/lib/setupSentry.ts
+++ b/src/shared/lib/setupSentry.ts
@@ -1,5 +1,58 @@
 import type { App, Plugin } from 'vue';
 
+const SAFE_EVENT_EXTRA_KEYS = ['userMessage', 'domainErrorCode', 'originalThrownType'] as const;
+const SAFE_EVENT_TAG_KEYS = ['handled', 'feature', 'action'] as const;
+type SentryTagValue = boolean | number | string | null | undefined;
+
+const pickEventFields = (source: Record<string, unknown> | undefined, keys: readonly string[]) => {
+  const result: Record<string, unknown> = {};
+
+  if (!source) {
+    return result;
+  }
+
+  for (const key of keys) {
+    if (key in source) {
+      result[key] = source[key];
+    }
+  }
+
+  return result;
+};
+
+const isSentryTagValue = (value: unknown): value is SentryTagValue =>
+  value === null ||
+  value === undefined ||
+  typeof value === 'boolean' ||
+  typeof value === 'number' ||
+  typeof value === 'string';
+
+const pickEventTags = (source: Record<string, unknown> | undefined, keys: readonly string[]) => {
+  const result: Record<string, SentryTagValue> = {};
+
+  if (!source) {
+    return result;
+  }
+
+  for (const key of keys) {
+    const value = source[key];
+
+    if (isSentryTagValue(value)) {
+      result[key] = value;
+    }
+  }
+
+  return result;
+};
+
+const getSafeRecord = (value: unknown) => {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  return Object.fromEntries(Object.entries(value));
+};
+
 /**
  * Runtime configuration for the optional Sentry integration.
  */
@@ -253,7 +306,28 @@ export const ensureSentry = async (app?: App): Promise<SentryFacade> => {
           return null;
         }
 
-        return event;
+        const {
+          breadcrumbs: _breadcrumbs,
+          request: originalRequest,
+          user: _user,
+          ...restEvent
+        } = event;
+        const safeTags = pickEventTags(getSafeRecord(event.tags), SAFE_EVENT_TAG_KEYS);
+        const safeExtra = pickEventFields(getSafeRecord(event.extra), SAFE_EVENT_EXTRA_KEYS);
+        const safeRequest = getSafeRecord(originalRequest);
+
+        return {
+          ...restEvent,
+          ...(Object.keys(safeExtra).length > 0 ? { extra: safeExtra } : {}),
+          ...(safeRequest
+            ? {
+                request: Object.fromEntries(
+                  Object.entries(safeRequest).filter(([key]) => key !== 'url'),
+                ),
+              }
+            : {}),
+          ...(Object.keys(safeTags).length > 0 ? { tags: safeTags } : {}),
+        };
       },
     });
 

--- a/src/shared/lib/setupSentry.ts
+++ b/src/shared/lib/setupSentry.ts
@@ -45,14 +45,6 @@ const pickEventTags = (source: Record<string, unknown> | undefined, keys: readon
   return result;
 };
 
-const getSafeRecord = (value: unknown) => {
-  if (!value || typeof value !== 'object') {
-    return undefined;
-  }
-
-  return Object.fromEntries(Object.entries(value));
-};
-
 /**
  * Runtime configuration for the optional Sentry integration.
  */
@@ -315,8 +307,8 @@ export const ensureSentry = async (app?: App): Promise<SentryFacade> => {
           user: _user,
           ...safeEvent
         } = event;
-        const safeTags = pickEventTags(getSafeRecord(tags), SAFE_EVENT_TAG_KEYS);
-        const safeExtra = pickEventFields(getSafeRecord(extra), SAFE_EVENT_EXTRA_KEYS);
+        const safeTags = pickEventTags(tags, SAFE_EVENT_TAG_KEYS);
+        const safeExtra = pickEventFields(extra, SAFE_EVENT_EXTRA_KEYS);
 
         return {
           ...safeEvent,

--- a/src/shared/lib/virtualFileSystem/MemoryFileSystem.ts
+++ b/src/shared/lib/virtualFileSystem/MemoryFileSystem.ts
@@ -68,7 +68,7 @@ export class MemoryFileSystem implements IFileSystemProvider {
   private getEntry(path: string): AnyEntry {
     const entry = this.store.get(path);
     if (!entry) {
-      throw new VfsError(FileSystemError.FileNotFound, `File not found: ${path}`);
+      throw new VfsError(FileSystemError.FileNotFound, 'File system entry not found');
     }
     return entry;
   }
@@ -121,7 +121,7 @@ export class MemoryFileSystem implements IFileSystemProvider {
     const entry = this.getEntry(normalized);
 
     if (entry.type !== FSNodeType.Directory) {
-      throw new VfsError(FileSystemError.FileNotADirectory, `${path} is not a directory`);
+      throw new VfsError(FileSystemError.FileNotADirectory, 'The selected item is not a directory');
     }
 
     const children: [string, FSNodeStat][] = [];
@@ -149,17 +149,14 @@ export class MemoryFileSystem implements IFileSystemProvider {
   public async createDirectory(path: string): Promise<void> {
     const normalized = PathUtils.normalize(path);
     if (this.store.has(normalized)) {
-      throw new VfsError(FileSystemError.FileExists, `Directory already exists: ${path}`);
+      throw new VfsError(FileSystemError.FileExists, 'Directory already exists');
     }
 
     const parentPath = PathUtils.dirname(normalized);
     const parentEntry = this.getEntry(parentPath);
 
     if (parentEntry.type !== FSNodeType.Directory) {
-      throw new VfsError(
-        FileSystemError.FileNotADirectory,
-        `Parent path ${parentPath} is not a directory`,
-      );
+      throw new VfsError(FileSystemError.FileNotADirectory, 'The parent item is not a directory');
     }
 
     this.store.set(normalized, {
@@ -184,7 +181,7 @@ export class MemoryFileSystem implements IFileSystemProvider {
     const entry = this.getEntry(normalized);
 
     if (entry.type !== FSNodeType.File) {
-      throw new VfsError(FileSystemError.FileIsADirectory, `${path} is a directory`);
+      throw new VfsError(FileSystemError.FileIsADirectory, 'The selected item is a directory');
     }
 
     return Promise.resolve(entry.content);
@@ -213,7 +210,7 @@ export class MemoryFileSystem implements IFileSystemProvider {
     // Проверка родительской директории
     if (!parentEntry || parentEntry.type !== FSNodeType.Directory) {
       return Promise.reject(
-        new VfsError(FileSystemError.FileNotFound, `Parent directory not found: ${parentPath}`),
+        new VfsError(FileSystemError.FileNotFound, 'Parent directory not found'),
       );
     }
 
@@ -224,16 +221,11 @@ export class MemoryFileSystem implements IFileSystemProvider {
     if (entry) {
       if (entry.type !== FSNodeType.File) {
         return Promise.reject(
-          new VfsError(FileSystemError.FileIsADirectory, `${path} is a directory`),
+          new VfsError(FileSystemError.FileIsADirectory, 'The selected item is a directory'),
         );
       }
       if (!options.overwrite) {
-        return Promise.reject(
-          new VfsError(
-            FileSystemError.FileExists,
-            `File already exists and overwrite is false: ${path}`,
-          ),
-        );
+        return Promise.reject(new VfsError(FileSystemError.FileExists, 'File already exists'));
       }
 
       entry.content = file;
@@ -241,12 +233,7 @@ export class MemoryFileSystem implements IFileSystemProvider {
       entry.modificationTime = now;
     } else {
       if (!options.create) {
-        return Promise.reject(
-          new VfsError(
-            FileSystemError.FileNotFound,
-            `File does not exist and create is false: ${path}`,
-          ),
-        );
+        return Promise.reject(new VfsError(FileSystemError.FileNotFound, 'File not found'));
       }
       this.store.set(normalized, {
         type: FSNodeType.File,
@@ -277,7 +264,7 @@ export class MemoryFileSystem implements IFileSystemProvider {
     if (entry.capabilities?.canDelete !== true) {
       throw new VfsError(
         FileSystemError.NoPermissions,
-        `Deletion is not allowed for path: ${path}`,
+        'File system delete operation is not allowed',
       );
     }
 
@@ -293,7 +280,7 @@ export class MemoryFileSystem implements IFileSystemProvider {
       }
 
       if (hasChildren && !recursive) {
-        return Promise.reject(new Error(`Directory not empty: ${path}`));
+        return Promise.reject(new Error('Directory not empty'));
       }
 
       if (hasChildren && recursive) {
@@ -303,7 +290,7 @@ export class MemoryFileSystem implements IFileSystemProvider {
             if (storedEntry.capabilities?.canDelete !== true) {
               throw new VfsError(
                 FileSystemError.NoPermissions,
-                `Deletion is not allowed for path: ${storedPath}`,
+                'File system delete operation is not allowed',
               );
             }
 
@@ -336,7 +323,7 @@ export class MemoryFileSystem implements IFileSystemProvider {
       return Promise.reject(
         new VfsError(
           FileSystemError.NotSupported,
-          `Cannot move directory into itself: ${oldPath} -> ${newPath}`,
+          'Cannot move a directory into itself or one of its subdirectories',
         ),
       );
     }
@@ -344,25 +331,20 @@ export class MemoryFileSystem implements IFileSystemProvider {
     const entry = this.getEntry(normalizedOld);
 
     if (this.store.has(normalizedNew)) {
-      return Promise.reject(
-        new VfsError(FileSystemError.FileExists, `Target already exists: ${newPath}`),
-      );
+      return Promise.reject(new VfsError(FileSystemError.FileExists, 'Target already exists'));
     }
 
     const newParentPath = PathUtils.dirname(normalizedNew);
     const newParentEntry = this.store.get(newParentPath);
     if (!newParentEntry || newParentEntry.type !== FSNodeType.Directory) {
       return Promise.reject(
-        new VfsError(
-          FileSystemError.FileNotFound,
-          `Target parent directory not found: ${newParentPath}`,
-        ),
+        new VfsError(FileSystemError.FileNotFound, 'Target parent directory not found'),
       );
     }
     if (newParentEntry.capabilities?.canEditChildren !== true) {
       throw new VfsError(
         FileSystemError.NoPermissions,
-        `Path change is not allowed inside directory: ${newParentPath}`,
+        'The destination directory is not writable',
       );
     }
 
@@ -387,7 +369,7 @@ export class MemoryFileSystem implements IFileSystemProvider {
         if (childEntry.capabilities?.canChangePath !== true) {
           throw new VfsError(
             FileSystemError.NoPermissions,
-            `Path change is not allowed for path: ${oldKey}`,
+            'The selected item does not support moving',
           );
         }
 
@@ -402,7 +384,7 @@ export class MemoryFileSystem implements IFileSystemProvider {
       if (entry.capabilities?.canChangePath !== true) {
         throw new VfsError(
           FileSystemError.NoPermissions,
-          `Path change is not allowed for path: ${normalizedOld}`,
+          'The selected item does not support moving',
         );
       }
       this.store.delete(normalizedOld);
@@ -415,7 +397,7 @@ export class MemoryFileSystem implements IFileSystemProvider {
       if (entry.capabilities?.canChangePath !== true) {
         throw new VfsError(
           FileSystemError.NoPermissions,
-          `Path change is not allowed for path: ${normalizedOld}`,
+          'The selected item does not support moving',
         );
       }
       this.store.delete(normalizedOld);

--- a/src/shared/lib/virtualFileSystem/VirtualFileSystem.ts
+++ b/src/shared/lib/virtualFileSystem/VirtualFileSystem.ts
@@ -259,7 +259,7 @@ export class VirtualFileSystem {
       }
     }
 
-    throw new VfsError(FileSystemError.FileNotFound, `No provider mounted for path: ${path}`);
+    throw new VfsError(FileSystemError.FileNotFound, 'No provider is mounted for the path');
   }
 
   // --- API Methods ---
@@ -377,7 +377,7 @@ export class VirtualFileSystem {
     if (stat.capabilities?.canDelete !== true) {
       throw new VfsError(
         FileSystemError.NoPermissions,
-        `Deletion is not allowed for path: ${path}`,
+        'File system delete operation is not allowed',
       );
     }
 
@@ -435,7 +435,7 @@ export class VirtualFileSystem {
     if (PathUtils.isChildOrSame(oldPath, newPath)) {
       throw new VfsError(
         FileSystemError.NotSupported,
-        `Cannot rename directory to a path inside itself: ${oldPath} -> ${newPath}`,
+        'Cannot move a directory into itself or one of its subdirectories',
       );
     }
 
@@ -445,13 +445,13 @@ export class VirtualFileSystem {
     if (stat.capabilities?.canChangePath !== true) {
       throw new VfsError(
         FileSystemError.NoPermissions,
-        `Path change is not allowed for path: ${oldPath}`,
+        'The selected item does not support moving',
       );
     }
     if (targetParentStat.capabilities?.canEditChildren !== true) {
       throw new VfsError(
         FileSystemError.NoPermissions,
-        `Path change is not allowed inside directory: ${PathUtils.dirname(newPath)}`,
+        'The destination directory is not writable',
       );
     }
 

--- a/src/shared/service/directories/directoriesStoreService.ts
+++ b/src/shared/service/directories/directoriesStoreService.ts
@@ -162,7 +162,7 @@ const setupDirectoryStoreService = () => {
 
     return new Promise((resolve, reject) => {
       const timeoutId = setTimeout(() => {
-        reject(new DomainError(`The entry ${stringPath(rawPath)} timeout expired`));
+        reject(new DomainError('The requested entry could not be loaded in time'));
       }, 30e3);
 
       void until(
@@ -378,7 +378,7 @@ const setupDirectoryStoreService = () => {
     if ('remove' in entry) {
       await entry.remove();
     } else {
-      throw new DomainError(`"${pathToString(entry.path)}" don't have "remove" method`);
+      throw new DomainError('The selected item cannot be removed');
     }
 
     strictRecordSet(stateEntries, pathString, new EntryNotFoundError(rawPath));
@@ -401,7 +401,7 @@ const setupDirectoryStoreService = () => {
       removeCachedEntry(pathString);
       await locateEntryFromRoot(path);
     } else {
-      throw new DomainError(`"${pathToString(entry.path)}" don't have "rename" method`);
+      throw new DomainError('The selected item cannot be renamed');
     }
   };
 

--- a/src/shared/service/document/useDocumentService.test.ts
+++ b/src/shared/service/document/useDocumentService.test.ts
@@ -361,12 +361,15 @@ describe('useDocumentService', () => {
 
     await expect(service.put(path, documentId, createDocument())).rejects.toMatchObject({
       __isDomainError: true,
+      message: 'The document could not be found',
     });
     await expect(service.patch(path, documentId, { name: 'Next' })).rejects.toMatchObject({
       __isDomainError: true,
+      message: 'The document could not be found',
     });
     await expect(service.change(path, documentId, vi.fn())).rejects.toMatchObject({
       __isDomainError: true,
+      message: 'The document could not be found',
     });
   });
 });

--- a/src/shared/service/document/useDocumentService.ts
+++ b/src/shared/service/document/useDocumentService.ts
@@ -154,7 +154,7 @@ const setupDocumentService = () => {
     }
 
     if (!handle) {
-      throw new DomainError(`Document "${documentId}" not found at "${directoryPath}"`);
+      throw new DomainError('The document could not be found');
     }
 
     handle.change((doc) => {
@@ -176,7 +176,7 @@ const setupDocumentService = () => {
     }
 
     if (!handle) {
-      throw new DomainError(`Document "${documentId}" not found at "${directoryPath}"`);
+      throw new DomainError('The document could not be found');
     }
 
     handle.change((doc) => {
@@ -198,7 +198,7 @@ const setupDocumentService = () => {
     }
 
     if (!handle) {
-      throw new DomainError(`Document "${documentId}" not found at "${directoryPath}"`);
+      throw new DomainError('The document could not be found');
     }
 
     return new Promise<void>((resolve, reject) => {

--- a/src/shared/service/repositories/repositoriesStoreService.ts
+++ b/src/shared/service/repositories/repositoriesStoreService.ts
@@ -4,7 +4,7 @@ import {
 } from '@shared/lib/cfrDocument/useDirectoryRepo';
 import type { EntryPath } from '@shared/lib/fileSystem';
 import { createGlobalState } from '@vueuse/core';
-import { stringPath, useDirectoryStoreService } from '../directories';
+import { useDirectoryStoreService } from '../directories';
 import type { AMDocumentId } from '@shared/lib/automerge';
 import { defineSubscribeByQueryService } from '@shared/lib/subscriptions';
 import type { CFRDocumentContent } from '@shared/lib/cfrDocument';
@@ -23,7 +23,7 @@ export const useRepositoriesStoreService = createGlobalState(() => {
     }
 
     if (!entry || entry.type === 'file') {
-      return new DomainError(`Entry ${stringPath(path)} is not directory with document repo`);
+      return new DomainError('The selected location is not a document repository');
     }
 
     const directoryRepo = getDirectoryRepoScope(entry.raw); // fixme: нужен механизм для release


### PR DESCRIPTION
- eliminate sensitive path details from error handling in document and entry management
- ensure error messages are user-friendly and do not expose internal paths
- update tests to reflect changes in error reporting behavior