### PR TITLE
docs(agents): add implementation preflight guidance

### DIFF
--- a/.agents/skills/crdt-storage/SKILL.md
+++ b/.agents/skills/crdt-storage/SKILL.md
@@ -34,9 +34,10 @@ Use this workflow when the task touches any of these areas:
 4. Keep writes small and scoped to the owning change callback.
 5. Ensure subscriptions and handles recover from legitimate transient states such as missing documents when that is expected behavior.
 6. Add cleanup or finalization for resources that can outlive the caller.
-7. Add or update focused tests for storage semantics, migrations, normalization, CRDT write helpers, or lifecycle behavior when the change affects behavior.
-8. Consider the `mutation-testing` skill after focused unit/integration tests pass for high-risk pure data logic.
-9. Run the narrowest relevant verification, then follow the final verification rule from `AGENTS.md`.
+7. For lifecycle, integration, or cache state changes, define the applicable state-transition matrix before implementation is considered complete.
+8. Add or update focused tests for storage semantics, migrations, normalization, CRDT write helpers, or lifecycle behavior when the change affects behavior.
+9. Consider the `mutation-testing` skill after focused unit/integration tests pass for high-risk pure data logic.
+10. Run the narrowest relevant verification, then follow the final verification rule from `AGENTS.md`.
 
 ## Testing guidance
 
@@ -52,6 +53,21 @@ Use focused unit or integration tests for:
 - VFS behavior that can be tested without real browser interaction.
 
 Use Playwright/e2e or a browser smoke check only when the behavior requires real browser APIs, file picker behavior, user interaction, or UI integration.
+
+## State-transition matrix
+
+When editing lifecycle, integration, or cache state, cover applicable transitions:
+
+- initial disabled or unavailable state;
+- enable after startup;
+- disable after enable;
+- repeated enable calls;
+- enable to disable while setup is pending;
+- enable to disable to enable while the first async operation resolves late;
+- cleanup when the owning scope stops;
+- multiple independent callers using the same target or service.
+
+Cover applicable transitions with focused tests before considering the implementation complete.
 
 ## Cache and lifecycle checks
 

--- a/.agents/skills/crdt-storage/SKILL.md
+++ b/.agents/skills/crdt-storage/SKILL.md
@@ -34,7 +34,7 @@ Use this workflow when the task touches any of these areas:
 4. Keep writes small and scoped to the owning change callback.
 5. Ensure subscriptions and handles recover from legitimate transient states such as missing documents when that is expected behavior.
 6. Add cleanup or finalization for resources that can outlive the caller.
-7. For lifecycle, integration, or cache state changes, define the applicable state-transition matrix before implementation is considered complete.
+7. For lifecycle, integration, or cache state changes, define the applicable state-transition matrix as part of the implementation preflight.
 8. Add or update focused tests for storage semantics, migrations, normalization, CRDT write helpers, or lifecycle behavior when the change affects behavior.
 9. Consider the `mutation-testing` skill after focused unit/integration tests pass for high-risk pure data logic.
 10. Run the narrowest relevant verification, then follow the final verification rule from `AGENTS.md`.
@@ -67,7 +67,7 @@ When editing lifecycle, integration, or cache state, cover applicable transition
 - cleanup when the owning scope stops;
 - multiple independent callers using the same target or service.
 
-Cover applicable transitions with focused tests before considering the implementation complete.
+Cover applicable transitions with focused tests to drive the implementation.
 
 ## Cache and lifecycle checks
 

--- a/.agents/skills/implementation-preflight/SKILL.md
+++ b/.agents/skills/implementation-preflight/SKILL.md
@@ -31,7 +31,7 @@ Use focused searches for names related to the domain, behavior, helper, config, 
 
 Do not start with broad repository exploration unless targeted search shows the impact is wider than expected.
 
-## Acceptance matrix guidance
+## Acceptance and risk matrix guidance
 
 Include only states relevant to the task, but consider:
 

--- a/.agents/skills/implementation-preflight/SKILL.md
+++ b/.agents/skills/implementation-preflight/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: implementation-preflight
+description: 'Use this skill before non-trivial implementation work to reduce corrective commits by identifying the owner layer, reusable project code, acceptance matrix, risk matrix, and focused verification before the first production edit.'
+---
+
+# Implementation preflight
+
+Use this skill before non-trivial code edits. Keep the preflight short and bounded; do not turn it into broad repository exploration.
+
+## Activation check
+
+Use this skill when the task will likely change production code, test behavior, tooling, CI, app configuration, storage semantics, diagnostics, browser behavior, or user-visible UI.
+
+Do not use this skill for trivial typo fixes, formatting-only changes, comments-only changes, or mechanical renames with no behavior or ownership decisions.
+
+## Required preflight
+
+Answer these before the first production edit:
+
+1. **Owner**: which FSD layer owns the behavior, and which public entry points should be used?
+2. **Reuse**: what existing helpers, components, configs, schemas, services, tests, or dependencies already cover nearby behavior?
+3. **Acceptance matrix**: what non-happy-path states must work in the first implementation?
+4. **Risk matrix**: which browser, lifecycle, async, cache, CI/tooling, accessibility, visual, or data-safety risks apply?
+5. **Verification**: what focused check proves the riskiest behavior, and what final verification is required?
+
+## Bounded reuse search
+
+Before creating a new helper, component, config, dependency, or test pattern, check reuse with targeted repository search or direct imports.
+
+Use focused searches for names related to the domain, behavior, helper, config, dependency, and test pattern. Stop once the owner and reuse decision are clear.
+
+Do not start with broad repository exploration unless targeted search shows the impact is wider than expected.
+
+## Acceptance matrix guidance
+
+Include only states relevant to the task, but consider:
+
+- unavailable or disabled integrations;
+- missing browser APIs or unsupported runtime;
+- async pending, cancellation, stale completion, and repeated toggles;
+- invalid, malformed, or hostile input;
+- cache invalidation after create, update, delete, or failed lookup;
+- data-safety-sensitive values in diagnostics, URLs, names, ids, and content;
+- accessibility structure and heading hierarchy for rendered UI;
+- CI, build, Storybook, Playwright, verify, fix, or verbose modes when tooling changes.
+
+The first implementation should cover the applicable matrix, not only the happy path. If a matrix item is intentionally not covered, state why.
+
+## Output discipline
+
+Keep the preflight concise. A useful preflight is usually 5-10 lines plus a short verification note.
+
+Do not repeat generic repository rules. Name only the rules and risks that apply to the current task.

--- a/.agents/skills/test-first/SKILL.md
+++ b/.agents/skills/test-first/SKILL.md
@@ -26,13 +26,28 @@ If any condition is false, skip test-first and use the normal verification rules
 ## Workflow
 
 1. Identify the smallest existing verification target that should own the changed behavior.
-2. Add or update one focused test or smoke check for that behavior before production edits.
-3. Run only that target and confirm it fails for the expected reason.
-4. If a focused failing check cannot be produced quickly, stop expanding coverage and state the risk in the final response.
-5. Implement the minimal production change.
-6. Rerun the same target and confirm it passes.
-7. Run the narrowest additional verification required by `AGENTS.md`.
-8. Run the final `pnpm verify` check required by `AGENTS.md` before reporting completion.
+2. Build a minimal acceptance matrix before writing the test. Include only states relevant to the task.
+3. Add or update one focused test or smoke check for the highest-risk matrix item before production edits.
+4. Run only that target and confirm it fails for the expected reason.
+5. If a focused failing check cannot be produced quickly, stop expanding coverage and state the risk in the final response.
+6. Implement the minimal production change.
+7. Rerun the same target and confirm it passes.
+8. Run the narrowest additional verification required by `AGENTS.md`.
+9. Run the final `pnpm verify` check required by `AGENTS.md` before reporting completion.
+
+## Acceptance matrix guidance
+
+Include only states that are relevant to the task, but consider:
+
+- unavailable or disabled integrations;
+- missing browser APIs or unsupported runtime;
+- async pending, cancellation, stale completion, and repeated toggles;
+- invalid, malformed, or hostile input;
+- cache invalidation after create, update, delete, or failed lookup;
+- data-safety-sensitive values in diagnostics, URLs, names, ids, and content;
+- accessibility structure and heading hierarchy for rendered UI.
+
+The first focused test should target the highest-risk applicable matrix item, not just the happy path.
 
 ## Choosing the check
 

--- a/.agents/skills/ui-browser-behavior/SKILL.md
+++ b/.agents/skills/ui-browser-behavior/SKILL.md
@@ -30,11 +30,22 @@ Use this workflow when the change touches any of these areas:
 
 1. Identify the user-visible behavior and the owning layer.
 2. Check the rendered hierarchy before moving wrappers, teleports, scroll owners, or composition boundaries.
-3. Keep component contracts narrow: prefer explicit props, named handlers, explicit emits, and slots over service bags or large config objects.
-4. Move reusable state transitions or business rules into composables or pure helpers when they can be tested without the browser.
-5. Verify browser-dependent behavior with Playwright/e2e or a reproducible browser smoke check.
-6. Use component unit tests only for small render or wiring contracts that do not depend on browser semantics.
-7. Run the narrowest relevant UI verification, then follow the final verification rule from `AGENTS.md`.
+3. For panes, docs, markdown, settings, dialogs, and app bars, apply the rendered structure checklist.
+4. Keep component contracts narrow: prefer explicit props, named handlers, explicit emits, and slots over service bags or large config objects.
+5. Move reusable state transitions or business rules into composables or pure helpers when they can be tested without the browser.
+6. Verify browser-dependent behavior with Playwright/e2e or a reproducible browser smoke check.
+7. Use component unit tests only for small render or wiring contracts that do not depend on browser semantics.
+8. Run the narrowest relevant UI verification, then follow the final verification rule from `AGENTS.md`.
+
+## Rendered structure checklist
+
+For rendered panes, docs, markdown, settings, dialogs, and app bars, check before implementation is complete:
+
+- one clear page-level heading or app-bar heading; avoid duplicate top-level headings;
+- slots preserve navigation and trailing actions;
+- browser APIs are guarded when unavailable or prototype-defined;
+- user-visible text and diagnostics use the correct format for their purpose;
+- Material typography and spacing reuse shared tokens or shared components before local CSS.
 
 ## Choosing verification
 

--- a/.agents/skills/verification/SKILL.md
+++ b/.agents/skills/verification/SKILL.md
@@ -47,6 +47,20 @@ Prefer the project `pnpm verify` script when it can infer the changed-file scope
 
 Use `pnpm verify --verbose` when you need full streamed command output in the terminal. It is a diagnostic mode, not a separate quality gate.
 
+## Mode-specific verification
+
+When changing tooling, scripts, CI, Storybook, Playwright, build config, package scripts, or command output, verify every user-visible mode touched by the change.
+
+Examples:
+
+- verify script changes: check default mode, `--fix`, and `--verbose` when affected;
+- GitHub Actions changes: ensure the workflow command still exposes useful logs and annotations;
+- Storybook changes: run the Storybook build or the narrow visual command that exercises the changed config;
+- Playwright config changes: run the affected project or config, not only a generic unit test;
+- package, dependency, or config changes: run type-check or build when runtime behavior or generated types can be affected.
+
+Do not rely on final `pnpm verify` alone when the changed behavior is a mode that `pnpm verify` does not exercise directly.
+
 ## Failure handling
 
 If `pnpm verify` fails:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ reason:
 
 - Prefer plan-first implementation over broad discovery.
 - Before broad repository exploration, use ByteRover local search to recall prior project decisions; use synthesized queries only when search results are insufficient.
+- Use the `implementation-preflight` skill before non-trivial implementation work to identify the owner layer, reuse opportunities, acceptance matrix, risk matrix, and focused verification before the first production edit.
 - Before editing, identify the smallest affected FSD owner layer and read only task-relevant files plus direct imports unless the task proves wider impact.
 - Split cross-layer work into separate schema/service, entity, feature, widget, and verification passes.
 - Keep changes in the layer that owns the behavior, and import through `index.ts` when a public entry point exists.
@@ -130,7 +131,7 @@ reason:
 - Raw `Error` may be preserved in reportable flows only when its message is project-controlled and does not include user-controlled values.
 - Errors from browser APIs, storage, network, Google API, File API, Automerge/repo internals, Zod, or any external library are untrusted by default and must be wrapped with a safe project-controlled cause message before they can reach handled diagnostics.
 - Do not include local paths, virtual paths, file names, folder names, document names, document ids, file ids, Google Drive file ids, record values, document contents, or raw external error text in `Error.message`, `DomainError.message`, or `DomainError.cause.message` when the error may be reported.
-- Do not write `new Error(\`Failed for ${path}\`)`, `new DomainError(\`Could not remove ${name}\`)`, or similar path/name/id-bearing messages in reportable flows.
+- Do not add path/name/id-bearing messages to reportable error flows.
 - Do not pass raw browser, filesystem, File API, File System API, Google API, IndexedDB, VFS, Automerge, Zod, or other low-level external errors as `cause` when the error may be reported. Wrap them in a project-controlled safe technical cause message instead.
 - Do not pass path, name, id, URL parameters, or other user-controlled values to `reportHandledError` options, Sentry `extra`, or Sentry `tags`.
 - Prefer stable domain error codes, safe user-facing messages, safe technical cause messages, and `feature` or `action` metadata.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,7 +131,7 @@ reason:
 - Raw `Error` may be preserved in reportable flows only when its message is project-controlled and does not include user-controlled values.
 - Errors from browser APIs, storage, network, Google API, File API, Automerge/repo internals, Zod, or any external library are untrusted by default and must be wrapped with a safe project-controlled cause message before they can reach handled diagnostics.
 - Do not include local paths, virtual paths, file names, folder names, document names, document ids, file ids, Google Drive file ids, record values, document contents, or raw external error text in `Error.message`, `DomainError.message`, or `DomainError.cause.message` when the error may be reported.
-- Do not add path/name/id-bearing messages to reportable error flows.
+- Do not add path/name/id-bearing messages to reportable error flows. Avoid messages like `Failed for <path>` or `Could not remove <name>`.
 - Do not pass raw browser, filesystem, File API, File System API, Google API, IndexedDB, VFS, Automerge, Zod, or other low-level external errors as `cause` when the error may be reported. Wrap them in a project-controlled safe technical cause message instead.
 - Do not pass path, name, id, URL parameters, or other user-controlled values to `reportHandledError` options, Sentry `extra`, or Sentry `tags`.
 - Prefer stable domain error codes, safe user-facing messages, safe technical cause messages, and `feature` or `action` metadata.

--- a/AGENTS.preflight.patch.md
+++ b/AGENTS.preflight.patch.md
@@ -1,9 +1,0 @@
-# Pending AGENTS.md preflight hook
-
-Add this bullet to the `## Patterns` section of `AGENTS.md`, near the other skill activation rules:
-
-```md
-- Use the `implementation-preflight` skill before non-trivial implementation work to identify the owner layer, reuse opportunities, acceptance matrix, risk matrix, and focused verification before the first production edit.
-```
-
-This separate patch note exists because updating the full root `AGENTS.md` through the available GitHub API was blocked while preserving the existing file content unchanged.

--- a/AGENTS.preflight.patch.md
+++ b/AGENTS.preflight.patch.md
@@ -1,0 +1,9 @@
+# Pending AGENTS.md preflight hook
+
+Add this bullet to the `## Patterns` section of `AGENTS.md`, near the other skill activation rules:
+
+```md
+- Use the `implementation-preflight` skill before non-trivial implementation work to identify the owner layer, reuse opportunities, acceptance matrix, risk matrix, and focused verification before the first production edit.
+```
+
+This separate patch note exists because updating the full root `AGENTS.md` through the available GitHub API was blocked while preserving the existing file content unchanged.


### PR DESCRIPTION
## Summary

- Add a new `implementation-preflight` skill for non-trivial implementation tasks.
- Require agents to identify owner layer, reuse opportunities, acceptance matrix, risk matrix, and focused verification before the first production edit.
- Strengthen `test-first` guidance so the first focused check targets the highest-risk applicable matrix item, not only the happy path.
- Add mode-specific verification guidance for tooling, CI, Storybook, Playwright, build config, package scripts, and command output changes.
- Add lifecycle state-transition guidance for storage, integration, cache, listener, and async setup changes.
- Add rendered structure checks for panes, docs, markdown, settings, dialogs, app bars, browser APIs, and Material styling.

## Motivation

Recent PR history shows repeated corrective commits caused by agents implementing a happy path first, then discovering missing lifecycle, async, browser, CI/tooling, data-safety, accessibility, or visual edge cases during review. This PR makes those checks explicit before the first implementation edit, while keeping the workflow bounded to avoid broad repository exploration.

## Notes

The guidance is implemented as a dedicated skill and reinforced in related workflow skills.

## Verification

Not run: documentation-only changes to agent skill markdown files.