### PR TITLE
fix(verify): finalize verify summary-first output polish

### DIFF
--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -435,7 +435,7 @@ function summarizeCommandForDisplay(command, args) {
   const otherArgs = [];
 
   for (const arg of args) {
-    if (arg.includes('/') && fileExists(arg)) {
+    if (!arg.startsWith('-') && fileExists(arg)) {
       groupedFileArgs.push(arg);
       continue;
     }
@@ -447,7 +447,7 @@ function summarizeCommandForDisplay(command, args) {
     return formatCommand(command, args);
   }
 
-  const previewFiles = groupedFileArgs.slice(0, MAX_FILE_ARGS_IN_SUMMARY).map(quoteArg);
+  const previewFiles = groupedFileArgs.slice(0, MAX_FILE_ARGS_IN_SUMMARY);
   const remainingCount = groupedFileArgs.length - previewFiles.length;
   const fileSummaryParts = [...previewFiles];
 
@@ -467,7 +467,11 @@ function isZeroWarningLine(line) {
   return /\b0 warnings?\b/i.test(line) && !/\b[1-9]\d* warnings?\b/i.test(line);
 }
 
-function getWarningSummary(output) {
+function getWarningSummary(label, output) {
+  if (!['oxlint', 'eslint'].includes(label)) {
+    return '';
+  }
+
   const lines = output
     .split('\n')
     .map(trimWarningLine)
@@ -554,7 +558,7 @@ async function runCommand(label, command, args) {
   }
 
   const logOutput = fs.readFileSync(logPath, 'utf8');
-  const warningSummary = getWarningSummary(logOutput);
+  const warningSummary = getWarningSummary(label, logOutput);
   const status = exitCode === 0 ? 'passed' : 'failed';
 
   if (status === 'passed' && !warningSummary) {
@@ -826,6 +830,7 @@ async function main() {
       continue;
     }
 
+    // oxlint-disable-next-line no-await-in-loop -- verify checks must run sequentially for stable summary/log ordering.
     results.push(await runCommand(entry.label, entry.command, entry.args));
   }
 


### PR DESCRIPTION
### Motivation

- Avoid a lint warning caused by an intentional `await` in the verify loop while keeping checks sequential. 
- Ensure compact command summaries correctly group root-level file args such as `package.json` and `README.md`.
- Prevent double-quoting in the compact display and avoid spurious warning summaries from unrelated command output.

### Description

- Change `summarizeCommandForDisplay()` to treat any existing non-option argument as a file by using `!arg.startsWith('-') && fileExists(arg)`. 
- Stop pre-quoting grouped file previews before `formatCommand()` so `formatCommand()` alone handles quoting and avoids double-escaping. 
- Tighten `getWarningSummary()` to accept the command `label` and only extract warnings for `oxlint` and `eslint`, leaving failure tails and full logs unchanged. 
- Add a narrow inline `oxlint-disable-next-line no-await-in-loop` comment above the intentional `await runCommand(...)` to suppress the linter warning without parallelizing execution. 

### Testing

- Ran `pnpm verify` and observed expected summary-first output and per-check logs; the run passed. 
- Ran `pnpm verify --verbose` and confirmed live streaming plus full logs were written to `.verify/logs/*.log`; the run passed. 
- Ran `pnpm verify --fix` and confirmed fix-mode behavior and logs; the run passed. 
- Inspected `.verify/logs/*.log` and confirmed logs contain full command output and headers.

VERIFY RESULT
command: pnpm verify
status: passed
reason if not run:

BRV RESULT
status: not available
reason: `brv` CLI is not installed in this environment (`brv: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06f39c857883248db8f02d00bbb7de)