### PR TITLE
feat(verify): summary-first output with per-check logs and --verbose

### DIFF
--- a/.agents/skills/verification/SKILL.md
+++ b/.agents/skills/verification/SKILL.md
@@ -38,6 +38,15 @@ Use the narrowest useful check for the current change:
 
 Prefer the project `pnpm verify` script when it can infer the changed-file scope. It already runs changed-file formatting, lint, type-check, focused Vitest, changed Playwright specs, and narrow Stryker scope when applicable.
 
+`pnpm verify` uses summary-first terminal output by default:
+
+- passed checks print concise status lines;
+- failed checks print the check label, exact command, exit code, relevant output tail, and log path;
+- warning-only checks print a warning summary and log path;
+- full command logs are written per check under `.verify/logs/`.
+
+Use `pnpm verify --verbose` when you need full streamed command output in the terminal. It is a diagnostic mode, not a separate quality gate.
+
 ## Failure handling
 
 If `pnpm verify` fails:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -24,4 +24,13 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm e2e:install
-      - run: pnpm verify
+      - run: pnpm verify --verbose
+
+      - name: Upload verify logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: verify-logs
+          path: .verify/logs/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ test-results/
 tsconfig.tsbuildinfo
 .eslintcache
 .stryker-tmp/
+.verify/
 
 # ByteRover — .brv/context-tree/ contains a nested .git managed by brv vc.
 # Without these entries, `git add .` fails with "does not have a commit checked out".

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -110,6 +110,21 @@ Before reporting completion after code or documentation edits, run the read-only
 pnpm verify
 ```
 
+By default, `pnpm verify` is summary-first:
+
+- each successful check prints a concise pass line;
+- failed checks print the label, exact command, exit code, and a relevant output tail;
+- checks with warnings print a warning summary;
+- full stdout/stderr for each executed check is written to `.verify/logs/<check>.log`.
+
+Use verbose mode when you need full live command output in the terminal:
+
+```bash
+pnpm verify --verbose
+```
+
+`--verbose` can be combined with `--fix` when applying automatic fixes.
+
 Agent workflow:
 
 - Use `pnpm verify --fix` only to apply automatic formatting or lint fixes.

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import toolingConfig from '../config/tooling.json' with { type: 'json' };
 
 const isFixMode = process.argv.includes('--fix');
@@ -10,6 +10,7 @@ const VERIFY_DIR = '.verify';
 const VERIFY_LOG_DIR = path.posix.join(VERIFY_DIR, 'logs');
 const MAX_RELEVANT_LINES = 20;
 const MAX_FILE_ARGS_IN_SUMMARY = 4;
+const MAX_ROLLING_BUFFER_CHARS = 128 * 1024;
 const FORMATTABLE_EXTENSIONS = new Set([
   '.css',
   '.html',
@@ -412,11 +413,21 @@ function ensureLogsDirectory() {
   fs.mkdirSync(VERIFY_LOG_DIR, { recursive: true });
 }
 
-function writeLog(label, command, output) {
-  const logPath = getLogPath(label);
-  const fileContent = [`# command`, command, '', '# output', output].join('\n');
-  fs.writeFileSync(logPath, fileContent, 'utf8');
-  return logPath;
+function appendToRollingBuffer(buffer, chunk) {
+  const nextBuffer = `${buffer}${chunk}`;
+
+  if (nextBuffer.length <= MAX_ROLLING_BUFFER_CHARS) {
+    return nextBuffer;
+  }
+
+  return nextBuffer.slice(-MAX_ROLLING_BUFFER_CHARS);
+}
+
+function closeLogStream(stream) {
+  return new Promise((resolve, reject) => {
+    stream.once('error', reject);
+    stream.end(() => resolve());
+  });
 }
 
 function summarizeCommandForDisplay(command, args) {
@@ -483,29 +494,67 @@ function getOutputTail(output) {
   return lines.slice(-MAX_RELEVANT_LINES);
 }
 
-function runCommand(label, command, args) {
+async function runCommand(label, command, args) {
   const formattedCommand = formatCommand(command, args);
   const displayCommand = summarizeCommandForDisplay(command, args);
-  const stdio = isVerboseMode ? 'inherit' : ['inherit', 'pipe', 'pipe'];
+  const logPath = getLogPath(label);
+  const logStream = fs.createWriteStream(logPath, { encoding: 'utf8' });
+  logStream.write(`# command\n${formattedCommand}\n\n# output\n`);
 
   console.log(`\n[${label}] running ${displayCommand}`);
 
-  const result = spawnSync(command, args, {
-    stdio,
-    encoding: 'utf8',
-    maxBuffer: 16 * 1024 * 1024,
+  const child = spawn(command, args, {
+    stdio: ['inherit', 'pipe', 'pipe'],
   });
 
-  if (result.error) {
-    throw result.error;
+  let outputBuffer = '';
+  let exitCode = 1;
+  let spawnError = null;
+
+  const onStdout = (chunk) => {
+    const text = chunk.toString();
+    logStream.write(text);
+    outputBuffer = appendToRollingBuffer(outputBuffer, text);
+
+    if (isVerboseMode) {
+      process.stdout.write(chunk);
+    }
+  };
+
+  const onStderr = (chunk) => {
+    const text = chunk.toString();
+    logStream.write(text);
+    outputBuffer = appendToRollingBuffer(outputBuffer, text);
+
+    if (isVerboseMode) {
+      process.stderr.write(chunk);
+    }
+  };
+
+  child.stdout?.on('data', onStdout);
+  child.stderr?.on('data', onStderr);
+
+  await new Promise((resolve) => {
+    child.once('error', (error) => {
+      spawnError = error;
+      logStream.write(`\n[verify] spawn error: ${error.message}\n`);
+      resolve();
+    });
+
+    child.once('close', (code) => {
+      exitCode = code ?? 1;
+      resolve();
+    });
+  });
+
+  await closeLogStream(logStream);
+
+  if (spawnError) {
+    throw spawnError;
   }
 
-  const stdout = result.stdout ?? '';
-  const stderr = result.stderr ?? '';
-  const combinedOutput = [stdout, stderr].filter((value) => value.length > 0).join('\n');
-  const logPath = writeLog(label, formattedCommand, combinedOutput);
-  const warningSummary = getWarningSummary(combinedOutput);
-  const exitCode = result.status ?? 1;
+  const logOutput = fs.readFileSync(logPath, 'utf8');
+  const warningSummary = getWarningSummary(logOutput);
   const status = exitCode === 0 ? 'passed' : 'failed';
 
   if (status === 'passed' && !warningSummary) {
@@ -520,7 +569,7 @@ function runCommand(label, command, args) {
     console.log(`[${label}] exit code: ${exitCode}`);
     console.log(`[${label}] output tail:`);
 
-    for (const tailLine of getOutputTail(combinedOutput)) {
+    for (const tailLine of getOutputTail(outputBuffer)) {
       console.log(`  ${tailLine}`);
     }
 
@@ -534,8 +583,8 @@ function runCommand(label, command, args) {
     logPath,
     exitCode,
     status,
-    stdout,
-    stderr,
+    stdout: '',
+    stderr: '',
     hasWarnings: warningSummary.length > 0,
     warningSummary,
   };
@@ -557,10 +606,7 @@ function buildCommands(changedFiles) {
   const hasVisualRelevantChanges = changedFiles.some(isVisualRelevantFile);
   const changedE2ESpecs = changedFiles.filter(
     (filePath) =>
-      filePath.startsWith('tests/e2e/') &&
-      !filePath.startsWith('tests/e2e/visual/') &&
-      filePath.endsWith('.ts') &&
-      fileExists(filePath),
+      !filePath.startsWith('tests/e2e/visual/') && filePath.endsWith('.ts') && fileExists(filePath),
   );
   const mutationScope = getMutationScope(changedFiles);
   const commands = [];
@@ -755,13 +801,15 @@ function printSummary(changedFiles, scope, results) {
   return status;
 }
 
-function main() {
+async function main() {
   const { changedFiles, scope } = getChangedFiles();
   const commands = buildCommands(changedFiles);
   const results = [];
   ensureLogsDirectory();
 
-  for (const entry of commands) {
+  await commands.reduce(async (previousRun, entry) => {
+    await previousRun;
+
     if (entry.kind === 'skipped') {
       results.push({
         label: entry.label,
@@ -774,11 +822,11 @@ function main() {
         hasWarnings: false,
         warningSummary: '',
       });
-      continue;
+      return;
     }
 
-    results.push(runCommand(entry.label, entry.command, entry.args));
-  }
+    results.push(await runCommand(entry.label, entry.command, entry.args));
+  }, Promise.resolve());
 
   const status = printSummary(changedFiles, scope, results);
   process.exitCode = status === 'failed' ? 1 : 0;
@@ -788,4 +836,4 @@ if (!directoryExists('.git')) {
   throw new Error('Repository root is required to run verify.');
 }
 
-main();
+await main();

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -4,7 +4,12 @@ import { spawnSync } from 'node:child_process';
 import toolingConfig from '../config/tooling.json' with { type: 'json' };
 
 const isFixMode = process.argv.includes('--fix');
+const isVerboseMode = process.argv.includes('--verbose');
 const cliBaseRef = getCliBaseRef(process.argv.slice(2));
+const VERIFY_DIR = '.verify';
+const VERIFY_LOG_DIR = path.posix.join(VERIFY_DIR, 'logs');
+const MAX_RELEVANT_LINES = 20;
+const MAX_FILE_ARGS_IN_SUMMARY = 4;
 const FORMATTABLE_EXTENSIONS = new Set([
   '.css',
   '.html',
@@ -398,6 +403,51 @@ function formatCommand(command, args) {
   return [command, ...args].map(quoteArg).join(' ');
 }
 
+function getLogPath(label) {
+  return path.posix.join(VERIFY_LOG_DIR, `${label}.log`);
+}
+
+function ensureLogsDirectory() {
+  fs.rmSync(VERIFY_LOG_DIR, { recursive: true, force: true });
+  fs.mkdirSync(VERIFY_LOG_DIR, { recursive: true });
+}
+
+function writeLog(label, command, output) {
+  const logPath = getLogPath(label);
+  const fileContent = [`# command`, command, '', '# output', output].join('\n');
+  fs.writeFileSync(logPath, fileContent, 'utf8');
+  return logPath;
+}
+
+function summarizeCommandForDisplay(command, args) {
+  const groupedFileArgs = [];
+  const otherArgs = [];
+
+  for (const arg of args) {
+    if (arg.includes('/') && fileExists(arg)) {
+      groupedFileArgs.push(arg);
+      continue;
+    }
+
+    otherArgs.push(arg);
+  }
+
+  if (groupedFileArgs.length === 0) {
+    return formatCommand(command, args);
+  }
+
+  const previewFiles = groupedFileArgs.slice(0, MAX_FILE_ARGS_IN_SUMMARY).map(quoteArg);
+  const remainingCount = groupedFileArgs.length - previewFiles.length;
+  const fileSummaryParts = [...previewFiles];
+
+  if (remainingCount > 0) {
+    fileSummaryParts.push(`<+${remainingCount} files>`);
+  }
+
+  const displayArgs = [...otherArgs, ...fileSummaryParts];
+  return formatCommand(command, displayArgs);
+}
+
 function trimWarningLine(line) {
   return line.trim().replace(/\s+/g, ' ');
 }
@@ -420,37 +470,70 @@ function getWarningSummary(output) {
   return uniqSorted(lines).slice(0, 3).join(' | ');
 }
 
+function getOutputTail(output) {
+  const lines = output
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter((line) => line.trim().length > 0);
+
+  if (lines.length === 0) {
+    return ['(no output captured)'];
+  }
+
+  return lines.slice(-MAX_RELEVANT_LINES);
+}
+
 function runCommand(label, command, args) {
   const formattedCommand = formatCommand(command, args);
-  const shouldCaptureOutput = ['eslint', 'oxlint'].includes(label);
+  const displayCommand = summarizeCommandForDisplay(command, args);
+  const stdio = isVerboseMode ? 'inherit' : ['inherit', 'pipe', 'pipe'];
 
-  console.log(`\n[${label}] $ ${formattedCommand}`);
+  console.log(`\n[${label}] running ${displayCommand}`);
 
   const result = spawnSync(command, args, {
-    stdio: shouldCaptureOutput ? ['inherit', 'pipe', 'pipe'] : 'inherit',
+    stdio,
     encoding: 'utf8',
     maxBuffer: 16 * 1024 * 1024,
   });
-
-  const stdout = shouldCaptureOutput ? (result.stdout ?? '') : '';
-  const stderr = shouldCaptureOutput ? (result.stderr ?? '') : '';
-
-  if (shouldCaptureOutput) {
-    process.stdout.write(stdout);
-    process.stderr.write(stderr);
-  }
 
   if (result.error) {
     throw result.error;
   }
 
-  const warningSummary = shouldCaptureOutput ? getWarningSummary(`${stdout}\n${stderr}`) : '';
+  const stdout = result.stdout ?? '';
+  const stderr = result.stderr ?? '';
+  const combinedOutput = [stdout, stderr].filter((value) => value.length > 0).join('\n');
+  const logPath = writeLog(label, formattedCommand, combinedOutput);
+  const warningSummary = getWarningSummary(combinedOutput);
+  const exitCode = result.status ?? 1;
+  const status = exitCode === 0 ? 'passed' : 'failed';
+
+  if (status === 'passed' && !warningSummary) {
+    console.log(`[${label}] passed ✅`);
+  } else if (status === 'passed' && warningSummary) {
+    console.log(`[${label}] passed with warnings ⚠️`);
+    console.log(`[${label}] warnings: ${warningSummary}`);
+    console.log(`[${label}] full log: ${logPath}`);
+  } else {
+    console.log(`[${label}] failed ❌`);
+    console.log(`[${label}] command: ${formattedCommand}`);
+    console.log(`[${label}] exit code: ${exitCode}`);
+    console.log(`[${label}] output tail:`);
+
+    for (const tailLine of getOutputTail(combinedOutput)) {
+      console.log(`  ${tailLine}`);
+    }
+
+    console.log(`[${label}] full log: ${logPath}`);
+  }
 
   return {
     label,
     command: formattedCommand,
-    exitCode: result.status ?? 1,
-    status: result.status === 0 ? 'passed' : 'failed',
+    displayCommand,
+    logPath,
+    exitCode,
+    status,
     stdout,
     stderr,
     hasWarnings: warningSummary.length > 0,
@@ -646,9 +729,11 @@ function printSummary(changedFiles, scope, results) {
 
   console.log('\nVERIFY RESULT');
   console.log(`mode: ${isFixMode ? 'fix' : 'check'}`);
+  console.log(`verbose: ${isVerboseMode ? 'on' : 'off'}`);
   console.log(`scope: ${scope}`);
   console.log(`changed files: ${changedFiles.length}`);
   console.log(`status: ${status}`);
+  console.log(`logs: ${VERIFY_LOG_DIR}`);
   console.log('commands:');
 
   for (const result of results) {
@@ -658,7 +743,7 @@ function printSummary(changedFiles, scope, results) {
     }
 
     const warningSuffix = result.hasWarnings ? ' (warnings found)' : '';
-    console.log(`- ${result.label}: ${result.status}${warningSuffix} (${result.command})`);
+    console.log(`- ${result.label}: ${result.status}${warningSuffix} (${result.displayCommand})`);
   }
 
   console.log('action required:');
@@ -674,6 +759,7 @@ function main() {
   const { changedFiles, scope } = getChangedFiles();
   const commands = buildCommands(changedFiles);
   const results = [];
+  ensureLogsDirectory();
 
   for (const entry of commands) {
     if (entry.kind === 'skipped') {

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -435,7 +435,7 @@ function summarizeCommandForDisplay(command, args) {
   const otherArgs = [];
 
   for (const arg of args) {
-    if (arg.includes('/') && fileExists(arg)) {
+    if (!arg.startsWith('-') && fileExists(arg)) {
       groupedFileArgs.push(arg);
       continue;
     }
@@ -447,7 +447,7 @@ function summarizeCommandForDisplay(command, args) {
     return formatCommand(command, args);
   }
 
-  const previewFiles = groupedFileArgs.slice(0, MAX_FILE_ARGS_IN_SUMMARY).map(quoteArg);
+  const previewFiles = groupedFileArgs.slice(0, MAX_FILE_ARGS_IN_SUMMARY);
   const remainingCount = groupedFileArgs.length - previewFiles.length;
   const fileSummaryParts = [...previewFiles];
 
@@ -467,7 +467,11 @@ function isZeroWarningLine(line) {
   return /\b0 warnings?\b/i.test(line) && !/\b[1-9]\d* warnings?\b/i.test(line);
 }
 
-function getWarningSummary(output) {
+function getWarningSummary(label, output) {
+  if (!['oxlint', 'eslint'].includes(label)) {
+    return '';
+  }
+
   const lines = output
     .split('\n')
     .map(trimWarningLine)
@@ -554,7 +558,7 @@ async function runCommand(label, command, args) {
   }
 
   const logOutput = fs.readFileSync(logPath, 'utf8');
-  const warningSummary = getWarningSummary(logOutput);
+  const warningSummary = getWarningSummary(label, logOutput);
   const status = exitCode === 0 ? 'passed' : 'failed';
 
   if (status === 'passed' && !warningSummary) {
@@ -826,6 +830,7 @@ async function main() {
       continue;
     }
 
+    // oxlint-disable-next-line no-await-in-loop -- verify checks must run sequentially for stable summary/log ordering.
     results.push(await runCommand(entry.label, entry.command, entry.args));
   }
 

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -606,7 +606,10 @@ function buildCommands(changedFiles) {
   const hasVisualRelevantChanges = changedFiles.some(isVisualRelevantFile);
   const changedE2ESpecs = changedFiles.filter(
     (filePath) =>
-      !filePath.startsWith('tests/e2e/visual/') && filePath.endsWith('.ts') && fileExists(filePath),
+      filePath.startsWith('tests/e2e/') &&
+      !filePath.startsWith('tests/e2e/visual/') &&
+      filePath.endsWith('.ts') &&
+      fileExists(filePath),
   );
   const mutationScope = getMutationScope(changedFiles);
   const commands = [];
@@ -807,9 +810,7 @@ async function main() {
   const results = [];
   ensureLogsDirectory();
 
-  await commands.reduce(async (previousRun, entry) => {
-    await previousRun;
-
+  for (const entry of commands) {
     if (entry.kind === 'skipped') {
       results.push({
         label: entry.label,
@@ -822,11 +823,11 @@ async function main() {
         hasWarnings: false,
         warningSummary: '',
       });
-      return;
+      continue;
     }
 
     results.push(await runCommand(entry.label, entry.command, entry.args));
-  }, Promise.resolve());
+  }
 
   const status = printSummary(changedFiles, scope, results);
   process.exitCode = status === 'failed' ? 1 : 0;


### PR DESCRIPTION
### Motivation
- Reduce noisy terminal output from `pnpm verify` while preserving the exact same inferred checks and non-fail-fast behavior.
- Keep full diagnostics available for debugging by saving complete stdout/stderr per check to stable log files.
- Make failures and warnings actionable from the summary without requiring immediate log inspection, and provide `--verbose` for full live streaming when needed.

### Description
- Implement summary-first reporting in `scripts/verify.mjs` that prints concise pass/warn/fail lines and, for failures, the check label, exact command, exit code, a relevant output tail, and the path to the full log file.
- Capture stdout/stderr for every executed check into a recreated gitignored `.verify/logs/` directory using stable filenames (e.g. `.verify/logs/format.log`) via `writeLog()` and `ensureLogsDirectory()` so stale logs are cleared each run.
- Add `--verbose` support to stream full command output to the terminal while still writing per-check logs, and add `summarizeCommandForDisplay()` to shorten long file lists in summaries while preserving the exact command in logs.
- Update `.gitignore` to include `.verify/` and update `DEVELOPMENT.md` and `.agents/skills/verification/SKILL.md` to document the new default summary-first behavior, log locations, and `--verbose` usage.

### Testing
- Ran the final read-only verification with `pnpm verify` and it completed successfully while producing concise summary output and creating per-check logs under `.verify/logs/`.
- Ran `pnpm verify --verbose` and confirmed full command output streamed to the terminal while per-check logs were still written; the run succeeded.
- Ran `pnpm verify --fix` to exercise fix-mode and confirmed it still applies fixes and writes logs as expected.
- Inspected `.verify/logs/*.log` to verify full captured stdout/stderr are present and that the logs directory is recreated/overwritten on subsequent runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06ead222888324a7e9c493c4340dfc)