### PR TITLE
docs: add Material 3 foundation policies

### DIFF
--- a/.agents/skills/material3-guidelines/SKILL.md
+++ b/.agents/skills/material3-guidelines/SKILL.md
@@ -31,9 +31,15 @@ Use these policies as the project contract:
 - `docs/material-3/tokens.md`
 - `docs/material-3/baseline-theme.md`
 - `docs/material-3/component-tokens.md`
+- `docs/material-3/token-validation.md`
+- `docs/material-3/component-registry.md`
+- `docs/material-3/component-conversion-checklist.md`
 - `docs/material-3/interaction-states.md`
 - `docs/material-3/accessibility.md`
 - `docs/material-3/layout-adaptive.md`
+- `docs/material-3/density-spacing.md`
+- `docs/material-3/icons.md`
+- `docs/material-3/overlays.md`
 - `docs/material-3/shared-ui-api.md`
 - `docs/material-3/storybook.md`
 - `docs/material-3/verification.md`
@@ -65,6 +71,8 @@ Before the first production edit, identify:
 3. **Project fit**: whether existing project policies, FSD ownership, mobile-first constraints, privacy, accessibility, or performance requirements add stricter constraints.
 4. **Deviation**: any deliberate mismatch with Material 3, with the reason and blast radius.
 5. **Verification**: the focused Storybook, browser smoke, Playwright/e2e, visual regression, token/unit check, or accessibility-oriented check that proves the Material-relevant behavior.
+
+For shared UI component-family work, also update or consult `docs/material-3/component-registry.md` and use `docs/material-3/component-conversion-checklist.md` as the completion checklist.
 
 ## Output discipline
 

--- a/.agents/skills/material3-guidelines/SKILL.md
+++ b/.agents/skills/material3-guidelines/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: material3-guidelines
-description: 'Use this skill before planning or implementing UI/UX changes to verify component choice, layout, interaction behavior, accessibility, and visual states against the cached official Material 3 documentation from m3-docs-mcp.'
+description: 'Use this skill before planning or implementing UI/UX changes to verify component choice, layout, interaction behavior, accessibility, visual states, tokens, and public UI APIs against official Material 3 guidance and the project Material 3 policies.'
 ---
 
 # Material 3 guidelines
@@ -15,13 +15,33 @@ Use this skill when a task adds, removes, repositions, restyles, or changes the 
 - navigation, panes, dialogs, sheets, menus, forms, buttons, lists, cards, tabs, or toolbars;
 - layout, density, hierarchy, responsive/adaptive behavior, or visual states;
 - onboarding, empty states, loading states, error states, destructive flows, or input flows;
-- focus, keyboard, pointer, touch, accessibility semantics, affordances, or motion.
+- focus, keyboard, pointer, touch, accessibility semantics, affordances, or motion;
+- Material tokens, Material authoring units, component tokens, or public `MD*` component API names.
 
-Do not use this skill for non-UI-only changes, type-only edits, internal storage/service logic, formatting, comments, or mechanical renames unless they affect rendered behavior.
+Do not use this skill for non-UI-only changes, type-only edits, internal storage/service logic, formatting, comments, or mechanical renames unless they affect rendered behavior or public UI contracts.
+
+## Project policies
+
+Before planning or editing shared UI primitives, Material-style wrappers, Material tokens, Storybook documentation, or Material visual verification surfaces, read the relevant policy under `docs/material-3/`.
+
+Use these policies as the project contract:
+
+- `docs/material-3/source-of-truth.md`
+- `docs/material-3/units.md`
+- `docs/material-3/tokens.md`
+- `docs/material-3/baseline-theme.md`
+- `docs/material-3/component-tokens.md`
+- `docs/material-3/interaction-states.md`
+- `docs/material-3/accessibility.md`
+- `docs/material-3/layout-adaptive.md`
+- `docs/material-3/shared-ui-api.md`
+- `docs/material-3/storybook.md`
+- `docs/material-3/verification.md`
+- `docs/material-3/deviations.md`
 
 ## Source of truth
 
-Use the `material3` MCP server from https://github.com/Vyachean/m3-docs-mcp as the reliable lookup source for official Material 3 documentation.
+Use the `material3` MCP server from https://github.com/Vyachean/m3-docs-mcp as the primary lookup source for official Material 3 documentation.
 
 Prefer these MCP tools when available:
 
@@ -30,34 +50,38 @@ Prefer these MCP tools when available:
 3. `get_component_docs` for component-level guidance.
 4. `get_material_page` for exact cached pages referenced by search results.
 
-Do not treat direct fetches, generic web search, screenshots, older Material versions, library examples, or memory as reliable substitutes for the MCP cache. The official Material 3 site is a JavaScript app; direct agent access may miss or distort content.
+If the MCP server is unavailable or incomplete for the needed page, use the `Vyachean/m3-docs-cache` repository as the fallback readable snapshot of official `m3.material.io` content. Inspect `index.json` when using the fallback so failed or suspicious pages are not treated as reliable guidance.
 
-If the MCP server is unavailable, the cache is missing or stale, or the needed page is absent, state that explicitly and treat the UI/UX decision as an unresolved Material 3 verification risk. Do not claim Material 3 alignment without a successful MCP-backed check.
+Do not treat Material Web, direct fetches, generic web search, screenshots, older Material versions, unrelated libraries, or memory as reliable substitutes for official Material 3 guidance. Material Web is not the source of truth for this project.
+
+If both MCP and `m3-docs-cache` lack the needed guidance, state that explicitly and treat the UI/UX decision as an unresolved Material 3 verification risk. Do not claim Material 3 alignment without a successful official-doc-backed check.
 
 ## Required check
 
 Before the first production edit, identify:
 
-1. **Relevant Material surface**: the component, pattern, or layout guidance checked.
-2. **Decision impact**: what the guidance implies for component choice, placement, hierarchy, state, interaction, or accessibility.
-3. **Project fit**: whether existing project rules, FSD ownership, mobile-first constraints, privacy, or accessibility requirements add stricter constraints.
+1. **Relevant Material surface**: the component, pattern, foundation, token family, or layout guidance checked.
+2. **Decision impact**: what the guidance implies for component choice, placement, hierarchy, token names, API names, state, interaction, accessibility, or verification.
+3. **Project fit**: whether existing project policies, FSD ownership, mobile-first constraints, privacy, accessibility, or performance requirements add stricter constraints.
 4. **Deviation**: any deliberate mismatch with Material 3, with the reason and blast radius.
-5. **Verification**: the focused Storybook, browser smoke, Playwright/e2e, visual regression, or accessibility-oriented check that proves the Material-relevant behavior.
+5. **Verification**: the focused Storybook, browser smoke, Playwright/e2e, visual regression, token/unit check, or accessibility-oriented check that proves the Material-relevant behavior.
 
 ## Output discipline
 
 Keep the Material 3 note short. A useful note usually has:
 
 - checked docs or component pages;
+- relevant `docs/material-3/` policy files;
 - resulting implementation constraint;
 - unresolved risk or deviation, if any;
 - verification surface.
 
-For PR summaries or task handoff, name the checked Material 3 pages, components, or patterns. If no relevant guidance was found in the MCP cache, state that explicitly.
+For PR summaries or task handoff, name the checked Material 3 pages, components, foundations, or patterns. If no relevant guidance was found in MCP or fallback cache, state that explicitly.
 
 ## Anti-patterns
 
-- Do not use Material 3 as a visual-only style guide; interaction and UX guidance also apply.
-- Do not invent local component behavior when Material 3 defines a suitable component, pattern, or interaction rule.
-- Do not copy patterns from unrelated libraries, desktop-first products, or older Material versions without an MCP-backed Material 3 check.
-- Do not defer the Material 3 lookup until final review when it could change component choice, flow, layout, or verification.
+- Do not use Material 3 as a visual-only style guide; interaction, tokens, API names, accessibility, and UX guidance also apply.
+- Do not invent local component behavior when Material 3 defines a suitable component, pattern, token, or interaction rule.
+- Do not copy patterns from Material Web, unrelated libraries, desktop-first products, or older Material versions without an official Material 3 check.
+- Do not defer the Material 3 lookup until final review when it could change component choice, token design, flow, layout, or verification.
+- Do not add new public `--md-*` tokens or `MD*` component props that conflict with the policy docs without documenting a deviation.

--- a/docs/material-3/README.md
+++ b/docs/material-3/README.md
@@ -6,14 +6,29 @@ The policies apply before changing shared UI primitives, Material-style wrappers
 
 ## Policy set
 
+Foundation policies:
+
 - [Source of truth](./source-of-truth.md)
 - [Units](./units.md)
 - [Tokens](./tokens.md)
+- [Baseline theme](./baseline-theme.md)
 - [Component tokens](./component-tokens.md)
+- [Interaction states](./interaction-states.md)
+- [Accessibility](./accessibility.md)
+- [Layout and adaptive behavior](./layout-adaptive.md)
 - [Shared UI API](./shared-ui-api.md)
 - [Storybook](./storybook.md)
 - [Verification](./verification.md)
 - [Deviations](./deviations.md)
+
+Implementation policies:
+
+- [Component registry](./component-registry.md)
+- [Token validation](./token-validation.md)
+- [Iconography](./icons.md)
+- [Density and spacing](./density-spacing.md)
+- [Overlays](./overlays.md)
+- [Component conversion checklist](./component-conversion-checklist.md)
 - [Adoption plan](./adoption-plan.md)
 
 ## Goals
@@ -32,5 +47,6 @@ These policies are foundation documents. They do not require all existing code t
 
 1. Keep these policies small and reviewable.
 2. Audit existing tokens and shared UI APIs against the policies.
-3. Use Buttons as the first pilot component family after the foundation contract is accepted.
-4. Apply the same pattern to Lists, Dialogs, Text fields, selection controls, Navigation, App bars, Toolbars, and Sheets.
+3. Use [Component registry](./component-registry.md), [Token validation](./token-validation.md), and [Component conversion checklist](./component-conversion-checklist.md) for every component-family migration.
+4. Use Buttons as the first pilot component family after the foundation contract is accepted.
+5. Apply the same pattern to Lists, Dialogs, Text fields, selection controls, Navigation, App bars, Toolbars, and Sheets.

--- a/docs/material-3/README.md
+++ b/docs/material-3/README.md
@@ -1,0 +1,36 @@
+# Material 3 policies
+
+This directory defines the project contract for aligning the shared UI kit, Storybook documentation, and visual verification with the official Material 3 documentation.
+
+The policies apply before changing shared UI primitives, Material-style wrappers, user-visible component APIs, design tokens, Storybook documentation, Material interaction states, layout behavior, or visual verification surfaces.
+
+## Policy set
+
+- [Source of truth](./source-of-truth.md)
+- [Units](./units.md)
+- [Tokens](./tokens.md)
+- [Component tokens](./component-tokens.md)
+- [Shared UI API](./shared-ui-api.md)
+- [Storybook](./storybook.md)
+- [Verification](./verification.md)
+- [Deviations](./deviations.md)
+- [Adoption plan](./adoption-plan.md)
+
+## Goals
+
+1. Reading the official Material 3 documentation should explain how to use the project UI kit.
+2. Reading the project Storybook should feel like reading the relevant Material 3 component documentation for the components used by the app.
+3. Material-compatible names must be used for public `--md-*` tokens and public `MD*` component APIs.
+4. Project-specific UI must be documented as project-specific and must not masquerade as an official Material 3 component.
+5. Visual similarity alone is not enough. Tokens, units, API names, accessibility, interaction states, and adaptive behavior are part of Material 3 alignment.
+
+## Scope
+
+These policies are foundation documents. They do not require all existing code to be immediately compliant. New Material UI work and refactors that touch affected surfaces must move the touched area toward this contract and document any deliberate deviation.
+
+## Implementation order
+
+1. Keep these policies small and reviewable.
+2. Audit existing tokens and shared UI APIs against the policies.
+3. Use Buttons as the first pilot component family after the foundation contract is accepted.
+4. Apply the same pattern to Lists, Dialogs, Text fields, selection controls, Navigation, App bars, Toolbars, and Sheets.

--- a/docs/material-3/accessibility.md
+++ b/docs/material-3/accessibility.md
@@ -1,0 +1,46 @@
+# Material 3 accessibility
+
+## Principle
+
+Accessibility is part of Material 3 alignment and must be considered with component choice, tokens, states, API design, and layout behavior.
+
+A component that looks visually close to Material 3 but has incorrect names, focus behavior, keyboard behavior, target size, semantics, or contrast is not Material 3 aligned.
+
+## Baseline expectations
+
+Shared Material components must define or preserve:
+
+- accessible names for interactive controls;
+- keyboard activation and navigation where applicable;
+- focus-visible behavior;
+- correct disabled and readonly semantics;
+- minimum target areas required by official Material guidance;
+- contrast-safe color role pairings;
+- semantic roles only when native HTML semantics are insufficient;
+- modal focus handling for dialogs, sheets, and overlays;
+- screen-reader-visible state when the state is meaningful.
+
+## Native semantics first
+
+Prefer native HTML semantics when they match the component behavior. Add ARIA only when native semantics are insufficient or when Material guidance requires an additional accessible description.
+
+Do not add roles that conflict with the rendered element's native behavior.
+
+## Color and contrast
+
+Use Material color roles in their intended pairings. Do not remap color roles for visual effect when doing so can break contrast, dynamic color, or future contrast modes.
+
+## Target area
+
+Target area requirements belong to the component contract. Do not rely on consumers to add padding around undersized interactive controls.
+
+When Material docs define a minimum target area for a component or size, the component should enforce it internally or document an explicit deviation.
+
+## Verification
+
+Accessibility-sensitive changes require verification appropriate to the changed behavior:
+
+- keyboard smoke check for keyboard/focus changes;
+- browser smoke or Playwright check for modal focus traps and overlays;
+- Storybook documentation for accessible names and required props;
+- visual checks for focus indicators and state layers when appearance changes.

--- a/docs/material-3/adoption-plan.md
+++ b/docs/material-3/adoption-plan.md
@@ -38,7 +38,7 @@ Resolved foundation decisions:
 - Start with a tokenized Material baseline theme with mandatory light and dark schemes.
 - Future base palette customization must update reference/system tokens rather than component CSS.
 - Do not keep old shared UI APIs only for internal compatibility; update in-repository consumers in the same focused migration.
-- Overlay stack values do not need to be chosen in the policy phase, but overlay stacking ownership must be centralized during the overlay audit.
+- Overlay containment ownership already exists through `useOverlayContainer`, `TeleportContainer`, child teleported container registration, and outside-interaction containment. Preserve and reuse that model instead of introducing a numeric z-index ownership model by default.
 
 ## Phase 2: Foundation audit
 
@@ -48,7 +48,7 @@ Audit existing implementation against the policies:
 - PostCSS custom unit handling, including adding `sp` support before typography migration relies on it;
 - `MDState` and state layer primitives;
 - icon primitives and Material Symbols handling;
-- overlay primitives and stacking behavior;
+- overlay primitives: `useOverlayContainer`, `TeleportContainer`, teleported container registry, outside-interaction containment, escape/back stacking, focus trap behavior, and any remaining local z-index usage;
 - public `MD*` component props;
 - Storybook story hierarchy and coverage;
 - visual regression coverage.
@@ -59,7 +59,7 @@ The audit must produce:
 - a token inventory and validation plan;
 - a typography token migration from legacy `pt` to Material `sp`;
 - a baseline light/dark theme plan;
-- an overlay stack ownership plan;
+- an overlay containment review based on the existing shared overlay primitives, with focused follow-ups only for gaps;
 - a shared UI API migration list without compatibility-only aliases unless technically necessary;
 - a Storybook coverage plan;
 - a prioritized component-family conversion order.

--- a/docs/material-3/adoption-plan.md
+++ b/docs/material-3/adoption-plan.md
@@ -6,12 +6,22 @@ Adopt Material 3 incrementally through foundation-first, component-family work. 
 
 ## Phase 1: Policies
 
-Add and review the Material 3 foundation policies:
+Add and review the Material 3 foundation and implementation policies:
 
 - source of truth;
 - units;
 - tokens;
+- baseline theme;
 - component tokens;
+- token validation;
+- component registry;
+- component conversion checklist;
+- interaction states;
+- accessibility;
+- layout and adaptive behavior;
+- density and spacing;
+- iconography;
+- overlays;
 - shared UI API;
 - Storybook;
 - verification;
@@ -26,11 +36,19 @@ Audit existing implementation against the policies:
 - `src/shared/lib/md/tokens.css`;
 - PostCSS custom unit handling;
 - `MDState` and state layer primitives;
+- icon primitives and Material Symbols handling;
+- overlay primitives and stacking behavior;
 - public `MD*` component props;
 - Storybook story hierarchy and coverage;
 - visual regression coverage.
 
-The audit should produce a parity matrix before component conversion starts.
+The audit must produce:
+
+- an expanded component registry;
+- a token inventory and validation plan;
+- a shared UI API migration list;
+- a Storybook coverage plan;
+- a prioritized component-family conversion order.
 
 ## Phase 3: Buttons pilot
 
@@ -46,11 +64,16 @@ Pilot scope:
 The pilot must establish the practical pattern for:
 
 - component tokens;
+- token validation;
 - public prop naming;
+- icon handling;
+- density, spacing, and target area handling;
 - invalid Material combinations;
 - Storybook documentation;
 - visual regression surfaces;
 - documented deviations.
+
+Use [Component conversion checklist](./component-conversion-checklist.md) as the pilot completion gate.
 
 ## Phase 4: Core components
 
@@ -62,6 +85,8 @@ After the Buttons pilot is accepted, convert component families in dependency an
 4. Chips and menus;
 5. Navigation, app bars, toolbars, and sheets;
 6. Cards, progress indicators, tooltips, dividers, and project-specific surfaces.
+
+Every converted component family must update [Component registry](./component-registry.md) and document remaining deviations.
 
 ## Phase 5: Structure cleanup
 

--- a/docs/material-3/adoption-plan.md
+++ b/docs/material-3/adoption-plan.md
@@ -29,12 +29,23 @@ Add and review the Material 3 foundation and implementation policies:
 
 This phase should not reorganize shared UI source files or change component behavior.
 
+Resolved foundation decisions:
+
+- `sp` is the target Material typography authoring unit; existing Material typography `pt` usage is legacy and should be migrated during the foundation audit.
+- `dp` remains the target Material measurement authoring unit.
+- `--app-*` is the neutral namespace for app-specific CSS custom properties outside Material token vocabulary.
+- Canonical `--md-comp-*` tokens are defined at the component definition boundary.
+- Start with a tokenized Material baseline theme with mandatory light and dark schemes.
+- Future base palette customization must update reference/system tokens rather than component CSS.
+- Do not keep old shared UI APIs only for internal compatibility; update in-repository consumers in the same focused migration.
+- Overlay stack values do not need to be chosen in the policy phase, but overlay stacking ownership must be centralized during the overlay audit.
+
 ## Phase 2: Foundation audit
 
 Audit existing implementation against the policies:
 
 - `src/shared/lib/md/tokens.css`;
-- PostCSS custom unit handling;
+- PostCSS custom unit handling, including adding `sp` support before typography migration relies on it;
 - `MDState` and state layer primitives;
 - icon primitives and Material Symbols handling;
 - overlay primitives and stacking behavior;
@@ -46,7 +57,10 @@ The audit must produce:
 
 - an expanded component registry;
 - a token inventory and validation plan;
-- a shared UI API migration list;
+- a typography token migration from legacy `pt` to Material `sp`;
+- a baseline light/dark theme plan;
+- an overlay stack ownership plan;
+- a shared UI API migration list without compatibility-only aliases unless technically necessary;
 - a Storybook coverage plan;
 - a prioritized component-family conversion order.
 
@@ -63,7 +77,7 @@ Pilot scope:
 
 The pilot must establish the practical pattern for:
 
-- component tokens;
+- component tokens defined at the component boundary;
 - token validation;
 - public prop naming;
 - icon handling;

--- a/docs/material-3/adoption-plan.md
+++ b/docs/material-3/adoption-plan.md
@@ -1,0 +1,91 @@
+# Material 3 adoption plan
+
+## Principle
+
+Adopt Material 3 incrementally through foundation-first, component-family work. Do not perform broad visual rewrites without first defining the token, API, Storybook, verification, and deviation contract.
+
+## Phase 1: Policies
+
+Add and review the Material 3 foundation policies:
+
+- source of truth;
+- units;
+- tokens;
+- component tokens;
+- shared UI API;
+- Storybook;
+- verification;
+- deviations.
+
+This phase should not reorganize shared UI source files or change component behavior.
+
+## Phase 2: Foundation audit
+
+Audit existing implementation against the policies:
+
+- `src/shared/lib/md/tokens.css`;
+- PostCSS custom unit handling;
+- `MDState` and state layer primitives;
+- public `MD*` component props;
+- Storybook story hierarchy and coverage;
+- visual regression coverage.
+
+The audit should produce a parity matrix before component conversion starts.
+
+## Phase 3: Buttons pilot
+
+Use Buttons as the first component family because the current implementation already maps closely to the Material 3 button model.
+
+Pilot scope:
+
+- `MDButton`;
+- `MDIconButton`;
+- `MDFab` and related FAB helpers;
+- deprecated button compatibility exports.
+
+The pilot must establish the practical pattern for:
+
+- component tokens;
+- public prop naming;
+- invalid Material combinations;
+- Storybook documentation;
+- visual regression surfaces;
+- documented deviations.
+
+## Phase 4: Core components
+
+After the Buttons pilot is accepted, convert component families in dependency and usage order:
+
+1. Lists;
+2. Dialogs;
+3. Text fields and selection controls;
+4. Chips and menus;
+5. Navigation, app bars, toolbars, and sheets;
+6. Cards, progress indicators, tooltips, dividers, and project-specific surfaces.
+
+## Phase 5: Structure cleanup
+
+Only after the policies and pilot prove the pattern should the code structure be reorganized.
+
+Possible later structure:
+
+```text
+src/shared/lib/md/
+  index.css
+  units.css
+  tokens/
+    ref.css
+    sys.color.css
+    sys.typescale.css
+    sys.shape.css
+    sys.elevation.css
+    sys.motion.css
+    sys.state.css
+    comp/
+      button.css
+      icon-button.css
+      list.css
+      dialog.css
+```
+
+Do not perform this reorganization before the foundation audit unless a focused change requires it.

--- a/docs/material-3/baseline-theme.md
+++ b/docs/material-3/baseline-theme.md
@@ -4,6 +4,16 @@
 
 The Material baseline theme is the project foundation for shared UI tokens. Component work must not redefine baseline color, typography, shape, elevation, motion, or state decisions locally.
 
+## Theme model
+
+Start with a tokenized Material baseline theme.
+
+The theme must support both light and dark color schemes from the beginning. Components must consume theme roles through tokens and must not hardcode light-only or dark-only colors.
+
+Future work may add user customization of the base palette. The foundation must be structured so a generated or user-selected palette can update reference and system tokens without rewriting components.
+
+Dynamic or user-custom color is not required for the initial foundation implementation, but the token model must not block it.
+
 ## Foundation families
 
 The baseline theme policy covers:
@@ -20,9 +30,13 @@ The baseline theme policy covers:
 
 Color roles must be used according to their Material meaning and intended pairings. Components should use component tokens that point to system color roles rather than hardcoded palette values.
 
+The initial theme should define Material baseline light and dark schemes. Palette customization belongs above the token model and should update reference/system tokens rather than component CSS.
+
 ## Typography
 
 Typography values must be provided through `md.sys.typescale.*` tokens. Components should use typography tokens instead of local font-size, line-height, weight, or tracking values unless the official component spec defines a component-specific override.
+
+Typography authoring values use `sp` as defined in [Units](./units.md).
 
 ## Shape
 
@@ -52,5 +66,5 @@ Before broad component conversion, audit the existing baseline token file and cl
 - Material system token;
 - Material component token;
 - compatibility alias;
-- project-specific token that needs project namespace;
+- app-specific token that needs `--app-*` namespace;
 - obsolete token to remove.

--- a/docs/material-3/baseline-theme.md
+++ b/docs/material-3/baseline-theme.md
@@ -1,0 +1,56 @@
+# Material 3 baseline theme
+
+## Principle
+
+The Material baseline theme is the project foundation for shared UI tokens. Component work must not redefine baseline color, typography, shape, elevation, motion, or state decisions locally.
+
+## Foundation families
+
+The baseline theme policy covers:
+
+- color roles;
+- typography scale;
+- shape scale;
+- elevation levels;
+- motion tokens;
+- state tokens;
+- light and dark contexts.
+
+## Color roles
+
+Color roles must be used according to their Material meaning and intended pairings. Components should use component tokens that point to system color roles rather than hardcoded palette values.
+
+## Typography
+
+Typography values must be provided through `md.sys.typescale.*` tokens. Components should use typography tokens instead of local font-size, line-height, weight, or tracking values unless the official component spec defines a component-specific override.
+
+## Shape
+
+Shape values must come from Material shape tokens or component tokens that point to them. Do not invent local radii for Material components when Material provides a shape role or measurement.
+
+## Elevation
+
+Elevation should use Material elevation levels. Surface tint color is deprecated in current Material guidance and should not be introduced as a new dependency.
+
+## Motion
+
+Motion should use Material motion tokens or a documented newer Material motion model when the relevant guidance requires it. Do not add arbitrary transition durations or easing curves to shared Material components.
+
+## State tokens
+
+State layer opacity and focus indicator values belong to the foundation layer. Components should not redefine them locally unless the official component spec requires a component-specific value.
+
+## Contexts
+
+Theme contexts such as light and dark mode must be handled at the token level. Components should not hardcode light or dark colors.
+
+## Audit requirement
+
+Before broad component conversion, audit the existing baseline token file and classify each token as:
+
+- Material reference token;
+- Material system token;
+- Material component token;
+- compatibility alias;
+- project-specific token that needs project namespace;
+- obsolete token to remove.

--- a/docs/material-3/component-conversion-checklist.md
+++ b/docs/material-3/component-conversion-checklist.md
@@ -1,0 +1,74 @@
+# Material 3 component conversion checklist
+
+Use this checklist when converting or creating a shared Material component family.
+
+## 1. Source check
+
+- [ ] Checked the relevant Material 3 pages through `material3` MCP.
+- [ ] Used `Vyachean/m3-docs-cache` fallback only if MCP was unavailable or incomplete.
+- [ ] Recorded checked pages or cache paths in PR notes or Storybook docs.
+- [ ] Identified unresolved documentation gaps.
+
+## 2. Registry
+
+- [ ] Added or updated the row in [Component registry](./component-registry.md).
+- [ ] Classified the component status.
+- [ ] Identified related deprecated or compatibility components.
+- [ ] Identified project-specific behavior.
+
+## 3. Tokens
+
+- [ ] Audited existing `--md-*` tokens used by the component.
+- [ ] Classified local variables as public component tokens, private implementation variables, compatibility aliases, app-specific tokens, or obsolete tokens.
+- [ ] Added required `--md-comp-*` tokens.
+- [ ] Moved app-specific values to `--app-*` where needed.
+- [ ] Avoided raw hardcoded colors unless the official spec requires a direct value.
+
+## 4. Public API
+
+- [ ] Public props use Material vocabulary where possible.
+- [ ] Prop values use Material value names.
+- [ ] Native HTML behavior is not hidden behind Material terminology.
+- [ ] Invalid Material combinations are blocked or documented.
+- [ ] Deprecated prop aliases have a migration path.
+
+## 5. States and accessibility
+
+- [ ] Enabled, disabled, hover, focused, pressed, selected, dragged, and loading/progress states were considered as applicable.
+- [ ] State layers and focus indicators use shared state primitives where possible.
+- [ ] Accessible names and roles are correct.
+- [ ] Keyboard behavior is correct.
+- [ ] Target area requirements are satisfied or documented as deviations.
+- [ ] Contrast-safe Material color role pairings are preserved.
+
+## 6. Layout and adaptivity
+
+- [ ] Component measurements follow Material specs or documented deviations.
+- [ ] Compact, medium, and expanded behavior was considered when relevant.
+- [ ] Spacing and density decisions follow [Density and spacing](./density-spacing.md).
+- [ ] Overlay behavior follows [Overlays](./overlays.md) when applicable.
+
+## 7. Storybook
+
+- [ ] Story hierarchy uses `Material 3/Components/...` or `Project UI/...` appropriately.
+- [ ] Stories document variants, configurations, states, accessibility notes, tokens, and deviations as relevant.
+- [ ] Stories use public props and public tokens.
+- [ ] Stories are deterministic and fixture-driven.
+- [ ] Visual stories are tagged with `visual` only when intended for screenshots.
+
+## 8. Verification
+
+- [ ] Focused token/unit checks were run when tokens or units changed.
+- [ ] TypeScript or contract checks were run when public API changed.
+- [ ] Browser smoke checks were run when behavior, focus, keyboard, overlay, or accessibility changed.
+- [ ] Visual regression checks were run when visual output or Material states changed.
+- [ ] Final repository verification follows `AGENTS.md` requirements.
+
+## 9. Deviations
+
+- [ ] Unsupported official Material features are documented.
+- [ ] Project-specific extensions are documented.
+- [ ] Temporary compatibility behavior has a migration target.
+- [ ] Remaining risks are explicit and not hidden as completed alignment.
+
+A component family should not be marked aligned until this checklist is complete or every incomplete item is documented as a deviation, unsupported feature, or follow-up risk.

--- a/docs/material-3/component-registry.md
+++ b/docs/material-3/component-registry.md
@@ -12,8 +12,8 @@ The foundation audit must create or expand the actual registry. Do not fill regi
 
 Use this table shape:
 
-| Material surface | Project component | Status | Material docs | Tokens | API | Storybook | Visual tests | Deviations |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Material surface     | Project component     | Status     | Material docs     | Tokens             | API                | Storybook       | Visual tests    | Deviations    |
+| -------------------- | --------------------- | ---------- | ----------------- | ------------------ | ------------------ | --------------- | --------------- | ------------- |
 | `<official surface>` | `<project component>` | `<status>` | `<checked pages>` | `<status/details>` | `<status/details>` | `<path/status>` | `<path/status>` | `<none/link>` |
 
 ## Status values

--- a/docs/material-3/component-registry.md
+++ b/docs/material-3/component-registry.md
@@ -1,0 +1,57 @@
+# Material 3 component registry
+
+## Principle
+
+The shared UI kit must be tracked as a registry that maps official Material 3 surfaces to project components, Storybook pages, tokens, verification, and deviations.
+
+Do not migrate components only by local inspection. Use the registry to keep the UI kit coherent and to avoid duplicating or partially reimplementing the same Material surface in multiple places.
+
+## Registry table
+
+Maintain the registry as the source of planning truth for Material component conversion.
+
+| Material surface | Project component | Status | Material docs | Tokens | API | Storybook | Visual tests | Deviations |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Buttons | `MDButton` | partial | `components/buttons/*` | partial | partial | missing/partial | missing/partial | TBD |
+| Icon buttons | `MDIconButton` | partial | `components/icon-buttons/*` | partial | partial | missing/partial | missing/partial | TBD |
+| FAB | `MDFab` | partial | `components/floating-action-button/*` | partial | partial | partial | partial | TBD |
+| Lists | `MDList`, `MDListItem` | partial | `components/lists/*` | partial | partial | missing | missing | TBD |
+| Dialogs | `MDDialog` | partial | `components/dialogs/*` | partial | partial | missing | missing | TBD |
+
+This initial table is intentionally incomplete. The foundation audit must expand it before broad component conversion.
+
+## Status values
+
+Use these status values consistently:
+
+- `missing`: no project component exists;
+- `partial`: project component exists but is not fully aligned or verified;
+- `aligned`: component has docs-backed API, tokens, Storybook, verification, and documented deviations;
+- `project-specific`: component is not an official Material component but uses Material foundations;
+- `deprecated`: component remains only as a compatibility surface;
+- `blocked`: Material guidance is missing, conflicting, or unavailable.
+
+## Required fields
+
+Each registry row should answer:
+
+1. Which official Material surface does this correspond to?
+2. Which project component or components implement it?
+3. Which Material pages were checked?
+4. Which public tokens are supported?
+5. Which public props are supported?
+6. Which Storybook page documents it?
+7. Which visual or browser checks cover it?
+8. Which deviations or unsupported official features exist?
+
+## Usage
+
+Before starting a component family conversion:
+
+1. update or add the registry row;
+2. identify the Material docs to check;
+3. identify existing project components and deprecated aliases;
+4. decide whether the component is official Material-aligned or project-specific;
+5. define the verification target.
+
+A component family is not done until the registry row can be marked `aligned` or its remaining gaps are explicitly documented.

--- a/docs/material-3/component-registry.md
+++ b/docs/material-3/component-registry.md
@@ -6,19 +6,15 @@ The shared UI kit must be tracked as a registry that maps official Material 3 su
 
 Do not migrate components only by local inspection. Use the registry to keep the UI kit coherent and to avoid duplicating or partially reimplementing the same Material surface in multiple places.
 
-## Registry table
+## Registry template
 
-Maintain the registry as the source of planning truth for Material component conversion.
+The foundation audit must create or expand the actual registry. Do not fill registry rows with guessed statuses.
+
+Use this table shape:
 
 | Material surface | Project component | Status | Material docs | Tokens | API | Storybook | Visual tests | Deviations |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Buttons | `MDButton` | partial | `components/buttons/*` | partial | partial | missing/partial | missing/partial | TBD |
-| Icon buttons | `MDIconButton` | partial | `components/icon-buttons/*` | partial | partial | missing/partial | missing/partial | TBD |
-| FAB | `MDFab` | partial | `components/floating-action-button/*` | partial | partial | partial | partial | TBD |
-| Lists | `MDList`, `MDListItem` | partial | `components/lists/*` | partial | partial | missing | missing | TBD |
-| Dialogs | `MDDialog` | partial | `components/dialogs/*` | partial | partial | missing | missing | TBD |
-
-This initial table is intentionally incomplete. The foundation audit must expand it before broad component conversion.
+| `<official surface>` | `<project component>` | `<status>` | `<checked pages>` | `<status/details>` | `<status/details>` | `<path/status>` | `<path/status>` | `<none/link>` |
 
 ## Status values
 

--- a/docs/material-3/component-tokens.md
+++ b/docs/material-3/component-tokens.md
@@ -6,6 +6,16 @@ Material shared UI components must expose a Material-compatible component token 
 
 Component tokens describe parts of a component and state-specific styling, such as container color, label text color, icon size, outline color, state layer opacity, container height, and container shape.
 
+## Ownership
+
+Define `--md-comp-*` tokens at the component definition boundary.
+
+A component family owns its own component tokens. For example, button component tokens should be defined with the Button family rather than in unrelated consumers or screen-level CSS.
+
+The foundation layer may provide shared reference and system tokens. It should not become a dumping ground for every component token unless a later structure cleanup intentionally extracts component token files under `src/shared/lib/md/tokens/comp/`.
+
+Consumers may override public component tokens, but they must not define the canonical token contract for a shared Material component.
+
 ## Naming
 
 Map Material token names to CSS custom properties mechanically:
@@ -28,7 +38,7 @@ Examples:
 
 When official Material 3 component specs list component tokens, use those names and meanings.
 
-When the official docs describe a component measurement or role but the exact token is missing from the cache, define the closest Material-compatible `--md-comp-*` token and document the mapping in the component policy or Storybook docs.
+When the official docs describe a component measurement or role but the exact token is missing from the cache, define the closest Material-compatible `--md-comp-*` token at the component definition boundary and document the mapping in the component policy or Storybook docs.
 
 Do not invent local `--md-comp-*` tokens for app-specific behavior. Use the neutral `--app-*` namespace for app-specific extensions.
 

--- a/docs/material-3/component-tokens.md
+++ b/docs/material-3/component-tokens.md
@@ -18,11 +18,11 @@ Consumers may override public component tokens, but they must not define the can
 
 ## Naming
 
-Map Material token names to CSS custom properties mechanically:
+Map Material token names to CSS custom properties mechanically. The variant or style segment is optional because some tokens apply to the component generally rather than to a specific variant.
 
 ```text
-md.comp.<component>.<variant-or-style>.<element>.<property>
---md-comp-<component>-<variant-or-style>-<element>-<property>
+md.comp.<component>.[variant-or-style].<element>.<property>
+--md-comp-<component>-[variant-or-style]-<element>-<property>
 ```
 
 Examples:

--- a/docs/material-3/component-tokens.md
+++ b/docs/material-3/component-tokens.md
@@ -1,0 +1,72 @@
+# Material 3 component tokens
+
+## Principle
+
+Material shared UI components must expose a Material-compatible component token layer before relying on local implementation variables.
+
+Component tokens describe parts of a component and state-specific styling, such as container color, label text color, icon size, outline color, state layer opacity, container height, and container shape.
+
+## Naming
+
+Map Material token names to CSS custom properties mechanically:
+
+```text
+md.comp.<component>.<variant-or-style>.<element>.<property>
+--md-comp-<component>-<variant-or-style>-<element>-<property>
+```
+
+Examples:
+
+```css
+--md-comp-button-filled-container-color: var(--md-sys-color-primary);
+--md-comp-button-filled-label-text-color: var(--md-sys-color-on-primary);
+--md-comp-button-container-height: 40dp;
+--md-comp-button-container-shape: var(--md-sys-shape-corner-full);
+```
+
+## Component token sources
+
+When official Material 3 component specs list component tokens, use those names and meanings.
+
+When the official docs describe a component measurement or role but the exact token is missing from the cache, define the closest Material-compatible `--md-comp-*` token and document the mapping in the component policy or Storybook docs.
+
+Do not invent local `--md-comp-*` tokens for project-specific behavior. Use a project namespace for project-specific extensions.
+
+## Relationship to system tokens
+
+Component tokens should point to system tokens whenever possible.
+
+Preferred:
+
+```css
+--md-comp-button-filled-container-color: var(--md-sys-color-primary);
+```
+
+Avoid:
+
+```css
+--md-comp-button-filled-container-color: #6750a4;
+```
+
+Hardcoded values are acceptable only when the official component spec defines a direct measurement such as `40dp`, `12dp`, or `0dp`.
+
+## Local implementation variables
+
+Local component variables are allowed only as private implementation details. They should not become the public styling contract when a Material component token exists or can be derived from the official docs.
+
+If a local variable is kept for readability, it should reference the public component token rather than bypass it.
+
+## Override contract
+
+The supported customization surface for shared Material components is:
+
+1. `--md-ref-*` when changing raw reference values;
+2. `--md-sys-*` when changing theme roles;
+3. `--md-comp-*` when changing a component part or state;
+4. project namespaced tokens for project-only behavior.
+
+Consumers should not depend on private class names or private local component variables for styling.
+
+## Pilot requirement
+
+The first converted component family should define this pattern end-to-end before the pattern is applied widely. Buttons are the preferred pilot because the current API already maps closely to the Material 3 button model.

--- a/docs/material-3/component-tokens.md
+++ b/docs/material-3/component-tokens.md
@@ -30,7 +30,7 @@ When official Material 3 component specs list component tokens, use those names 
 
 When the official docs describe a component measurement or role but the exact token is missing from the cache, define the closest Material-compatible `--md-comp-*` token and document the mapping in the component policy or Storybook docs.
 
-Do not invent local `--md-comp-*` tokens for project-specific behavior. Use a project namespace for project-specific extensions.
+Do not invent local `--md-comp-*` tokens for app-specific behavior. Use the neutral `--app-*` namespace for app-specific extensions.
 
 ## Relationship to system tokens
 
@@ -63,7 +63,7 @@ The supported customization surface for shared Material components is:
 1. `--md-ref-*` when changing raw reference values;
 2. `--md-sys-*` when changing theme roles;
 3. `--md-comp-*` when changing a component part or state;
-4. project namespaced tokens for project-only behavior.
+4. `--app-*` for app-specific behavior that is not part of the Material token model.
 
 Consumers should not depend on private class names or private local component variables for styling.
 

--- a/docs/material-3/density-spacing.md
+++ b/docs/material-3/density-spacing.md
@@ -1,0 +1,43 @@
+# Material 3 density and spacing
+
+## Principle
+
+Density, spacing, and target areas are foundation decisions. Shared Material components must not invent local spacing systems when official Material guidance defines measurements, target areas, or density expectations.
+
+## Units
+
+Use the units shown by the official Material 3 documentation as authoring units. Translation into CSS-supported values is handled by the PostCSS unit pipeline described in [Units](./units.md).
+
+## Spacing sources
+
+Use spacing in this order:
+
+1. exact Material component spec measurements;
+2. Material layout guidance for panes, canonical layouts, and adaptive surfaces;
+3. project spacing helpers such as `step` only when no exact Material value applies or when composing app-specific layout around Material components;
+4. documented deviation when neither Material nor project spacing rules fit.
+
+## Density
+
+Density changes must be deliberate. Do not shrink Material components or touch targets to fit more content unless official Material guidance supports the density or a deviation is documented.
+
+For compact surfaces, first check Material compact, medium, and expanded guidance before changing component internals.
+
+## Target areas
+
+Interactive controls must satisfy Material and accessibility target area requirements. Components should own their target area rather than requiring consumers to add surrounding padding.
+
+When visual size and target size differ, document the distinction in Storybook and verify it in browser behavior when relevant.
+
+## App-specific spacing
+
+Use `--app-*` tokens for app-specific spacing that is not a Material token. Do not encode app-specific spacing as `--md-*`.
+
+## Verification
+
+Spacing or density changes should be verified by:
+
+- inspecting the checked Material docs or component specs;
+- Storybook surfaces for affected components;
+- responsive/browser smoke checks when layout behavior changes;
+- visual regression tests for shared primitives or high-risk surfaces.

--- a/docs/material-3/deviations.md
+++ b/docs/material-3/deviations.md
@@ -1,0 +1,44 @@
+# Material 3 deviations
+
+## Principle
+
+A deviation is any project behavior, naming, token, layout, state, or component pattern that intentionally differs from the checked official Material 3 guidance.
+
+Deviations are allowed only when they are explicit, justified, and documented. Undocumented drift is not a deviation; it is technical debt or an unresolved verification risk.
+
+## When to document a deviation
+
+Document a deviation when:
+
+- the project supports a component variant not described by Material 3;
+- the project omits an official Material 3 variant that users of the UI kit might expect;
+- a prop or token cannot use the official Material term;
+- a project-specific component uses Material tokens or states but is not an official Material component;
+- a Material guideline cannot be followed because of platform, product, accessibility, privacy, or implementation constraints;
+- the official docs are unavailable or incomplete for the touched surface.
+
+## Deviation record format
+
+Use this format in the relevant component docs, Storybook notes, or a future deviation registry:
+
+```text
+Surface: <component, token family, layout, or pattern>
+Material guidance: <checked page/cache path>
+Project behavior: <what the project does>
+Reason: <why the project differs>
+Blast radius: <where it affects users or developers>
+Verification: <how the behavior is checked>
+Review date: <date or milestone for revisiting>
+```
+
+## Project-specific UI
+
+Project-specific components must be documented under `Project UI` in Storybook or equivalent docs. They may use Material foundations such as tokens, state layers, typography, and shape, but they must not be presented as official Material components.
+
+## Unsupported official features
+
+If the project intentionally supports only a subset of an official Material component, document the unsupported features. The public API should not accept unsupported values unless they are compatibility aliases with a migration plan.
+
+## Temporary deviations
+
+Temporary deviations should include a migration target. Do not create permanent compatibility aliases without documenting why they must remain.

--- a/docs/material-3/icons.md
+++ b/docs/material-3/icons.md
@@ -1,0 +1,54 @@
+# Material 3 iconography
+
+## Principle
+
+Icons in shared Material UI must follow official Material 3 icon guidance and component specs. Icon behavior is part of the component contract, not an arbitrary slot detail.
+
+## Source
+
+Use official Material 3 documentation through MCP or `m3-docs-cache` fallback for component-specific icon usage. Component specs override generic icon preferences when they define size, placement, selected state, or accessibility behavior.
+
+## Icon system
+
+Use the project Material icon primitive for Material Symbols unless a component or product requirement needs a custom icon.
+
+When using Material Symbols, keep these concerns explicit:
+
+- icon name;
+- size;
+- fill;
+- weight;
+- grade;
+- optical size;
+- selected/unselected state;
+- accessible name or decorative status.
+
+## Component usage
+
+Component-specific icon rules must follow the relevant Material component docs.
+
+Examples:
+
+- button icons should use the component-defined leading or trailing placement rules;
+- toggle components should define selected and unselected icon behavior when Material guidance requires different icon styles;
+- navigation icons should expose selected state clearly;
+- list icons and avatars should match the list item layout and density rules.
+
+## Accessibility
+
+Icons are decorative when the surrounding component has a sufficient accessible name. Icons are semantic when they are the only visible label or communicate required state.
+
+Semantic icon-only controls must require or derive an accessible name. Do not rely on the icon glyph name as the user-facing accessible label unless it is intentionally stable and understandable.
+
+## Custom icons
+
+Custom SVG or non-Material icons are allowed only when:
+
+- Material Symbols does not provide an appropriate icon;
+- the icon represents a product-specific concept;
+- the icon is documented as project-specific;
+- sizing, color, selected state, and accessibility still follow Material component guidance.
+
+## Verification
+
+Icon changes should be verified through Storybook or browser smoke checks when they affect size, alignment, state, accessibility, or visual output. For shared visual primitives, include the affected icon states in visual regression coverage.

--- a/docs/material-3/interaction-states.md
+++ b/docs/material-3/interaction-states.md
@@ -1,0 +1,42 @@
+# Material 3 interaction states
+
+## Principle
+
+Material interaction states must be implemented consistently through shared state primitives instead of ad hoc per-component hover, focus, pressed, or dragged logic.
+
+The state model is part of Material 3 alignment. Visual similarity without correct state behavior is incomplete.
+
+## State vocabulary
+
+Use Material state names for public documentation and shared implementation concepts:
+
+- enabled;
+- disabled;
+- hover;
+- focused;
+- pressed;
+- dragged;
+- selected when a component supports selection;
+- loading or progress when the component explicitly communicates work in progress.
+
+## Shared state foundation
+
+Shared Material components should use the project state foundation, such as `MDState`, state layers, focus handling, pressed handling, and last-hover handling, unless there is a documented reason not to.
+
+Components must not bypass shared state primitives with local hover or focus implementations when the shared primitive can represent the state correctly.
+
+## Combined states
+
+States can combine, such as selected + hover or disabled + selected. Component APIs, tokens, and visual documentation should make combined states explicit when they affect behavior or appearance.
+
+## Focus
+
+Focus behavior must be real browser behavior, not only visual styling. Keyboard focus, focus-visible behavior, and accessibility semantics must be verified in a browser surface when changed.
+
+## Ripple and state layers
+
+State layers and ripple behavior should be applied consistently with Material guidance and component specs. Disabling ripple or state layers requires a documented reason.
+
+## Verification
+
+Interaction state changes require browser-based verification. Use Storybook as the preferred isolated surface and Playwright screenshots for visual state regressions when appearance changes.

--- a/docs/material-3/layout-adaptive.md
+++ b/docs/material-3/layout-adaptive.md
@@ -1,0 +1,52 @@
+# Material 3 layout and adaptive behavior
+
+## Principle
+
+Material layout behavior is a foundation concern. Component and screen work should use the official Material 3 layout, adaptive, and canonical layout guidance where it applies.
+
+Do not treat desktop layout, hover input, or precise pointer input as the default. The project remains mobile-first while still supporting larger screens through adaptive Material patterns.
+
+## Adaptive vocabulary
+
+Use Material layout vocabulary in docs and APIs when applicable:
+
+- compact;
+- medium;
+- expanded;
+- pane;
+- list-detail;
+- supporting pane;
+- feed;
+- navigation bar;
+- navigation rail;
+- navigation drawer;
+- sheet;
+- app bar;
+- toolbar.
+
+## Canonical layouts
+
+Use canonical layouts as starting points for app-level organization when they match the product flow:
+
+- list-detail for explorable lists with item detail;
+- supporting pane for primary content with secondary supporting content;
+- feed for browsable content grids or streams.
+
+Do not invent a custom screen structure when a canonical Material layout fits the problem.
+
+## Component-level adaptivity
+
+Components that change behavior across viewport classes must document:
+
+- the relevant Material guidance;
+- the breakpoints or container conditions used by the project;
+- the behavioral difference between compact, medium, and expanded contexts;
+- the Storybook or browser surface used to verify the behavior.
+
+## Navigation surfaces
+
+Navigation bar, navigation rail, and navigation drawer choices should follow Material adaptive guidance and product information architecture. Do not choose a navigation surface by visual preference alone.
+
+## Verification
+
+Adaptive layout changes need browser verification at the affected sizes. Prefer deterministic Storybook surfaces for shared UI and focused Playwright screenshots when the visual layout is the invariant.

--- a/docs/material-3/overlays.md
+++ b/docs/material-3/overlays.md
@@ -2,7 +2,7 @@
 
 ## Principle
 
-Dialogs, sheets, menus, tooltips, snackbars, and other overlay-like surfaces must follow a shared overlay contract. Overlay behavior must not be reinvented independently for each component family.
+Dialogs, sheets, menus, tooltips, snackbars, and other overlay-like surfaces must follow the existing shared overlay contract. Overlay behavior must not be reinvented independently for each component family.
 
 ## Covered surfaces
 
@@ -18,6 +18,17 @@ This policy applies to:
 - scrims;
 - any future modal or transient surface.
 
+## Existing ownership model
+
+The project already owns overlay containment through shared primitives:
+
+- `useOverlayContainer` resolves the nearest provided overlay container and falls back to the current Vue app root or `document.body`.
+- `TeleportContainer` teleports overlay content into that container and registers the teleported container.
+- `useChildTeleportContainerStack` tracks child teleported containers and propagates them through parent stacks.
+- `onInteractionOutside` treats the target, ignored elements, and registered child teleported containers as inside the same interaction boundary.
+
+New overlay-like Material components should use this existing ownership model instead of introducing unrelated teleport roots, ad hoc document-level containment, or independent outside-click logic.
+
 ## Shared concerns
 
 Every overlay-like surface must explicitly define:
@@ -31,9 +42,9 @@ Every overlay-like surface must explicitly define:
 - scroll locking;
 - scrim usage;
 - elevation level;
-- z-index or stacking ownership;
-- teleport/container strategy;
-- nested overlay behavior;
+- teleport/container strategy through the shared overlay primitives;
+- nested overlay behavior through the teleported container stack;
+- z-index only when the shared overlay/container model is insufficient by itself;
 - accessibility name, role, and description.
 
 ## Material source
@@ -42,18 +53,16 @@ Use the relevant official Material component docs before changing overlay behavi
 
 If Material guidance is incomplete for a shared overlay concern, document the project decision as a local overlay policy or deviation.
 
-## Stacking ownership
+## Stacking and containment
 
-The risk is not the absence of final numeric `z-index` values in this policy. The risk is letting dialogs, sheets, menus, tooltips, and future overlays assign unrelated local stacking values that later conflict.
+The primary project rule is containment ownership, not a global numeric z-index table.
 
-At this stage, the contract is ownership:
+Prefer the existing overlay container and teleport registry for ordering and interaction containment. Component-local z-index values are allowed only when a component needs an internal visual layer, such as a scrim behind its own surface or a menu above its own container. Do not use local z-index values to create a second overlay ownership model.
 
-- overlay stacking must be centralized enough to keep overlay surfaces ordered predictably;
-- component-local z-index values are allowed only when they reference the shared overlay stack or document why the surface is outside that stack;
-- the concrete stack scale should be defined during the overlay foundation audit, after existing overlay components and teleport targets are inspected.
+When changing dialogs, sheets, menus, tooltips, or snackbars, inspect their use of `useOverlayContainer`, `TeleportContainer`, child teleport registration, escape/back stacking, focus trap behavior, and outside interaction handling before adding new primitives.
 
-Do not add component-local z-index values without checking the existing overlay stack and documenting the intended layer.
+If future overlay work proves that numeric stacking conflicts remain, introduce a shared overlay-layer token or helper as a focused follow-up. Do not preemptively replace the existing ownership model.
 
 ## Verification
 
-Overlay changes require browser-based verification when behavior changes. Use Storybook for isolated surfaces where possible, and Playwright/browser smoke checks for focus, keyboard, scrim, outside click, scroll lock, and responsive behavior.
+Overlay changes require browser-based verification when behavior changes. Use Storybook for isolated surfaces where possible, and Playwright/browser smoke checks for focus, keyboard, scrim, outside click, scroll lock, nested teleports, and responsive behavior.

--- a/docs/material-3/overlays.md
+++ b/docs/material-3/overlays.md
@@ -31,7 +31,7 @@ Every overlay-like surface must explicitly define:
 - scroll locking;
 - scrim usage;
 - elevation level;
-- z-index or stacking order;
+- z-index or stacking ownership;
 - teleport/container strategy;
 - nested overlay behavior;
 - accessibility name, role, and description.
@@ -42,9 +42,15 @@ Use the relevant official Material component docs before changing overlay behavi
 
 If Material guidance is incomplete for a shared overlay concern, document the project decision as a local overlay policy or deviation.
 
-## Stacking
+## Stacking ownership
 
-Stacking must be centralized enough to prevent dialogs, sheets, menus, and tooltips from competing with unrelated z-index values.
+The risk is not the absence of final numeric `z-index` values in this policy. The risk is letting dialogs, sheets, menus, tooltips, and future overlays assign unrelated local stacking values that later conflict.
+
+At this stage, the contract is ownership:
+
+- overlay stacking must be centralized enough to keep overlay surfaces ordered predictably;
+- component-local z-index values are allowed only when they reference the shared overlay stack or document why the surface is outside that stack;
+- the concrete stack scale should be defined during the overlay foundation audit, after existing overlay components and teleport targets are inspected.
 
 Do not add component-local z-index values without checking the existing overlay stack and documenting the intended layer.
 

--- a/docs/material-3/overlays.md
+++ b/docs/material-3/overlays.md
@@ -1,0 +1,53 @@
+# Material 3 overlays
+
+## Principle
+
+Dialogs, sheets, menus, tooltips, snackbars, and other overlay-like surfaces must follow a shared overlay contract. Overlay behavior must not be reinvented independently for each component family.
+
+## Covered surfaces
+
+This policy applies to:
+
+- dialogs;
+- full-screen dialogs;
+- bottom sheets;
+- side sheets;
+- menus;
+- tooltips;
+- snackbars;
+- scrims;
+- any future modal or transient surface.
+
+## Shared concerns
+
+Every overlay-like surface must explicitly define:
+
+- modal or non-modal behavior;
+- focus entry and restoration;
+- focus trap behavior when modal;
+- escape key behavior;
+- browser back behavior when applicable;
+- outside click or outside tap behavior;
+- scroll locking;
+- scrim usage;
+- elevation level;
+- z-index or stacking order;
+- teleport/container strategy;
+- nested overlay behavior;
+- accessibility name, role, and description.
+
+## Material source
+
+Use the relevant official Material component docs before changing overlay behavior. When a component-specific doc exists, it overrides generic overlay preferences.
+
+If Material guidance is incomplete for a shared overlay concern, document the project decision as a local overlay policy or deviation.
+
+## Stacking
+
+Stacking must be centralized enough to prevent dialogs, sheets, menus, and tooltips from competing with unrelated z-index values.
+
+Do not add component-local z-index values without checking the existing overlay stack and documenting the intended layer.
+
+## Verification
+
+Overlay changes require browser-based verification when behavior changes. Use Storybook for isolated surfaces where possible, and Playwright/browser smoke checks for focus, keyboard, scrim, outside click, scroll lock, and responsive behavior.

--- a/docs/material-3/shared-ui-api.md
+++ b/docs/material-3/shared-ui-api.md
@@ -44,12 +44,17 @@ Project-specific components may use project vocabulary, but they must not be doc
 
 When a project-specific component uses Material tokens or states, document the Material foundations it uses and the project-specific behavior it adds.
 
-## Deprecation
+## API migrations
 
-When renaming an existing public prop toward Material vocabulary:
+Do not keep old shared UI APIs only for compatibility with previous internal usage. When a Material-aligned API rename is needed, update all in-repository consumers in the same focused migration.
 
-1. introduce the Material-compatible prop;
-2. keep the old prop as a temporary compatibility alias when practical;
-3. prefer one canonical path in new code;
-4. document the migration in the component Storybook page;
-5. remove the compatibility alias in a focused cleanup after consumers migrate.
+Compatibility aliases are allowed only when an immediate full migration is technically unsafe or would make the change too broad to review. Such aliases must be documented as temporary deviations with a removal target.
+
+Preferred migration flow:
+
+1. identify the Material-compatible API;
+2. update the component implementation;
+3. update all project consumers;
+4. update Storybook and visual surfaces;
+5. remove obsolete props, emits, slots, and token names;
+6. document any remaining temporary compatibility surface as a deviation.

--- a/docs/material-3/shared-ui-api.md
+++ b/docs/material-3/shared-ui-api.md
@@ -17,16 +17,16 @@ A developer should be able to read the official Material 3 documentation and pre
 
 ## Preferred prop vocabulary
 
-| Material concept | Preferred prop name | Notes |
-| --- | --- | --- |
-| Variant | `variant` | Example: `default`, `toggle` when the docs describe variants. |
-| Color style | `colorStyle` | Example: `elevated`, `filled`, `tonal`, `outlined`, `text`. |
-| Size | `size` | Use Material size names. |
-| Shape | `shape` | Use Material shape names. |
-| Selection state | `selected` | For toggle/selection-capable components. |
-| Disabled state | `disabled` | Native disabled semantics where supported. |
-| Loading/progress state | `loading` or `progress` | Prefer progress when numeric progress is the main contract. |
-| Native button type | `nativeType` or `htmlType` | Do not call this `variant` or `formAction`. |
+| Material concept       | Preferred prop name        | Notes                                                         |
+| ---------------------- | -------------------------- | ------------------------------------------------------------- |
+| Variant                | `variant`                  | Example: `default`, `toggle` when the docs describe variants. |
+| Color style            | `colorStyle`               | Example: `elevated`, `filled`, `tonal`, `outlined`, `text`.   |
+| Size                   | `size`                     | Use Material size names.                                      |
+| Shape                  | `shape`                    | Use Material shape names.                                     |
+| Selection state        | `selected`                 | For toggle/selection-capable components.                      |
+| Disabled state         | `disabled`                 | Native disabled semantics where supported.                    |
+| Loading/progress state | `loading` or `progress`    | Prefer progress when numeric progress is the main contract.   |
+| Native button type     | `nativeType` or `htmlType` | Do not call this `variant` or `formAction`.                   |
 
 ## Invalid combinations
 

--- a/docs/material-3/shared-ui-api.md
+++ b/docs/material-3/shared-ui-api.md
@@ -1,0 +1,55 @@
+# Material 3 shared UI API
+
+## Principle
+
+Public `MD*` component APIs must use official Material 3 vocabulary wherever possible.
+
+A developer should be able to read the official Material 3 documentation and predict the relevant project prop names and allowed values.
+
+## Naming rules
+
+- Use Material component names for shared Material components.
+- Use Material configuration names for props.
+- Use Material value names for prop values.
+- Avoid generic local names when Material has a specific term.
+- Avoid names that conflict with native HTML meanings unless the prop actually controls the native HTML behavior.
+- Document every deliberate mismatch in [Deviations](./deviations.md) or the component Storybook page.
+
+## Preferred prop vocabulary
+
+| Material concept | Preferred prop name | Notes |
+| --- | --- | --- |
+| Variant | `variant` | Example: `default`, `toggle` when the docs describe variants. |
+| Color style | `colorStyle` | Example: `elevated`, `filled`, `tonal`, `outlined`, `text`. |
+| Size | `size` | Use Material size names. |
+| Shape | `shape` | Use Material shape names. |
+| Selection state | `selected` | For toggle/selection-capable components. |
+| Disabled state | `disabled` | Native disabled semantics where supported. |
+| Loading/progress state | `loading` or `progress` | Prefer progress when numeric progress is the main contract. |
+| Native button type | `nativeType` or `htmlType` | Do not call this `variant` or `formAction`. |
+
+## Invalid combinations
+
+Components should prevent impossible Material combinations through TypeScript types, runtime validation, documentation, or a combination of these.
+
+Examples:
+
+- If official docs say a color style has no toggle variant, the API should not silently accept that combination.
+- If a slot is required for an accessible name or icon, the component should enforce or clearly document it.
+- If a component only supports a subset of official Material variants, the unsupported variants must not appear as accepted public API values.
+
+## Project-specific components
+
+Project-specific components may use project vocabulary, but they must not be documented under official Material component headings unless they are a deliberate adaptation of a Material pattern.
+
+When a project-specific component uses Material tokens or states, document the Material foundations it uses and the project-specific behavior it adds.
+
+## Deprecation
+
+When renaming an existing public prop toward Material vocabulary:
+
+1. introduce the Material-compatible prop;
+2. keep the old prop as a temporary compatibility alias when practical;
+3. prefer one canonical path in new code;
+4. document the migration in the component Storybook page;
+5. remove the compatibility alias in a focused cleanup after consumers migrate.

--- a/docs/material-3/source-of-truth.md
+++ b/docs/material-3/source-of-truth.md
@@ -1,0 +1,35 @@
+# Material 3 source of truth
+
+## Primary source
+
+Use the `material3` MCP server from `Vyachean/m3-docs-mcp` as the primary source for official Material 3 documentation when it is available.
+
+Before planning or implementing Material UI work, check the relevant official Material 3 pages through MCP. Prefer component pages, foundation pages, specs, accessibility pages, and guidance pages that match the touched surface.
+
+## Fallback source
+
+Use `Vyachean/m3-docs-cache` as the fallback source when the `material3` MCP server is unavailable or incomplete for the needed page.
+
+The cache is treated as a readable snapshot of `https://m3.material.io`, not as an independent design system. When using the cache, prefer files under `pages/` and inspect `index.json` for capture metadata, failed URLs, and suspicious pages.
+
+## Non-sources
+
+Do not use Material Web as the source of truth for this project. Material Web may be useful as an implementation reference only after the official Material 3 guidance has been checked, and only if the implementation reference does not override the official guidance.
+
+Do not use older Material versions, third-party component libraries, screenshots, or memory as substitutes for official Material 3 documentation.
+
+## Unavailable guidance
+
+If neither MCP nor `m3-docs-cache` has the needed guidance, state that the Material 3 verification is incomplete and document the decision as a deviation or unresolved risk. Do not claim full Material 3 alignment for that surface.
+
+## PR expectation
+
+For Material UI changes, PR descriptions or review notes should name the Material 3 pages checked, such as:
+
+- `components/buttons/overview`
+- `components/buttons/specs`
+- `foundations/design-tokens/overview`
+- `foundations/interaction/states/overview`
+- `styles/color/roles`
+
+Use stable page names or cache paths instead of raw screenshots or generic references.

--- a/docs/material-3/storybook.md
+++ b/docs/material-3/storybook.md
@@ -1,0 +1,56 @@
+# Material 3 Storybook policy
+
+## Principle
+
+Storybook is the project documentation surface for shared UI. For Material components used by the app, Storybook should read like the corresponding official Material 3 documentation adapted to the project implementation.
+
+Storybook is not the source of truth for Material 3. It documents how the project implements the official guidance checked through MCP or `m3-docs-cache`.
+
+## Story hierarchy
+
+Use a hierarchy that separates official Material-aligned components from project-specific UI:
+
+```text
+Material 3/Components/<Component>/<Story>
+Project UI/<Component>/<Story>
+```
+
+Use `Material 3/Components` only for components that intentionally implement an official Material 3 component or pattern.
+
+Use `Project UI` for components such as markdown renderers, repository-specific navigation helpers, and other app-specific surfaces.
+
+## Required story sections for Material components
+
+A mature Material component story set should cover:
+
+- Overview;
+- Variants;
+- Configurations;
+- Anatomy when useful;
+- States;
+- Accessibility notes;
+- Tokens and supported override points;
+- Do / Don't or usage notes when the official docs include them;
+- Project deviations or unsupported official variants;
+- Visual regression surfaces when the component is a shared primitive or has high visual risk.
+
+Do not add every section mechanically in the first pass. Add the sections that make the component understandable and verifyable, then expand during the component's parity work.
+
+## Story rules
+
+- Keep stories deterministic and fixture-driven.
+- Do not connect product stores, storage flows, diagnostics, routing lifecycle, Google Drive integration, live network calls, or app bootstrap side effects.
+- Do not change public component APIs only to satisfy Storybook.
+- Do not put business logic in stories.
+- Use the same public props and tokens that product code uses.
+- Tag screenshot-ready stories with `visual`.
+
+## Visual documentation
+
+For components that are used as visual regression surfaces, prefer stable gallery stories that show Material-relevant states and configurations in one bounded locator screenshot.
+
+Do not add visual snapshots for every story. Use visual coverage for shared primitives, important Material states, responsive layout surfaces, CSS-heavy components, and previously broken states.
+
+## Documentation notes
+
+Each Material component's Storybook docs should name the checked official Material 3 pages or cache paths. If a feature is project-specific or unsupported, say so in the Storybook notes rather than implying official Material support.

--- a/docs/material-3/token-validation.md
+++ b/docs/material-3/token-validation.md
@@ -1,0 +1,60 @@
+# Material 3 token validation
+
+## Principle
+
+Token policy must be mechanically checkable where practical. A token name that looks Material-compatible but does not map to official guidance creates long-term drift.
+
+## Validation goals
+
+A token validation pass should identify:
+
+- public `--md-*` tokens that do not map to Material `md.ref`, `md.sys`, or `md.comp` vocabulary;
+- app-specific values that should use `--app-*`;
+- component-local variables that should become public `--md-comp-*` tokens;
+- hardcoded Material values in component CSS;
+- deprecated or compatibility tokens;
+- missing system or component tokens needed by a converted component family.
+
+## Allowed public token namespaces
+
+Use these namespaces for public styling contracts:
+
+| Namespace | Use |
+| --- | --- |
+| `--md-ref-*` | Material reference tokens. |
+| `--md-sys-*` | Material system tokens. |
+| `--md-comp-*` | Material component tokens. |
+| `--app-*` | App-specific tokens outside Material vocabulary. |
+
+Do not introduce new public token namespaces without updating this document.
+
+## Validation process
+
+Before converting a component family:
+
+1. collect all CSS custom properties used by the component and its direct shared UI dependencies;
+2. classify each property as reference, system, component, app-specific, private local, compatibility alias, or obsolete;
+3. compare Material token names and meanings through MCP or fallback cache;
+4. define missing `--md-comp-*` tokens before changing visuals;
+5. document unsupported or adapted tokens as deviations.
+
+## Future automation
+
+A future script may enforce parts of this policy. It should start as advisory and become blocking only after the existing token inventory has been classified.
+
+Recommended checks:
+
+- reject new public `--md-*` tokens without `ref`, `sys`, or `comp` class;
+- warn on new `--md-*` names that are not present in the allowlist or deviation registry;
+- warn on project-specific names under `--md-*`;
+- warn on raw hex colors in shared Material component CSS;
+- warn on component CSS that bypasses defined `--md-comp-*` tokens.
+
+## Review expectation
+
+A Material token PR should include:
+
+- the checked Material token docs or component specs;
+- the token classification summary;
+- renamed or deprecated compatibility aliases;
+- focused verification for generated CSS and affected visual surfaces.

--- a/docs/material-3/token-validation.md
+++ b/docs/material-3/token-validation.md
@@ -19,12 +19,12 @@ A token validation pass should identify:
 
 Use these namespaces for public styling contracts:
 
-| Namespace | Use |
-| --- | --- |
-| `--md-ref-*` | Material reference tokens. |
-| `--md-sys-*` | Material system tokens. |
-| `--md-comp-*` | Material component tokens. |
-| `--app-*` | App-specific tokens outside Material vocabulary. |
+| Namespace     | Use                                              |
+| ------------- | ------------------------------------------------ |
+| `--md-ref-*`  | Material reference tokens.                       |
+| `--md-sys-*`  | Material system tokens.                          |
+| `--md-comp-*` | Material component tokens.                       |
+| `--app-*`     | App-specific tokens outside Material vocabulary. |
 
 Do not introduce new public token namespaces without updating this document.
 

--- a/docs/material-3/tokens.md
+++ b/docs/material-3/tokens.md
@@ -10,11 +10,11 @@ A developer who knows the official Material 3 token model should be able to unde
 
 Material 3 defines three token classes. The project maps them to CSS custom properties as follows:
 
-| Material token class | Material example | CSS custom property example |
-| --- | --- | --- |
-| Reference | `md.ref.palette.primary40` | `--md-ref-palette-primary40` |
-| System | `md.sys.color.primary` | `--md-sys-color-primary` |
-| Component | `md.comp.button.filled.container.color` | `--md-comp-button-filled-container-color` |
+| Material token class | Material example                        | CSS custom property example               |
+| -------------------- | --------------------------------------- | ----------------------------------------- |
+| Reference            | `md.ref.palette.primary40`              | `--md-ref-palette-primary40`              |
+| System               | `md.sys.color.primary`                  | `--md-sys-color-primary`                  |
+| Component            | `md.comp.button.filled.container.color` | `--md-comp-button-filled-container-color` |
 
 ## Public `--md-*` rule
 

--- a/docs/material-3/tokens.md
+++ b/docs/material-3/tokens.md
@@ -1,0 +1,77 @@
+# Material 3 tokens
+
+## Principle
+
+Public Material tokens in the project must use Material 3 vocabulary.
+
+A developer who knows the official Material 3 token model should be able to understand the project token names without learning an unrelated local naming system.
+
+## Token classes
+
+Material 3 defines three token classes. The project maps them to CSS custom properties as follows:
+
+| Material token class | Material example | CSS custom property example |
+| --- | --- | --- |
+| Reference | `md.ref.palette.primary40` | `--md-ref-palette-primary40` |
+| System | `md.sys.color.primary` | `--md-sys-color-primary` |
+| Component | `md.comp.button.filled.container.color` | `--md-comp-button-filled-container-color` |
+
+## Public `--md-*` rule
+
+A public CSS custom property starting with `--md-` must be Material-compatible:
+
+- it should map to an official Material token name; or
+- it should be a direct, documented adaptation of an official Material token; or
+- it should be listed as a documented project deviation.
+
+Project-only implementation helpers must not be introduced as public `--md-*` tokens. Use a project namespace such as `--beaver-*` for project-specific values that do not correspond to Material vocabulary.
+
+## Reference tokens
+
+Reference tokens represent available values. They should not encode component usage.
+
+Examples:
+
+- palette values;
+- typeface values;
+- baseline measurement values when Material exposes them as reference tokens.
+
+## System tokens
+
+System tokens represent theme decisions and roles. They should point to reference tokens whenever possible.
+
+Examples:
+
+- color roles;
+- typescale roles;
+- shape roles;
+- elevation levels;
+- motion tokens;
+- state layer opacities.
+
+Components should prefer system tokens through component tokens instead of hardcoding reference values.
+
+## Component tokens
+
+Component tokens are the public override surface for component internals such as container, label text, icon, outline, selected state, disabled state, and measurements.
+
+Component token naming is defined in [Component tokens](./component-tokens.md).
+
+## Deprecated or compatibility tokens
+
+If a legacy token must remain temporarily:
+
+1. keep it as a compatibility alias;
+2. document the target Material-compatible token;
+3. avoid using it in new code;
+4. remove it after touched consumers have migrated.
+
+## Token audit requirements
+
+Before converting a component family, audit the relevant token families:
+
+- existing public `--md-*` tokens;
+- local component variables that should become `--md-comp-*` tokens;
+- hardcoded Material values inside component CSS;
+- values that are project-specific and need `--beaver-*` or another project namespace;
+- deprecated Material tokens such as surface tint color when the official guidance marks them as deprecated.

--- a/docs/material-3/tokens.md
+++ b/docs/material-3/tokens.md
@@ -24,7 +24,20 @@ A public CSS custom property starting with `--md-` must be Material-compatible:
 - it should be a direct, documented adaptation of an official Material token; or
 - it should be listed as a documented project deviation.
 
-Project-only implementation helpers must not be introduced as public `--md-*` tokens. Use a project namespace such as `--beaver-*` for project-specific values that do not correspond to Material vocabulary.
+Project-only implementation helpers must not be introduced as public `--md-*` tokens. Use the neutral `--app-*` namespace for app-specific values that do not correspond to Material vocabulary.
+
+## App-specific namespace
+
+Use `--app-*` for project-specific CSS custom properties that intentionally sit outside Material token vocabulary.
+
+Examples:
+
+- app-specific debug or diagnostic colors;
+- app shell measurements that are not Material layout tokens;
+- product-only integration surfaces;
+- compatibility aliases that are not intended as public Material tokens.
+
+Do not use repository-name-specific prefixes for new tokens. The token vocabulary should remain stable if the repository or product name changes.
 
 ## Reference tokens
 
@@ -73,5 +86,5 @@ Before converting a component family, audit the relevant token families:
 - existing public `--md-*` tokens;
 - local component variables that should become `--md-comp-*` tokens;
 - hardcoded Material values inside component CSS;
-- values that are project-specific and need `--beaver-*` or another project namespace;
+- values that are app-specific and need `--app-*` namespace;
 - deprecated Material tokens such as surface tint color when the official guidance marks them as deprecated.

--- a/docs/material-3/units.md
+++ b/docs/material-3/units.md
@@ -1,0 +1,39 @@
+# Material 3 units
+
+## Principle
+
+Author Material UI styles with the units used by the official Material 3 documentation.
+
+The source code may use Material-oriented authoring units such as `dp` when the checked Material 3 guidance uses them. Translating those units into browser-supported CSS values is the responsibility of the PostCSS custom unit pipeline, not individual components.
+
+## Current project unit pipeline
+
+The project supports custom CSS units through PostCSS:
+
+- `dp` is translated through `--one-dp`.
+- `pt` is translated through `--one-pt`.
+- `step` is translated through `--one-step`.
+
+The base unit values are defined in the Material CSS foundation layer. Changes to unit conversion must be treated as foundation changes because they can affect all shared UI components and visual baselines.
+
+## Unit rules
+
+- Use the unit shown by the official Material 3 documentation for Material-derived measurements when practical.
+- Do not replace Material measurements with arbitrary CSS values inside components just because the runtime target is the web.
+- Do not introduce a new custom unit without documenting its Material or project role here.
+- Do not mix equivalent units for the same token family without a deliberate reason.
+- Keep unit conversion centralized in PostCSS and the Material CSS foundation layer.
+
+## Typography units
+
+Typography units must be handled consistently as a foundation decision. If the project uses a Material-derived authoring unit for typography, components should consume the typography tokens and should not convert typography values locally.
+
+A future typography audit must decide whether the existing `pt` authoring unit remains the project convention or whether a more Material-specific typography unit should be introduced. Until that decision is made, do not perform component-local conversions.
+
+## Verification
+
+Unit changes require focused verification of:
+
+- the PostCSS custom unit transform;
+- generated CSS for representative `dp`, `pt`, and `step` values;
+- at least one visual surface that uses typography, shape, and layout measurements.

--- a/docs/material-3/units.md
+++ b/docs/material-3/units.md
@@ -4,36 +4,49 @@
 
 Author Material UI styles with the units used by the official Material 3 documentation.
 
-The source code may use Material-oriented authoring units such as `dp` when the checked Material 3 guidance uses them. Translating those units into browser-supported CSS values is the responsibility of the PostCSS custom unit pipeline, not individual components.
+The source code may use Material-oriented authoring units such as `dp` and `sp` when the checked Material 3 guidance uses them. Translating those units into browser-supported CSS values is the responsibility of the PostCSS custom unit pipeline, not individual components.
 
-## Current project unit pipeline
+## Project unit pipeline
 
-The project supports custom CSS units through PostCSS:
+The project supports custom CSS units through PostCSS. The Material foundation layer is responsible for defining the base conversion values.
 
-- `dp` is translated through `--one-dp`.
-- `pt` is translated through `--one-pt`.
-- `step` is translated through `--one-step`.
+Required Material authoring units:
 
-The base unit values are defined in the Material CSS foundation layer. Changes to unit conversion must be treated as foundation changes because they can affect all shared UI components and visual baselines.
+- `dp` for Material dimensions, layout measurements, shape, and component specs;
+- `sp` for Material typography sizes.
+
+Project helper units:
+
+- `step` for app spacing composition when no exact Material measurement applies.
+
+Legacy units:
+
+- `pt` exists in the current codebase, but it is not the target Material typography authoring unit. Do not add new Material typography tokens in `pt`. Migrate existing Material typography `pt` usage to `sp` during the foundation token audit.
+
+Changes to unit conversion must be treated as foundation changes because they can affect all shared UI components and visual baselines.
 
 ## Unit rules
 
-- Use the unit shown by the official Material 3 documentation for Material-derived measurements when practical.
+- Use the unit shown by the official Material 3 documentation for Material-derived measurements.
 - Do not replace Material measurements with arbitrary CSS values inside components just because the runtime target is the web.
 - Do not introduce a new custom unit without documenting its Material or project role here.
-- Do not mix equivalent units for the same token family without a deliberate reason.
+- Do not mix equivalent units for the same token family.
 - Keep unit conversion centralized in PostCSS and the Material CSS foundation layer.
+- Components must consume tokens and authoring units; they must not perform local unit conversion.
 
 ## Typography units
 
-Typography units must be handled consistently as a foundation decision. If the project uses a Material-derived authoring unit for typography, components should consume the typography tokens and should not convert typography values locally.
+Use `sp` for Material typography authoring values.
 
-A future typography audit must decide whether the existing `pt` authoring unit remains the project convention or whether a more Material-specific typography unit should be introduced. Until that decision is made, do not perform component-local conversions.
+Typography values must be exposed through `md.sys.typescale.*` tokens. Components should consume those tokens and should not convert typography values locally.
+
+The foundation audit must migrate current Material typography tokens from `pt` to `sp` and add the required PostCSS `sp` conversion before component-family migration relies on the new typography tokens.
 
 ## Verification
 
 Unit changes require focused verification of:
 
 - the PostCSS custom unit transform;
-- generated CSS for representative `dp`, `pt`, and `step` values;
+- generated CSS for representative `dp`, `sp`, and `step` values;
+- migration or removal of legacy `pt` Material typography values;
 - at least one visual surface that uses typography, shape, and layout measurements.

--- a/docs/material-3/verification.md
+++ b/docs/material-3/verification.md
@@ -8,17 +8,17 @@ Visual screenshots alone are not enough. Verification should cover the relevant 
 
 ## Verification matrix
 
-| Changed layer | Expected verification |
-| --- | --- |
-| Source policy or docs | Read the affected docs and check links/paths. |
-| Unit conversion | Focused PostCSS transform check or generated CSS inspection. |
-| Reference/system tokens | Token diff review and at least one rendered surface if values affect UI. |
-| Component tokens | Storybook surface showing affected variants/states and token usage. |
-| Public component API | TypeScript checks, consumer migration review, and Storybook controls/docs. |
-| Interaction states | Browser-based state checks, preferably Storybook + Playwright for visual states. |
-| Accessibility behavior | Keyboard/focus/ARIA checks in a real browser surface when behavior changes. |
-| Adaptive layout | Responsive browser smoke or visual tests for affected breakpoints. |
-| Visual appearance | Playwright screenshot assertions against deterministic Storybook stories. |
+| Changed layer           | Expected verification                                                            |
+| ----------------------- | -------------------------------------------------------------------------------- |
+| Source policy or docs   | Read the affected docs and check links/paths.                                    |
+| Unit conversion         | Focused PostCSS transform check or generated CSS inspection.                     |
+| Reference/system tokens | Token diff review and at least one rendered surface if values affect UI.         |
+| Component tokens        | Storybook surface showing affected variants/states and token usage.              |
+| Public component API    | TypeScript checks, consumer migration review, and Storybook controls/docs.       |
+| Interaction states      | Browser-based state checks, preferably Storybook + Playwright for visual states. |
+| Accessibility behavior  | Keyboard/focus/ARIA checks in a real browser surface when behavior changes.      |
+| Adaptive layout         | Responsive browser smoke or visual tests for affected breakpoints.               |
+| Visual appearance       | Playwright screenshot assertions against deterministic Storybook stories.        |
 
 ## Required Material lookup
 

--- a/docs/material-3/verification.md
+++ b/docs/material-3/verification.md
@@ -1,0 +1,51 @@
+# Material 3 verification
+
+## Principle
+
+Material 3 alignment must be verified at the layer where the change matters.
+
+Visual screenshots alone are not enough. Verification should cover the relevant source-of-truth lookup, tokens, units, public APIs, interaction states, accessibility, layout behavior, Storybook documentation, and visual output.
+
+## Verification matrix
+
+| Changed layer | Expected verification |
+| --- | --- |
+| Source policy or docs | Read the affected docs and check links/paths. |
+| Unit conversion | Focused PostCSS transform check or generated CSS inspection. |
+| Reference/system tokens | Token diff review and at least one rendered surface if values affect UI. |
+| Component tokens | Storybook surface showing affected variants/states and token usage. |
+| Public component API | TypeScript checks, consumer migration review, and Storybook controls/docs. |
+| Interaction states | Browser-based state checks, preferably Storybook + Playwright for visual states. |
+| Accessibility behavior | Keyboard/focus/ARIA checks in a real browser surface when behavior changes. |
+| Adaptive layout | Responsive browser smoke or visual tests for affected breakpoints. |
+| Visual appearance | Playwright screenshot assertions against deterministic Storybook stories. |
+
+## Required Material lookup
+
+Before implementation, identify the relevant official Material guidance checked through:
+
+1. `material3` MCP; or
+2. `Vyachean/m3-docs-cache` fallback.
+
+If the guidance is unavailable or incomplete, document the risk and do not claim full Material 3 alignment.
+
+## Storybook and visual tests
+
+Use Storybook as the preferred harness for shared UI visual verification. Visual tests should be deterministic and focused on stable surfaces.
+
+Use Playwright screenshots for visual appearance, rendered layout, and Material state regressions. Do not use Vue unit tests, happy-dom, or Vitest for visual appearance.
+
+## Final verification
+
+After implementation changes, follow the repository verification policy in `AGENTS.md`. Documentation-only policy changes may be reviewed without broad browser verification, but the final PR should still state what was and was not run.
+
+## Review checklist
+
+For each Material UI PR, reviewers should be able to answer:
+
+1. Which Material 3 pages were checked?
+2. Which tokens or API names changed?
+3. Which states and accessibility behaviors are affected?
+4. Which Storybook surfaces document the behavior?
+5. Which focused verification proves the change?
+6. Are deviations documented?

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -4,6 +4,10 @@ Inherits the rules from the root `AGENTS.md`. Applies to all application source 
 
 ## Material 3 guideline checks
 
-For user-visible UI or UX changes, use the `material3-guidelines` skill before planning component choice, layout, interaction behavior, visual states, accessibility semantics, or verification.
+For user-visible UI or UX changes, use the `material3-guidelines` skill before planning component choice, layout, interaction behavior, visual states, accessibility semantics, tokens, public UI API names, or verification.
 
-Do not claim Material 3 alignment unless the relevant guidance was checked through the `material3` MCP cache from https://github.com/Vyachean/m3-docs-mcp. If that check is unavailable or incomplete, report it as an unresolved Material 3 verification risk.
+For shared UI primitives, Material-style wrappers, Material tokens, Material authoring units, Storybook UI documentation, or Material visual verification surfaces, also follow the relevant policies under `docs/material-3/` before editing production code.
+
+Use the `material3` MCP server from https://github.com/Vyachean/m3-docs-mcp as the primary source of official Material 3 guidance. If MCP is unavailable or incomplete for the needed page, use `Vyachean/m3-docs-cache` as the fallback snapshot of official `m3.material.io` content.
+
+Do not claim Material 3 alignment unless the relevant guidance was checked through MCP or the documented fallback cache. If that check is unavailable or incomplete, report it as an unresolved Material 3 verification risk.


### PR DESCRIPTION
## Summary

- add `docs/material-3/` foundation and implementation policies for Material 3 source lookup, units, tokens, baseline theme, component tokens, token validation, interaction states, accessibility, adaptive layout, density/spacing, iconography, overlays, shared UI API naming, Storybook, verification, deviations, registry, checklist, and adoption order
- define `material3` MCP as the primary source of official Material 3 guidance, with `Vyachean/m3-docs-cache` as the fallback snapshot when MCP is unavailable or incomplete
- document Material authoring units: `dp` for Material measurements and `sp` for typography, with PostCSS responsible for translating authoring units into CSS-supported values
- define the initial theme target as a tokenized Material baseline theme with mandatory light and dark schemes, while keeping the model ready for future user-selected base palette customization
- use neutral `--app-*` namespace for app-specific tokens that do not belong to Material `--md-*` vocabulary
- define canonical `--md-comp-*` tokens at the component definition boundary
- require in-repository shared UI API migrations to update consumers directly instead of keeping compatibility aliases by default
- document the existing overlay ownership model: `useOverlayContainer`, `TeleportContainer`, child teleported container registration, and outside-interaction containment; preserve it instead of introducing ad hoc overlay stack/z-index ownership
- add practical adoption gates: component registry, token validation policy, and component conversion checklist
- update the Material 3 agent skill and `src/AGENTS.md` to point UI work to the policy docs before component implementation

## Verification

Documentation-only change. I reviewed the branch diff with `compare_commits` and did not run `pnpm verify` in this environment.