### PR TITLE
docs: add Material 3 project knowledge base

### DIFF
--- a/docs/design/material-3/README.md
+++ b/docs/design/material-3/README.md
@@ -1,0 +1,49 @@
+# Material 3 project knowledge
+
+This directory is the local Material 3 knowledge base for Mioframe UI work.
+
+It is not a copy of the external Material documentation. It is a project-specific index of rules, tokens, component decisions, and review checks used before changing shared UI components or product screens.
+
+## When to read this
+
+Read this section before work that changes visual styling, design tokens, typography, colors, elevation, shape, motion, `src/shared/lib/md/tokens.css`, `src/shared/ui/MD*` components, dialogs, menus, tooltips, lists, tables, forms, navigation, empty states, progress states, or compact/mobile layout.
+
+## Map
+
+### Sources
+
+- [sources.md](./sources.md) — indexed source list and limitations.
+
+### Foundations
+
+- [tokens](./foundations/tokens.md) — reference, system, and component tokens.
+- [color](./foundations/color.md) — semantic color roles and surface hierarchy.
+- [typography](./foundations/typography.md) — type scale usage in Mioframe.
+- [shape, elevation, and motion](./foundations/shape-elevation-motion.md) — spatial and temporal hierarchy.
+- [layout, accessibility, and states](./foundations/layout-accessibility-states.md) — compact-first layout, touch targets, focus, disabled states, and interaction states.
+
+### Components
+
+- [buttons](./components/buttons.md) — text, outlined, filled, tonal, icon buttons, FAB.
+- [text input and selection](./components/text-input-selection.md) — text fields, checkboxes, chips.
+- [dialogs, menus, and tooltips](./components/dialogs-menus-tooltips.md) — modal and temporary surfaces.
+- [lists and navigation](./components/lists-navigation.md) — list items, tabs, navigation affordances.
+- [progress and feedback](./components/progress-feedback.md) — circular/linear progress and loading states.
+
+### Project rules
+
+- [Mioframe UI rules](./project-rules/mioframe-ui-rules.md) — project-specific rules derived from Material 3.
+- [Review checklist](./project-rules/review-checklist.md) — checklist for UI PR review.
+
+## Source of truth order
+
+1. Existing shared tokens in `src/shared/lib/md/tokens.css`.
+2. Existing shared components in `src/shared/ui`.
+3. These project rules.
+4. Official Material 3 and Material Web documentation linked from [sources.md](./sources.md).
+
+When external guidance and current implementation conflict, document the mismatch in the task or PR and decide whether to adapt the component, add a project exception, or keep the current behavior.
+
+## Update rule
+
+When a UI task introduces a new reusable pattern or intentionally deviates from Material 3, update this directory in the same PR.

--- a/docs/design/material-3/components/buttons.md
+++ b/docs/design/material-3/components/buttons.md
@@ -1,0 +1,39 @@
+# Buttons, icon buttons, and FAB
+
+Buttons communicate actions. In Mioframe, button choice should reflect action priority, not visual preference.
+
+## Button hierarchy
+
+Use higher-emphasis variants for higher-value actions:
+
+- filled button — primary action on a screen, dialog, or form;
+- filled tonal button — medium emphasis action that should still stand out;
+- outlined button — secondary action that needs visible boundary;
+- text button — low-emphasis action, often in dialogs and compact surfaces;
+- icon button — compact action with a recognizable icon and accessible label;
+- FAB — single prominent creation or primary transformation action for a surface.
+
+## Project rules
+
+- Do not put several filled buttons in the same action group unless they are equally primary.
+- Dialog actions should stay simple and direct. Avoid nested decisions inside dialogs.
+- Prefer two explicit entry actions when the user is choosing between different flows, for example open existing space vs create new space.
+- Icon-only buttons must have an accessible label and visible focus state.
+- Button labels should be action verbs, not nouns when possible.
+- Destructive actions require explicit wording and error/destructive color only when the action is truly destructive.
+- Loading buttons should prevent duplicate activation and preserve layout width when practical.
+
+## Existing components
+
+- `src/shared/ui/Button/MDButton.vue`
+- `src/shared/ui/Button/MDIconButton.vue`
+- `src/shared/ui/Button/MDFab.vue`
+
+## Review checklist
+
+- Is there only one visually primary action in the group?
+- Does the variant match the action priority?
+- Does the label describe the action result?
+- Does an icon-only button have an accessible label?
+- Are focus, hover, pressed, disabled, and loading states covered?
+- Does the layout work on compact touch screens?

--- a/docs/design/material-3/components/dialogs-menus-tooltips.md
+++ b/docs/design/material-3/components/dialogs-menus-tooltips.md
@@ -1,0 +1,48 @@
+# Dialogs, menus, and tooltips
+
+Dialogs, menus, and tooltips are temporary surfaces. They should reduce uncertainty, not become hidden application flows.
+
+## Dialogs
+
+Use dialogs for important prompts that interrupt the current flow and require a decision or acknowledgement.
+
+Project rules:
+
+- Dialogs should have a clear headline unless the accessible name is provided another way.
+- Keep dialog content focused on one decision.
+- Do not use a dialog as a branching wizard when separate entry actions would be clearer.
+- Actions should be explicit and limited.
+- Destructive confirmations should name the destructive result.
+- Dialog size should be controlled by layout constraints, not arbitrary content overflow.
+
+## Menus
+
+Use menus for compact sets of contextual commands.
+
+Project rules:
+
+- Menu items should be short action labels.
+- Do not put long explanations inside a menu item.
+- Use disabled menu items only when their presence helps discoverability.
+- Preserve keyboard navigation and focus return.
+- Prefer a visible button or list row when the action is important enough to show directly.
+
+## Tooltips
+
+Use tooltips for brief explanatory text for icon-only controls or ambiguous affordances.
+
+Project rules:
+
+- Tooltips must be short.
+- Tooltip text should wrap within its max width instead of overflowing.
+- Do not rely on tooltips for essential information on touch devices.
+- Do not use tooltips as validation or error messages.
+- The control must remain understandable without hover.
+
+## Review checklist
+
+- Is this really a temporary surface, or should it be inline content?
+- Is focus managed correctly?
+- Does the surface close predictably?
+- Is the content concise enough for compact screens?
+- Is the user making one clear decision?

--- a/docs/design/material-3/components/lists-navigation.md
+++ b/docs/design/material-3/components/lists-navigation.md
@@ -1,0 +1,44 @@
+# Lists and navigation
+
+Lists and navigation surfaces must keep dense data usable on compact screens.
+
+## Lists
+
+Use lists for repeated items that share a structure. A list item should communicate the item identity, key supporting metadata, and available action path.
+
+Project rules:
+
+- List items must support multiline content when item identity or state cannot be safely understood in one line.
+- Do not truncate user-critical names by default.
+- Keep primary text, secondary text, leading icon/avatar, and trailing actions visually distinct.
+- Avoid placing too many trailing actions inside each row.
+- Row activation and nested actions must not conflict.
+- Empty, loading, and error list states need explicit copy.
+
+## Navigation
+
+Navigation should expose stable product structure, not temporary actions.
+
+Project rules:
+
+- Use tabs for peer sections in the same context.
+- Do not use tabs as filters unless the user perceives them as stable categories.
+- Keep navigation labels short and concrete.
+- Preserve current location after refresh and back navigation where possible.
+- On compact screens, avoid hiding the only path to important functionality behind unclear icons.
+
+## Toolbar containers
+
+Existing component:
+
+- `src/shared/ui/Toolbar/MDToolbarContainer.vue`
+
+Toolbar actions should be ordered by task frequency and risk. Destructive actions should not sit next to high-frequency safe actions without spacing or confirmation.
+
+## Review checklist
+
+- Can long item names wrap without breaking layout?
+- Is truncation safe and recoverable?
+- Are trailing actions clear and reachable on touch devices?
+- Is selected/current navigation state visible?
+- Does keyboard navigation follow the visual order?

--- a/docs/design/material-3/components/progress-feedback.md
+++ b/docs/design/material-3/components/progress-feedback.md
@@ -1,0 +1,40 @@
+# Progress and feedback
+
+Progress indicators explain that work is happening. They must reduce uncertainty without hiding the current app state.
+
+## Progress indicators
+
+Use progress indicators when an operation takes long enough that the user may wonder whether the app is still working.
+
+Project rules:
+
+- Use determinate progress when the app can honestly report progress.
+- Use indeterminate progress only when the duration or amount of work is unknown.
+- Do not block the whole UI for local work unless continuing would be unsafe.
+- Keep progress close to the affected surface when possible.
+- Use full-screen loading only for initial app boot or missing critical data.
+- Avoid multiple competing spinners.
+- Use progress text when the operation has meaningful stages.
+
+Existing component:
+
+- `src/shared/ui/ProgressIndicators/MDCircularProgressIndicator.vue`
+
+## Feedback copy
+
+Feedback should tell the user what changed or what is still happening.
+
+Project rules:
+
+- Avoid generic text such as `Loading...` when the operation is specific.
+- Error feedback should identify the failing operation and recovery path.
+- Success feedback should be short and should not interrupt repeated data entry.
+- Long diagnostics belong in expandable details, not primary UI.
+
+## Review checklist
+
+- Is the progress indicator attached to the correct scope?
+- Is determinate progress used when available?
+- Can the user continue safely while the operation runs?
+- Does copy explain the operation without technical noise?
+- Are loading, empty, error, and success states distinct?

--- a/docs/design/material-3/components/text-input-selection.md
+++ b/docs/design/material-3/components/text-input-selection.md
@@ -1,0 +1,61 @@
+# Text input and selection controls
+
+Text fields, checkboxes, and chips are high-frequency controls in Mioframe. They must stay predictable, readable, and accessible on compact screens.
+
+## Text fields
+
+Use text fields for direct user input. Keep labels stable and visible when the value is empty or focused.
+
+Project rules:
+
+- Prefer explicit labels over placeholders.
+- Placeholder text must not replace a label.
+- Helper text should explain format, consequence, or recovery, not restate the label.
+- Error text should say what is wrong and how to fix it.
+- Preserve focus visibility.
+- Avoid putting complex branching flows inside a text field interaction.
+- Do not truncate the active value while the user is editing.
+
+Existing component:
+
+- `src/shared/ui/TextField/MDTextField.vue`
+
+## Checkboxes
+
+Use checkboxes for independent boolean choices.
+
+Project rules:
+
+- The label must describe the checked state clearly.
+- Do not use a checkbox for mutually exclusive options; use another pattern.
+- Keep label and checkbox activation area connected.
+- Support keyboard interaction and visible focus.
+- Error state should be used only when the choice is required or invalid.
+
+Existing component:
+
+- `src/shared/ui/Checkbox/MDCheckbox.vue`
+
+## Chips
+
+Use chips for compact pieces of selection, filtering, or metadata.
+
+Project rules:
+
+- Use chips for lightweight classification or quick filters, not primary page navigation.
+- Do not use chips when a normal button or list row would be clearer.
+- Selected state must be visually clear and accessible.
+- Removable chips need a clear remove action and accessible name.
+- Long chip labels should wrap only if the surrounding layout supports it; otherwise use a detail surface.
+
+Existing component:
+
+- `src/shared/ui/Chips/MDChip.vue`
+
+## Review checklist
+
+- Does each input have a stable label?
+- Are helper and error texts actionable?
+- Are selected/checked states visually clear?
+- Does keyboard interaction work?
+- Does the control remain usable on compact screens?

--- a/docs/design/material-3/foundations/color.md
+++ b/docs/design/material-3/foundations/color.md
@@ -1,0 +1,60 @@
+# Color
+
+Material 3 color roles are semantic roles, not visual names. Mioframe components should style surfaces and content through system tokens instead of raw palette values.
+
+## Role groups
+
+### Primary, secondary, tertiary
+
+Use primary roles for the most important actions and active emphasis. Use secondary and tertiary roles for supporting accents, not for arbitrary decoration.
+
+Common pairs:
+
+- `--md-sys-color-primary` with `--md-sys-color-on-primary`;
+- `--md-sys-color-primary-container` with `--md-sys-color-on-primary-container`;
+- `--md-sys-color-secondary` with `--md-sys-color-on-secondary`;
+- `--md-sys-color-tertiary` with `--md-sys-color-on-tertiary`.
+
+### Surface roles
+
+Use surfaces to build hierarchy before adding elevation or borders.
+
+Common roles:
+
+- `--md-sys-color-surface` — base app surface;
+- `--md-sys-color-surface-container-lowest` to `--md-sys-color-surface-container-highest` — nested containers;
+- `--md-sys-color-on-surface` — main content on surface;
+- `--md-sys-color-on-surface-variant` — supporting content;
+- `--md-sys-color-outline` and `--md-sys-color-outline-variant` — dividers and boundaries.
+
+### Error roles
+
+Use error roles only for validation, destructive actions, or unrecoverable states.
+
+- `--md-sys-color-error`
+- `--md-sys-color-on-error`
+- `--md-sys-color-error-container`
+- `--md-sys-color-on-error-container`
+
+Do not use error red for neutral warnings or product emphasis.
+
+## Project rules
+
+- Pair every background/container color with its matching `on-*` role.
+- Prefer surface-container roles over ad hoc neutral colors.
+- Use outline roles for boundaries; do not use arbitrary gray borders.
+- Disabled controls should reduce emphasis consistently, not invent new gray values.
+- Avoid using primary color for every interactive element; reserve it for the primary path.
+- On compact screens, color should clarify hierarchy but not replace labels.
+
+## Current implementation notes
+
+`src/shared/lib/md/tokens.css` already defines light and dark mappings for primary, secondary, tertiary, error, surface, outline, fixed, inverse, scrim, and shadow roles. New shared components should consume these roles instead of adding their own palette.
+
+## Review checklist
+
+- Are text/icon colors readable on the chosen container?
+- Does the component use `on-*` roles instead of raw colors?
+- Are dark theme values inherited correctly?
+- Is primary color reserved for meaningful emphasis?
+- Is error color used only for real error/destructive states?

--- a/docs/design/material-3/foundations/layout-accessibility-states.md
+++ b/docs/design/material-3/foundations/layout-accessibility-states.md
@@ -1,0 +1,53 @@
+# Layout, accessibility, and states
+
+Mioframe is a compact-first data application. Layout, accessibility, and interaction states are part of the same UI contract.
+
+## Layout
+
+Project rules:
+
+- Start from compact/mobile layout, then expand.
+- Preserve full functionality on compact screens.
+- Prefer progressive disclosure over hiding important actions.
+- Avoid dialog branching when the user is choosing between clearly different flows; use explicit entry actions instead.
+- Keep repeated actions close to the content they affect.
+- Do not create dense desktop-only affordances that are hard to discover on touch devices.
+- Prefer wrapping labels over ambiguous icons when the action is not obvious.
+
+## Touch targets
+
+- Interactive controls must be comfortable for touch use.
+- Adjacent controls need enough spacing to avoid accidental activation.
+- Icon-only controls need accessible names and visible focus.
+- Dense table/list controls should still have reliable pointer and keyboard affordances.
+
+## Accessibility
+
+Project rules:
+
+- Every icon-only button needs an accessible label.
+- Form fields need stable visible labels or equivalent accessible labels.
+- Validation errors must be connected to the relevant field.
+- Focus must remain visible and logical during keyboard navigation.
+- Dialogs and menus must manage focus according to their interaction model.
+- Disabled state must not be the only way to explain why an action is unavailable.
+
+## Interaction states
+
+Every reusable component should define or inherit states for enabled, hover, focus-visible, pressed, selected or checked, disabled, error, and loading when those states apply.
+
+Use existing state opacity tokens for hover, focus, and pressed state layers. Do not replace state layers with unrelated background colors unless this is a deliberate component exception.
+
+## Soft disabled
+
+Use soft-disabled behavior only when the disabled control must remain keyboard-discoverable, for example in a toolbar where the unavailable action teaches the user what may become available later.
+
+Do not use soft-disabled controls as a substitute for clear validation or permission messaging.
+
+## Review checklist
+
+- Can the flow be completed on a compact touch device?
+- Does the keyboard path match visual order?
+- Are focus, hover, pressed, disabled, selected, error, and loading states covered?
+- Are icon-only controls named?
+- Are disabled controls explained when the reason is not obvious?

--- a/docs/design/material-3/foundations/shape-elevation-motion.md
+++ b/docs/design/material-3/foundations/shape-elevation-motion.md
@@ -1,0 +1,67 @@
+# Shape, elevation, and motion
+
+Shape, elevation, and motion define hierarchy. In Mioframe they should clarify structure and state, not decorate the UI.
+
+## Shape
+
+Use Material shape tokens instead of arbitrary border radii.
+
+Common local roles:
+
+- `--md-sys-shape-corner-extra-small` — compact text field containers and small surfaces;
+- `--md-sys-shape-corner-small` — chips, small containers, compact cards;
+- `--md-sys-shape-corner-medium` — medium containers and menus;
+- `--md-sys-shape-corner-large` — larger panels and sheets;
+- `--md-sys-shape-corner-extra-large` — dialogs and prominent surfaces;
+- `--md-sys-shape-corner-full` — pills, buttons, FAB-like controls.
+
+Project rules:
+
+- Do not reduce rounded Material controls to square corners without an explicit product reason.
+- Use full shape for pill controls and primary action buttons when following M3 button patterns.
+- Use larger corners for modal or elevated surfaces than for dense inline controls.
+- Keep shape consistent inside a component family.
+
+## Elevation
+
+Elevation should communicate layering, temporary surfaces, and user focus.
+
+Use existing tokens:
+
+- `--md-sys-elevation-level0` — no elevation;
+- `--md-sys-elevation-level1` — subtle raised surface;
+- `--md-sys-elevation-level2` and above — temporary surfaces, menus, dialogs, overlays, or active drag/focus contexts.
+
+Project rules:
+
+- Prefer surface color hierarchy before adding shadows.
+- Do not add elevation to every card or list item.
+- Use elevation for overlays, menus, dialogs, floating actions, and active surfaces.
+- Avoid nested high-elevation surfaces.
+
+## Motion
+
+Motion should explain state changes and preserve orientation.
+
+Use existing tokens:
+
+- `--md-sys-motion-duration-short*` for small state changes;
+- `--md-sys-motion-duration-medium*` for component transitions;
+- `--md-sys-motion-duration-long*` only for large surface transitions;
+- `--md-sys-motion-easing-emphasized-*` for important spatial transitions;
+- `--md-sys-motion-easing-standard-*` for ordinary UI changes.
+
+Project rules:
+
+- Do not add decorative animation without user-task value.
+- Respect `prefers-reduced-motion` for non-essential motion.
+- Keep loading/progress animation deterministic and non-distracting.
+- Avoid motion that delays basic data entry or navigation.
+
+## Review checklist
+
+- Does shape communicate component type and hierarchy?
+- Is elevation used only where layering matters?
+- Does motion clarify the transition rather than distract?
+- Is reduced motion respected?
+- Are tokens used instead of raw values?

--- a/docs/design/material-3/foundations/tokens.md
+++ b/docs/design/material-3/foundations/tokens.md
@@ -1,0 +1,52 @@
+# Tokens
+
+Mioframe uses Material 3-style CSS custom properties as the design contract between global theme data and shared UI components.
+
+## Token layers
+
+### Reference tokens
+
+Reference tokens describe raw palette and typeface values. In Mioframe these are represented by variables such as:
+
+- `--md-ref-palette-primary40`
+- `--md-ref-palette-neutral98`
+- `--md-ref-typeface-plain`
+
+Do not use reference tokens directly in component styles unless the component is defining or remapping a system role.
+
+### System tokens
+
+System tokens describe semantic roles used across the app:
+
+- color: `--md-sys-color-primary`, `--md-sys-color-surface`, `--md-sys-color-on-surface`, `--md-sys-color-outline`;
+- shape: `--md-sys-shape-corner-small`, `--md-sys-shape-corner-large`, `--md-sys-shape-corner-full`;
+- elevation: `--md-sys-elevation-level0` to `--md-sys-elevation-level5`;
+- typography: `--md-sys-typescale-body-medium-*`, `--md-sys-typescale-title-medium-*`;
+- state: `--md-sys-state-hover-state-layer-opacity`, `--md-sys-state-focus-state-layer-opacity`, `--md-sys-state-pressed-state-layer-opacity`;
+- motion: `--md-sys-motion-duration-*`, `--md-sys-motion-easing-*`.
+
+Shared UI components should prefer system tokens.
+
+### Component tokens
+
+Component tokens customize a specific component surface or part, for example `--md-comp-progress-indicator-active-indicator-color`.
+
+Use component tokens when a style belongs to one component family and should not become a global semantic role.
+
+## Project rules
+
+- Keep tokens in `src/shared/lib/md/tokens.css` unless there is a clear reason to split by theme or platform.
+- Do not hardcode colors in components when a system color role exists.
+- Do not hardcode type sizes in components when a typescale token exists.
+- Do not introduce one-off CSS variables with vague names such as `--border-color` or `--main-bg` inside shared components.
+- Use `on-*` color roles with their matching background roles.
+- Use component tokens for component internals, not product-specific screen layout.
+- Dark theme overrides belong near the token definition, not inside individual components.
+
+## Review checklist
+
+- Does the component consume system/component tokens rather than raw palette values?
+- Are light and dark theme values covered?
+- Does the token name describe a semantic role rather than a visual accident?
+- Is the fallback useful for debugging?
+- Could the token be reused by another component without weakening its meaning?

--- a/docs/design/material-3/foundations/typography.md
+++ b/docs/design/material-3/foundations/typography.md
@@ -1,0 +1,56 @@
+# Typography
+
+Mioframe typography should use the Material 3 type scale as semantic UI roles. Do not choose font size only by visual preference.
+
+## Type scale roles
+
+### Display
+
+Use display styles rarely. They are for large marketing or onboarding moments, not dense application UI.
+
+### Headline
+
+Use headline styles for major page or pane titles when there is enough room and the title anchors the whole surface.
+
+### Title
+
+Use title styles for app bars, dialogs, cards, sheets, list section headers, and prominent form groups.
+
+### Body
+
+Use body styles for primary readable content, form help text, settings descriptions, dialog body text, and markdown content.
+
+### Label
+
+Use label styles for buttons, chips, compact metadata, navigation labels, field labels, and low-density control text.
+
+## Project usage
+
+- Prefer `body-medium` for normal application copy.
+- Prefer `body-small` for secondary metadata only when it remains readable on compact screens.
+- Prefer `title-medium` or `title-small` for dense app surfaces.
+- Use `label-large` for button text and high-emphasis control labels.
+- Avoid display styles in ordinary product screens.
+- Do not use typography to fake disabled, selected, or error states. Use state, color, and component rules.
+
+## Current implementation notes
+
+`src/shared/lib/md/tokens.css` defines Material 3 typescale token groups for display, headline, title, body, and label. Shared components should consume these tokens or expose a documented local mapping.
+
+## Compact UI rules
+
+Mioframe is mobile-first. On compact screens:
+
+- avoid reducing text below the existing type scale;
+- prefer wrapping over truncating when the user must understand the content;
+- use truncation only when the full value is still available through context or detail view;
+- avoid dense all-caps labels;
+- keep line height from the typescale to preserve touch readability.
+
+## Review checklist
+
+- Is the type role semantic and consistent with similar screens?
+- Does the text remain readable on compact screens?
+- Is wrapping behavior intentional?
+- Is truncation safe for the user task?
+- Are labels and helper text visually subordinate without becoming unreadable?

--- a/docs/design/material-3/project-rules/mioframe-ui-rules.md
+++ b/docs/design/material-3/project-rules/mioframe-ui-rules.md
@@ -1,0 +1,42 @@
+# Mioframe UI rules
+
+These rules adapt Material 3 to Mioframe's product constraints: local-first data work, compact/mobile parity, and custom Vue shared components.
+
+## Product principles
+
+- Mobile is not a reduced version of desktop. Compact screens must preserve the same core capabilities.
+- Prefer clear entry points over hidden branching inside dialogs.
+- Keep user data actions explicit, reversible where possible, and close to the affected content.
+- Use Material 3 component hierarchy to guide the user, not to decorate the screen.
+- Avoid adding new one-off UI primitives when a shared `MD*` component already exists.
+
+## Component usage
+
+- Shared components belong in `src/shared/ui`.
+- Material tokens belong in `src/shared/lib/md/tokens.css` unless a clear split is introduced.
+- Product widgets should not redefine Material component internals.
+- If a widget needs a reusable Material pattern, extract or improve a shared component first.
+
+## Copy and labeling
+
+- Button labels should describe the resulting action.
+- Empty states should explain what the user can do next.
+- Error messages should identify the failed operation and recovery path.
+- Avoid generic labels such as `OK` when a concrete action label is available.
+- Avoid implementation terms in user-facing copy unless the user must understand them.
+
+## Compact layout
+
+- Design and review first at compact width.
+- Avoid requiring hover-only discovery.
+- Wrap important content instead of truncating it.
+- Keep primary action reachable without excessive scrolling when practical.
+- Prefer bottom or inline actions only when they do not hide content or conflict with browser UI.
+
+## Deviation rule
+
+If a UI intentionally deviates from Material 3, document:
+
+- what guidance is being overridden;
+- why Mioframe needs the deviation;
+- whether it is a one-off exception or a reusable project rule.

--- a/docs/design/material-3/project-rules/review-checklist.md
+++ b/docs/design/material-3/project-rules/review-checklist.md
@@ -1,0 +1,71 @@
+# Material 3 UI review checklist
+
+Use this checklist for PRs that change visual UI, shared components, tokens, layout, or interaction states.
+
+## Scope
+
+- Which screen, widget, or shared component changed?
+- Is this a product-specific change or a reusable Material component change?
+- Does it touch `src/shared/lib/md/tokens.css` or `src/shared/ui`?
+- Should this documentation be updated with a new rule or exception?
+
+## Material hierarchy
+
+- Is there one clear primary action per action group?
+- Are secondary and low-emphasis actions visually lower than the primary action?
+- Are surface roles used before adding shadows or borders?
+- Are elevation and overlays used only where layering matters?
+- Are shape tokens consistent with the component family?
+
+## Tokens
+
+- Are colors, type, shape, elevation, state, and motion values taken from tokens?
+- Are matching `on-*` colors used with their container/background colors?
+- Are dark theme values inherited or covered?
+- Are component tokens used for component internals instead of vague local variables?
+
+## Typography and content
+
+- Is the type role semantic?
+- Does important text wrap instead of truncating unsafely?
+- Are labels action-oriented and specific?
+- Are helper, error, loading, and empty-state messages actionable?
+- Is implementation language hidden from users unless necessary?
+
+## Responsive behavior
+
+- Was the compact/mobile layout checked first?
+- Is the same core functionality available on compact and desktop layouts?
+- Are touch targets comfortable?
+- Is hover-only discovery avoided?
+- Do dialogs, menus, and tooltips fit within viewport constraints?
+
+## Accessibility
+
+- Do icon-only controls have accessible names?
+- Is keyboard focus visible and ordered logically?
+- Do dialogs and menus manage focus predictably?
+- Are errors connected to the relevant input or surface?
+- Is disabled state explained when the reason is not obvious?
+
+## Component states
+
+Check every applicable state:
+
+- enabled;
+- hover;
+- focus-visible;
+- pressed;
+- selected;
+- checked;
+- disabled;
+- error;
+- loading;
+- empty.
+
+## Testing expectations
+
+- Component contract tests should cover props, emits, state wiring, and accessible labels where practical.
+- Visual regression tests should cover important shared component variants and previously broken states.
+- E2E tests should cover user flows, focus behavior, overlays, storage prompts, and browser semantics.
+- Final gate remains `pnpm verify`.

--- a/docs/design/material-3/sources.md
+++ b/docs/design/material-3/sources.md
@@ -1,0 +1,74 @@
+# Material 3 source index
+
+Indexed on 2026-05-17.
+
+## Primary sources
+
+- Material Design 3: `https://m3.material.io/`
+- Material Web: `https://material-web.dev/`
+- Material Web components: `https://material-web.dev/components/`
+- Material Web theming: `https://material-web.dev/theming/`
+
+## Material Web pages used
+
+Material Web is the practical implementation reference for web component behavior, token names, theming hooks, and accessibility notes.
+
+- `https://material-web.dev/components/button/`
+- `https://material-web.dev/components/icon-button/`
+- `https://material-web.dev/components/fab/`
+- `https://material-web.dev/components/dialog/`
+- `https://material-web.dev/components/text-field/`
+- `https://material-web.dev/components/checkbox/`
+- `https://material-web.dev/components/chips/`
+- `https://material-web.dev/components/list/`
+- `https://material-web.dev/components/menu/`
+- `https://material-web.dev/components/tooltip/`
+- `https://material-web.dev/components/progress/`
+- `https://material-web.dev/components/tabs/`
+- `https://material-web.dev/theming/color/`
+- `https://material-web.dev/theming/typography/`
+- `https://material-web.dev/theming/shape/`
+
+## Material Design 3 pages to re-check when changing UI
+
+The official M3 site is the design source for intent and component usage. Some pages require JavaScript rendering, so do not rely on plain HTML scraping alone.
+
+- `https://m3.material.io/foundations`
+- `https://m3.material.io/styles/color`
+- `https://m3.material.io/styles/typography`
+- `https://m3.material.io/styles/shape`
+- `https://m3.material.io/styles/elevation`
+- `https://m3.material.io/styles/motion`
+- `https://m3.material.io/foundations/layout`
+- `https://m3.material.io/components/buttons`
+- `https://m3.material.io/components/icon-buttons`
+- `https://m3.material.io/components/floating-action-button`
+- `https://m3.material.io/components/dialogs`
+- `https://m3.material.io/components/text-fields`
+- `https://m3.material.io/components/checkbox`
+- `https://m3.material.io/components/chips`
+- `https://m3.material.io/components/lists`
+- `https://m3.material.io/components/menus`
+- `https://m3.material.io/components/tooltips`
+- `https://m3.material.io/components/progress-indicators`
+- `https://m3.material.io/components/tabs`
+
+## Local project sources
+
+- `src/shared/lib/md/tokens.css`
+- `src/shared/ui/Button/MDButton.vue`
+- `src/shared/ui/Button/MDIconButton.vue`
+- `src/shared/ui/Button/MDFab.vue`
+- `src/shared/ui/TextField/MDTextField.vue`
+- `src/shared/ui/Checkbox/MDCheckbox.vue`
+- `src/shared/ui/Chips/MDChip.vue`
+- `src/shared/ui/ProgressIndicators/MDCircularProgressIndicator.vue`
+- `src/shared/ui/Toolbar/MDToolbarContainer.vue`
+
+## Rules for future indexing
+
+- Prefer official Material Design and Material Web sources.
+- Keep local files concise and decision-oriented.
+- Link to source pages instead of copying large external sections.
+- For pages that require JavaScript rendering, use a browser-rendered capture or manual reading before updating project rules.
+- Record any unresolved mismatch between M3 guidance and current Mioframe implementation in the relevant markdown file.


### PR DESCRIPTION
## Summary

Adds a local Material 3 knowledge base for Mioframe UI work under `docs/design/material-3`.

The documentation is project-oriented rather than a copy of external docs. It covers:

- source index and indexing limitations;
- token layers and token usage rules;
- color, typography, shape, elevation, motion, layout, accessibility, and interaction states;
- component guidance for buttons, icon buttons, FAB, text fields, checkboxes, chips, dialogs, menus, tooltips, lists, navigation, progress, and feedback;
- Mioframe-specific UI rules;
- reusable Material 3 UI review checklist.

## Notes

- Primary references are Material Design 3 and Material Web.
- `m3.material.io` pages can require JavaScript rendering, so `sources.md` records this limitation and avoids treating plain HTML scraping as complete indexing.
- The content links to external sources instead of copying large external documentation sections.

## Verification

- Not run: documentation-only change created through GitHub API.