### PR TITLE
docs: audit Material 3 foundation

### DIFF
--- a/docs/material-3/component-family-audit.md
+++ b/docs/material-3/component-family-audit.md
@@ -1,0 +1,156 @@
+# Material 3 component family audit
+
+This file records component-family findings from the current implementation and Material 3 cache. It complements [Material 3 foundation audit](./foundation-audit.md) and [Foundation audit details](./foundation-audit-details.md).
+
+## Buttons: `MDButton`
+
+Material cache confirms default/toggle variants, elevated/filled/tonal/outlined/text color configurations, five sizes, round/square shapes, 16dp recommended small padding, no text toggle button, 48x48dp target area for extra-small/small buttons, and 20dp standard icons.
+
+Current state:
+
+- strong match for M3 Expressive variants: color, type, size, shape, selected state, shape morph, optional icon, loading, and 48dp target layers exist;
+- uses `MDStateLayer`, ripple, and progress indicator;
+- has visual and target-area tests.
+
+Gaps:
+
+- local `--md-button-*` variables instead of `--md-comp-button-*`;
+- API allows `type="toggle"` with `color="text"`, while Material docs exclude text toggle buttons;
+- `formAction` diverges from native button `type` terminology;
+- icon size is 18px while Material cache states 20dp;
+- loading is a project extension and must be documented.
+
+Verdict: best first component pilot after the small foundation token/state prerequisite.
+
+## Icon buttons: `MDIconButton`
+
+Material cache confirms default/toggle variants, filled/tonal/outlined/standard colors, size/width/shape configurations, tooltip on web, and outlined-to-filled icon treatment for toggle state.
+
+Current state:
+
+- supports color, type, selected, size, width, shape, tooltip, symbol name, icon slot, and rich tooltip slot;
+- implements selected symbol fill behavior and 48dp target layers;
+- has visual, target-area, toolbar, and dense-toolbar behavior tests.
+
+Gaps:
+
+- local `--md-icon-button-*` variables instead of `--md-comp-icon-button-*`;
+- loading and rich tooltip content are project extensions;
+- compact toolbar sizing is intentionally tested but must be documented if it deviates from Material layout expectations.
+
+Verdict: include in Buttons pilot.
+
+## FAB: `MDFab`, `MDFabContainer`
+
+Material cache confirms FAB, medium FAB, and large FAB; small FAB is no longer recommended; variants are size-based; primary/secondary/tertiary and container color styles are current; surface FABs are no longer recommended.
+
+Current state:
+
+- supports default, medium, and large sizes;
+- no small FAB exists;
+- supports primary, secondary, tertiary, and `tonal-*` color values;
+- has tooltip, symbol slot/name, loading, state layer, and visual tests.
+
+Gaps:
+
+- local `--md-fab-*` variables instead of `--md-comp-fab-*`;
+- public color names `tonal-primary`, `tonal-secondary`, and `tonal-tertiary` should be reviewed against Material container color naming;
+- `MDFabContainer` is project-specific placement infrastructure, not the Material FAB itself;
+- loading is a project extension;
+- `columns: var(--md-fab-icon-color)` inside icon styles appears to be a typo and should be confirmed/fixed during migration.
+
+Verdict: include in Buttons pilot after base buttons and icon buttons.
+
+## Lists: `MDList`, `MDListItem`, `MDListContainer`
+
+Material cache confirms lists help users find and act on items; items should be scannable and consistently formatted; M3 baseline heights are 56dp, 72dp, and 88dp; M3 Expressive adds standard/segmented styles and improved selection states.
+
+Current state:
+
+- `MDListItem` supports headline, supporting text, 1/2/3 line heights, leading icon/avatar, trailing icon, native `button`/`a`/`div`/`li` hosts, disabled, draggable, and role override;
+- uses state layer, ripple, and keyboard handling;
+- has visual/interaction/trailing-action tests.
+
+Gaps:
+
+- local list variables instead of `--md-comp-list-*` and `--md-comp-list-item-*`;
+- heights are authored as px rather than dp;
+- selected and segmented list styles are not first-class contracts;
+- trailing action needs an explicit contract instead of being only a `trailingIcon` slot convention.
+
+Verdict: second migration family after Buttons.
+
+## Dialogs: `DialogForm`
+
+Material cache confirms basic and full-screen dialogs; dialogs should be single-task prompts and commonly confirm high-risk actions.
+
+Current state:
+
+- supports headline, supporting text, optional icon, body slot, cancel/apply actions, loading, `basic`/`full-screen` type, focus trap, escape, and browser back handling.
+
+Gaps:
+
+- uses a native `dialog` with fixed scrim and local z-index instead of the shared overlay container/teleport ownership model;
+- no registry-backed visual/browser coverage found;
+- full-screen implementation is not confirmed beyond the public type class;
+- action ordering/count, destructive action semantics, focus restoration, nested overlays, and scroll behavior need browser verification.
+
+Verdict: migrate after Buttons and Lists; start with overlay ownership.
+
+## Text fields: `MDTextField`, `MDFieldContainer`
+
+Current state:
+
+- supports filled/outlined type, label, supporting text, disabled, error, counter, native input types, multiline, readonly, autofocus, leading/trailing icons, and focus/keydown emits.
+
+Gaps:
+
+- local field variables instead of `--md-comp-text-field-*`;
+- `MDFieldContainer` is public-looking but acts as an implementation primitive;
+- label motion, padding, icon behavior, focus indicator, disabled/error colors, and counter behavior need source-backed review;
+- no registry-backed visual coverage found.
+
+Verdict: migrate after dialogs or with select controls if menu ownership is ready.
+
+## Chips: `MDChipBase`
+
+Material cache confirms assist, filter, input, and suggestion variants; elevation defaults to 0 but can be elevated; chip stroke changed from outline to outline variant.
+
+Current state:
+
+- supports all four variants, selected, elevated, draggable, disabled, autofocus, leading/trailing icon slots, and input close action;
+- uses state layer, ripple, `MDSymbol`, and `MDIconButton`;
+- has visual and interaction tests.
+
+Gaps:
+
+- one broad base component permits combinations that may be invalid per chip type;
+- no `--md-comp-chip-*` token set;
+- disabled state uses whole-chip opacity;
+- input close action needs keyboard/accessibility verification.
+
+Verdict: prefer strict type-specific wrapper contracts during chip migration.
+
+## Menus: `MDMenuBase`
+
+Material cache confirms menus are temporary action sets; persistent actions belong in toolbars; menus can open from icon buttons, split buttons, and text fields; context menus are element-specific and usually secondary-click driven.
+
+Current state:
+
+- uses `useOverlayContainer`, `TeleportContainer`, `onInteractionOutside`, Floating UI, focus trap, keyboard search, escape stack, and browser back stack;
+- renders through `MDListContainer` with default `role="menu"`.
+
+Gaps:
+
+- no `--md-comp-menu-*` token set;
+- CSS capitalizes first letters of list item headlines, which is not a Material menu rule and should be removed or documented as product-specific;
+- no registry-backed visual/browser tests for positioning, focus, outside interaction, nested overlays, or mobile viewport behavior;
+- M3 Expressive vertical menu features are not represented.
+
+Verdict: overlay model is better aligned than dialogs; migrate after selection controls/chips depending on dependencies.
+
+## Remaining component groups
+
+The registry still treats navigation, app bars, toolbars, sheets, cards, progress indicators, tooltips, dividers, snackbars, tables, empty states, panes, and buttons bar as `partial` or `project-specific` until each family receives the same source-backed audit.
+
+For those groups, do not claim alignment until the component-family PR checks the relevant cache pages, defines `--md-comp-*` tokens where applicable, documents public API/deviations, and adds high-value Storybook/visual/browser coverage.

--- a/docs/material-3/component-registry.md
+++ b/docs/material-3/component-registry.md
@@ -6,56 +6,71 @@ The shared UI kit must be tracked as a registry that maps official Material 3 su
 
 Do not migrate components only by local inspection. Use the registry to keep the UI kit coherent and to avoid duplicating or partially reimplementing the same Material surface in multiple places.
 
-## Registry template
+## Related audit documents
 
-Use this table shape for new rows:
-
-| Material surface     | Project component     | Status     | Material docs     | Tokens             | API                | Storybook       | Visual tests    | Deviations    |
-| -------------------- | --------------------- | ---------- | ----------------- | ------------------ | ------------------ | --------------- | --------------- | ------------- |
-| `<official surface>` | `<project component>` | `<status>` | `<checked pages>` | `<status/details>` | `<status/details>` | `<path/status>` | `<path/status>` | `<none/link>` |
+- [Material 3 foundation audit](./foundation-audit.md)
+- [Foundation audit details](./foundation-audit-details.md)
+- [Component family audit](./component-family-audit.md)
+- [Secondary component family audit](./secondary-component-family-audit.md)
 
 ## Status values
 
 Use these status values consistently:
 
-- `missing`: no project component exists;
-- `partial`: project component exists but is not fully aligned or verified;
-- `aligned`: component has docs-backed API, tokens, Storybook, verification, and documented deviations;
-- `project-specific`: component is not an official Material component but uses Material foundations;
-- `deprecated`: component remains only as a compatibility surface;
+- `missing`: no project component exists.
+- `partial`: project component exists but is not fully aligned or verified.
+- `aligned`: component has docs-backed API, tokens, Storybook, verification, and documented deviations.
+- `project-specific`: component is not an official Material component but uses Material foundations.
+- `deprecated`: component remains only as a compatibility surface.
 - `blocked`: Material guidance is missing, conflicting, or unavailable.
+
+## Registry row fields
+
+Each registry row should record:
+
+- Material surface.
+- Project component or components.
+- Status.
+- Material docs checked.
+- Token status.
+- Public API status.
+- Storybook status.
+- Visual or browser verification status.
+- Deviations or unsupported features.
 
 ## Foundation audit snapshot
 
-The current detailed audit lives in [Material 3 foundation audit](./foundation-audit.md).
+Rows below are intentionally conservative. `partial` does not mean Material 3 alignment. It means the project has an implementation surface that still needs source-backed API, token, Storybook, verification, and deviation work before it can be marked `aligned`.
 
-Rows below are intentionally conservative. `partial` does not mean Material 3 alignment; it means the project has an implementation surface that still needs source-backed API, token, Storybook, verification, and deviation work before it can be marked `aligned`.
+### Primary official surfaces
 
-| Material surface | Project component | Status | Next check |
-| --- | --- | --- | --- |
-| Buttons | `MDButton` | `partial` | First pilot. Verify variants, props, target area, `--md-comp-button-*`, Storybook hierarchy, visual states. |
-| Icon buttons | `MDIconButton` | `partial` | Include in Buttons pilot. Verify selected/toggle behavior, icon sizing, toolbar target behavior. |
-| Floating action buttons | `MDFab`, `MDFabContainer` | `partial` | Include in Buttons pilot. Separate Material FAB behavior from project placement helpers. |
-| Lists | `MDList`, `MDListItem`, `MDListContainer` | `partial` | Verify row interaction, trailing actions, density, supporting text, and target area. |
-| Dialogs | `Dialog/*` shared UI surfaces | `partial` | Verify modal semantics, actions, focus, scroll, adaptive layout, and destructive flows. |
-| Text fields | `MDTextField`, `MDFieldContainer` | `partial` | Verify labels, supporting/error text, value contract, slots, and states. |
-| Selection controls | `MDCheckbox`, `MDCheckboxField`, `MDSelectBase` | `partial` | Verify checkbox/select semantics, keyboard behavior, menu ownership, and accessibility. |
-| Chips | `MDChipBase` and chip wrappers | `partial` | Verify strict chip type contracts and invalid combinations. |
-| Menus | `MDMenuBase`, `MDMenuItemBase`, `MDContextMenuButton` | `partial` | Verify positioning, keyboard, focus, selection, and context-menu extension. |
-| Navigation | Navigation bar, rail, and path surfaces | `partial` / `project-specific` | Verify official bar/rail mapping; keep navigation path project-specific unless a Material mapping is found. |
-| App bars and toolbars | `MDAppBar`, toolbar containers | `partial` / `project-specific` | Verify app bar mapping; keep toolbar containers project-specific unless they map to a Material surface. |
-| Bottom sheets | `MDBottomSheet*` surfaces | `partial` | Verify modal/persistent behavior, drag handle, focus, scroll, back behavior, and duplicate `*2` surfaces. |
-| Cards | `MDCard` | `partial` | Verify variants, clickability, elevation, and content slots. |
-| Progress indicators | Shared progress indicator surfaces | `partial` | Expand beyond the current single progress component token. |
-| Tooltips | `MDPlainTooltip`, `MDRichTooltip`, `MDOverlayTooltip` | `partial` | Verify plain/rich contracts, trigger ownership, delay, and overlay containment. |
-| Dividers | `MDDivider` | `partial` | Verify inset/full-bleed and orientation contracts. |
-| Snackbars | `MDSnackbar` | `partial` | Verify action, dismiss, timeout, live-region, and queue/portal ownership. |
-| Tables | `MDTable` | `project-specific` | Do not claim official alignment until current Material data-table guidance is verified. |
-| Empty states | `MDEmptyState` | `project-specific` | Treat as product UX surface using Material foundations. |
-| Pane/layout | `MDPane`, `MDSplitLayout` | `project-specific` | Treat as adaptive layout primitives, not official Material components. |
-| Buttons bar | `MDButtonsBar` | `project-specific` | Treat as action-layout helper unless mapped through dialogs/buttons. |
+- Buttons: `MDButton` is `partial`. First pilot. Verify variants, props, target area, `--md-comp-button-*`, Storybook hierarchy, and visual states.
+- Icon buttons: `MDIconButton` is `partial`. Include in Buttons pilot. Verify selected/toggle behavior, icon sizing, and toolbar target behavior.
+- Floating action buttons: `MDFab` and `MDFabContainer` are `partial`. Include in Buttons pilot. Separate Material FAB behavior from project placement helpers.
+- Lists: `MDList`, `MDListItem`, and `MDListContainer` are `partial`. Verify row interaction, trailing actions, density, supporting text, and target area.
+- Dialogs: shared `Dialog/*` surfaces are `partial`. Verify modal semantics, actions, focus, scroll, adaptive layout, and destructive flows.
+- Text fields: `MDTextField` and `MDFieldContainer` are `partial`. Verify labels, supporting/error text, value contract, slots, and states.
+- Selection controls: `MDCheckbox`, `MDCheckboxField`, and `MDSelectBase` are `partial`. Verify checkbox/select semantics, keyboard behavior, menu ownership, and accessibility.
+- Chips: `MDChipBase` and chip wrappers are `partial`. Verify strict chip type contracts and invalid combinations.
+- Menus: `MDMenuBase`, `MDMenuItemBase`, and `MDContextMenuButton` are `partial`. Verify positioning, keyboard, focus, selection, and context-menu extension.
+- Bottom sheets: `MDBottomSheet*` surfaces are `partial`. Verify modal/persistent behavior, drag handle, focus, scroll, back behavior, and duplicate `*2` surfaces.
+- Cards: `MDCard` is `partial`. Verify variants, clickability, elevation, and content slots.
+- Progress indicators: shared progress indicator surfaces are `partial`. Expand beyond the current single progress component token.
+- Tooltips: `MDPlainTooltip`, `MDRichTooltip`, and `MDOverlayTooltip` are `partial`. Verify plain/rich contracts, trigger ownership, delay, and overlay containment.
+- Dividers: `MDDivider` is `partial`. Verify inset/full-bleed and orientation contracts.
+- Snackbars: `MDSnackbar` is `partial`. Verify action, dismiss, timeout, live-region, and queue/portal ownership.
 
-## Required fields for aligned rows
+### Mixed or project-specific surfaces
+
+- Navigation bar and rail surfaces are `partial`. Verify official bar/rail mapping and adaptive ownership.
+- Navigation path is `project-specific` unless a Material mapping is found.
+- `MDAppBar` is `partial`; toolbar containers are `project-specific` unless they map to app bar guidance.
+- `MDTable` is `project-specific` until current Material data-table guidance is verified.
+- `MDEmptyState` is `project-specific` and should be treated as a product UX surface using Material foundations.
+- `MDPane` and `MDSplitLayout` are `project-specific` adaptive layout primitives.
+- `MDButtonsBar` is `project-specific` unless mapped through dialogs or buttons.
+
+## Requirements before marking a row aligned
 
 Before any row is marked `aligned`, it must answer:
 
@@ -72,10 +87,10 @@ Before any row is marked `aligned`, it must answer:
 
 Before starting a component family conversion:
 
-1. update or add the registry row;
-2. identify the Material docs to check;
-3. identify existing project components and deprecated aliases;
-4. decide whether the component is official Material-aligned or project-specific;
-5. define the verification target.
+1. Update or add the registry row.
+2. Identify the Material docs to check.
+3. Identify existing project components and deprecated aliases.
+4. Decide whether the component is official Material-aligned or project-specific.
+5. Define the verification target.
 
 A component family is not done until the registry row can be marked `aligned` or its remaining gaps are explicitly documented.

--- a/docs/material-3/component-registry.md
+++ b/docs/material-3/component-registry.md
@@ -8,9 +8,7 @@ Do not migrate components only by local inspection. Use the registry to keep the
 
 ## Registry template
 
-The foundation audit must create or expand the actual registry. Do not fill registry rows with guessed statuses.
-
-Use this table shape:
+Use this table shape for new rows:
 
 | Material surface     | Project component     | Status     | Material docs     | Tokens             | API                | Storybook       | Visual tests    | Deviations    |
 | -------------------- | --------------------- | ---------- | ----------------- | ------------------ | ------------------ | --------------- | --------------- | ------------- |
@@ -27,9 +25,39 @@ Use these status values consistently:
 - `deprecated`: component remains only as a compatibility surface;
 - `blocked`: Material guidance is missing, conflicting, or unavailable.
 
-## Required fields
+## Foundation audit snapshot
 
-Each registry row should answer:
+The current detailed audit lives in [Material 3 foundation audit](./foundation-audit.md).
+
+Rows below are intentionally conservative. `partial` does not mean Material 3 alignment; it means the project has an implementation surface that still needs source-backed API, token, Storybook, verification, and deviation work before it can be marked `aligned`.
+
+| Material surface | Project component | Status | Next check |
+| --- | --- | --- | --- |
+| Buttons | `MDButton` | `partial` | First pilot. Verify variants, props, target area, `--md-comp-button-*`, Storybook hierarchy, visual states. |
+| Icon buttons | `MDIconButton` | `partial` | Include in Buttons pilot. Verify selected/toggle behavior, icon sizing, toolbar target behavior. |
+| Floating action buttons | `MDFab`, `MDFabContainer` | `partial` | Include in Buttons pilot. Separate Material FAB behavior from project placement helpers. |
+| Lists | `MDList`, `MDListItem`, `MDListContainer` | `partial` | Verify row interaction, trailing actions, density, supporting text, and target area. |
+| Dialogs | `Dialog/*` shared UI surfaces | `partial` | Verify modal semantics, actions, focus, scroll, adaptive layout, and destructive flows. |
+| Text fields | `MDTextField`, `MDFieldContainer` | `partial` | Verify labels, supporting/error text, value contract, slots, and states. |
+| Selection controls | `MDCheckbox`, `MDCheckboxField`, `MDSelectBase` | `partial` | Verify checkbox/select semantics, keyboard behavior, menu ownership, and accessibility. |
+| Chips | `MDChipBase` and chip wrappers | `partial` | Verify strict chip type contracts and invalid combinations. |
+| Menus | `MDMenuBase`, `MDMenuItemBase`, `MDContextMenuButton` | `partial` | Verify positioning, keyboard, focus, selection, and context-menu extension. |
+| Navigation | Navigation bar, rail, and path surfaces | `partial` / `project-specific` | Verify official bar/rail mapping; keep navigation path project-specific unless a Material mapping is found. |
+| App bars and toolbars | `MDAppBar`, toolbar containers | `partial` / `project-specific` | Verify app bar mapping; keep toolbar containers project-specific unless they map to a Material surface. |
+| Bottom sheets | `MDBottomSheet*` surfaces | `partial` | Verify modal/persistent behavior, drag handle, focus, scroll, back behavior, and duplicate `*2` surfaces. |
+| Cards | `MDCard` | `partial` | Verify variants, clickability, elevation, and content slots. |
+| Progress indicators | Shared progress indicator surfaces | `partial` | Expand beyond the current single progress component token. |
+| Tooltips | `MDPlainTooltip`, `MDRichTooltip`, `MDOverlayTooltip` | `partial` | Verify plain/rich contracts, trigger ownership, delay, and overlay containment. |
+| Dividers | `MDDivider` | `partial` | Verify inset/full-bleed and orientation contracts. |
+| Snackbars | `MDSnackbar` | `partial` | Verify action, dismiss, timeout, live-region, and queue/portal ownership. |
+| Tables | `MDTable` | `project-specific` | Do not claim official alignment until current Material data-table guidance is verified. |
+| Empty states | `MDEmptyState` | `project-specific` | Treat as product UX surface using Material foundations. |
+| Pane/layout | `MDPane`, `MDSplitLayout` | `project-specific` | Treat as adaptive layout primitives, not official Material components. |
+| Buttons bar | `MDButtonsBar` | `project-specific` | Treat as action-layout helper unless mapped through dialogs/buttons. |
+
+## Required fields for aligned rows
+
+Before any row is marked `aligned`, it must answer:
 
 1. Which official Material surface does this correspond to?
 2. Which project component or components implement it?

--- a/docs/material-3/foundation-audit-details.md
+++ b/docs/material-3/foundation-audit-details.md
@@ -1,0 +1,128 @@
+# Material 3 foundation audit details
+
+This file extends [Material 3 foundation audit](./foundation-audit.md) with source-backed findings from the current code and the local Material 3 cache.
+
+## Sources checked
+
+Project sources:
+
+- `src/shared/lib/md/tokens.css`
+- `postcss.config.js`
+- `src/shared/ui/Button/MDButton.vue`
+- `src/shared/ui/Button/MDIconButton.vue`
+- `src/shared/ui/Button/MDFab.vue`
+- `src/shared/ui/Lists/MDListItem.vue`
+- `src/shared/ui/Dialog/DialogForm.vue`
+- `src/shared/ui/TextField/MDTextField.vue`
+- `src/shared/ui/TextField/MDFieldContainer.vue`
+- `src/shared/ui/Chips/MDChipBase.vue`
+- `src/shared/ui/Menu/MDMenuBase.vue`
+- `src/shared/ui/State/MDStateLayer.vue`
+- `src/shared/ui/State/useStateLayer.ts`
+- `tests/e2e/visual/shared-ui.spec.ts`
+
+Material 3 cache pages:
+
+- `pages/components/buttons/overview.md`
+- `pages/components/buttons/specs.md`
+- `pages/components/icon-buttons/overview.md`
+- `pages/components/floating-action-button/overview.md`
+- `pages/components/lists/overview.md`
+- `pages/components/dialogs/overview.md`
+- `pages/components/chips/overview.md`
+- `pages/components/menus/overview.md`
+
+The cache is treated as the readable Material 3 source for this project.
+
+## Executive result
+
+The project can proceed with gradual Material 3 normalization, but not with broad restyling.
+
+The main problem is not missing components. The main problem is that the foundation is only partially normalized:
+
+- system tokens exist, but public component tokens are mostly missing;
+- Material typography still uses legacy `pt` because `sp` conversion is absent;
+- state-layer system tokens are declared but not directly consumed by `MDStateLayer`;
+- Storybook and visual tests exist for the strongest pilot families, but the hierarchy still uses legacy `shared/ui/...` names;
+- overlay ownership is inconsistent: menus use the shared overlay/teleport model, while dialogs currently use a separate fixed native-dialog path.
+
+## Foundation findings
+
+### Tokens
+
+`tokens.css` already contains Material reference palette, typeface, system color, shape, elevation, typescale, state, and motion tokens. It also contains one progress-indicator component token.
+
+Gaps:
+
+- most component-family values remain local variables such as `--md-button-*`, `--md-icon-button-*`, `--md-fab-*`, `--md-list-item-*`, and field-local border/padding variables;
+- `--unknownColor` is a debug fallback and should not become public API;
+- `--md-sys-color-surface-tint-color` is already marked deprecated;
+- light/dark theme exists through `prefers-color-scheme`, but there is no explicit app-level theme override contract;
+- token validation does not yet enforce completeness or component-token shape.
+
+Decision: keep the monolithic token file until the Buttons pilot proves the token pattern. Add `--md-comp-*` tokens during each component-family migration.
+
+### Units and typography
+
+`postcss.config.js` converts `step`, `pt`, and `dp`. It does not convert `sp`.
+
+`tokens.css` still authors typescale sizes, line heights, and tracking with `pt`.
+
+Decision: add `sp` support before typography migration. Do not hide typography migration inside an unrelated component PR.
+
+### State layers
+
+`MDStateLayer` supports hover, focused, pressed, dragged, and disabled. `useStateLayer` centralizes hover, focus-visible, pressed, and dragged state, and is already used by the important interactive primitives.
+
+Gap: `tokens.css` declares `--md-sys-state-hover-state-layer-opacity`, `--md-sys-state-focus-state-layer-opacity`, and `--md-sys-state-pressed-state-layer-opacity`, but `MDStateLayer` consumes local aliases such as `--md-state-hover-layer-opacity` with fallback values.
+
+Decision: wire `MDStateLayer` to the declared system state tokens before or during the Buttons pilot. If local aliases remain, document them as private compatibility aliases. Dragged state should be source-backed or explicitly documented as a project extension.
+
+### Storybook and visual coverage
+
+Current stories still use legacy titles such as `shared/ui/MDButton` instead of `Material 3/Components/...` or `Project UI/...`.
+
+Visual tests already cover:
+
+- `MDButton` states, interaction states, target layers, and expanded hit area;
+- `MDIconButton` states, target layers, compact toolbar layout, and dense toolbar behavior;
+- `MDChip` states;
+- `MDCheckbox` states;
+- `MDFab` states;
+- `MDListItem` states and trailing action layout;
+- `MDStateLayer` states and host integrations.
+
+Gaps: dialogs, text fields, menus, sheets, navigation, cards, tooltips, snackbars, and progress indicators do not yet have equivalent registry-backed coverage.
+
+Decision: rename Storybook hierarchy during each component-family migration and update Playwright story IDs in the same PR.
+
+## Cross-family risks
+
+1. Storybook hierarchy migration will change story IDs and must update visual tests at the same time.
+2. Overlay ownership is inconsistent across menus and dialogs.
+3. Units are mixed: px, dp, pt, and raw values. Do not mechanically replace them; preserve rendered output unless a PR intentionally changes Material values.
+4. Several public APIs expose project extensions. Keep them only when documented as project-specific and verified.
+
+## Recommended next work
+
+### PR 1: foundation token wiring
+
+Small focused implementation before the Buttons pilot:
+
+- add PostCSS `sp` support and the matching base variable;
+- wire `MDStateLayer` to system state opacity tokens;
+- decide/document dragged state as a project extension or source-backed token;
+- isolate/remove `--unknownColor` from public production token API if it is not intentionally public;
+- run focused visual checks for state-layer consumers.
+
+### PR 2: Buttons pilot
+
+Scope:
+
+- `MDButton`;
+- `MDIconButton`;
+- `MDFab`;
+- `MDFabContainer` only as project-specific placement infrastructure;
+- related Storybook and visual tests.
+
+The pilot must introduce public `--md-comp-*` tokens, block or document invalid combinations, move stories to `Material 3/Components/...`, and keep visual/browser coverage green.

--- a/docs/material-3/foundation-audit.md
+++ b/docs/material-3/foundation-audit.md
@@ -1,0 +1,238 @@
+# Material 3 foundation audit
+
+## Scope
+
+This audit starts Phase 2 from [Material 3 adoption plan](./adoption-plan.md). It records the current foundation state before any component-family migration.
+
+This document is intentionally documentation-only. It must not migrate component implementations, rename public props, reorganize shared UI source files, or update visual snapshots.
+
+## Source status
+
+- Project policy sources checked: every policy listed by `.agents/skills/material3-guidelines/SKILL.md` remains the project contract for UI work.
+- Repository implementation sources checked: `src/shared/lib/md/tokens.css`, `postcss.config.js`, existing `src/shared/ui/**/MD*.vue` surfaces found through repository search, and representative Storybook files such as `src/shared/ui/Button/MDButton.stories.ts`.
+- Official Material 3 MCP status: not available in the current execution environment.
+- Fallback cache status: `Vyachean/m3-docs-cache/index.json` is available, captured from `https://m3.material.io` at `2026-05-19T05:56:22.642Z`, with 357 captured pages, 609 attempted pages, and 20 failed pages.
+- Fallback cache warning: the cache marks several old or internal routes as suspicious/not-found. Use stable cache paths such as `components/buttons/overview.md`, `components/buttons/guidelines.md`, `components/buttons/specs.md`, and `components/buttons/accessibility.md`, not the failed `google-material-3/pages/...` or `m3/pages/...` routes.
+
+## Confirmed foundation state
+
+### Tokens
+
+`src/shared/lib/md/tokens.css` already contains a single-root Material token bundle with:
+
+- reference palette tokens for primary, secondary, tertiary, error, neutral, and neutral variant colors;
+- reference typeface tokens;
+- system shape corner tokens;
+- light system color role mappings;
+- dark system color role overrides under `@media (prefers-color-scheme: dark)`;
+- system elevation tokens;
+- system typescale tokens;
+- system state opacity and focus-indicator tokens;
+- system motion duration and easing tokens;
+- one component token: `--md-comp-progress-indicator-active-indicator-color`.
+
+Current gaps:
+
+- Component-family tokens are mostly still local implementation variables inside components, for example `MDButton.vue` uses local `--md-button-*` variables instead of canonical public `--md-comp-button-*` tokens.
+- `--unknownColor` is a debug fallback and should not be treated as a production token.
+- `--md-sys-color-surface-tint-color` is explicitly marked deprecated and should be removed or isolated as a compatibility alias during a focused token cleanup.
+- The token bundle is monolithic. The adoption plan already says structural cleanup should happen later, after the foundation audit and pilot prove the pattern.
+- Baseline theme has light and dark system color mappings, but the audit has not yet proven full parity against every official Material role.
+
+### Units and typography
+
+`postcss.config.js` currently converts these custom units:
+
+- `step` through `--one-step`;
+- `pt` through `--one-pt`;
+- `dp` through `--one-dp`.
+
+Confirmed gap:
+
+- `sp` support is not currently present in PostCSS.
+- `src/shared/lib/md/tokens.css` still defines Material typescale sizes, tracking, and line heights with `pt`.
+- The next typography foundation task should add `sp` conversion first, then migrate Material typography authoring values from `pt` to `sp` without changing rendered output unintentionally.
+
+### State layers
+
+The shared state primitives exist as `src/shared/ui/State/MDStateLayer.vue`, `useStateLayer`, and `useRipple`, and they are already used by `MDButton.vue` for hover, focus, pressed, disabled, and ripple behavior.
+
+Current gaps:
+
+- State layer behavior is not yet documented as the canonical primitive for every interactive `MD*` component family.
+- Existing visual stories cover some state surfaces, but the registry must make coverage explicit per component family.
+- Dragged and selected states need per-component review rather than assuming a global state-layer mapping.
+
+### Icons
+
+`src/shared/ui/Icon/MDSymbol.vue` exists as the Material Symbol primitive.
+
+Current gaps:
+
+- The audit has not yet verified whether every icon-bearing Material component uses `MDSymbol` directly or accepts icon slots that can preserve Material Symbol sizing.
+- The public icon API strategy should be documented per component family: slot-only, symbol-name prop, or project-specific wrapper.
+
+### Overlays
+
+The adoption plan states that overlay ownership already exists through `useOverlayContainer`, `TeleportContainer`, child teleported container registration, and outside-interaction containment. The audit should preserve this model.
+
+Current gaps:
+
+- Overlay component families still need per-surface review: dialogs, menus, tooltips, bottom sheets, select menus, and context menus.
+- Any remaining local z-index usage should be inventoried and either justified as local stacking inside an owned overlay or scheduled for replacement through the existing containment model.
+- Escape/back stacking and focus-trap behavior should be verified by browser smoke or Playwright checks when a specific overlay family is migrated.
+
+### Storybook
+
+Confirmed state from representative stories:
+
+- `src/shared/ui/Button/MDButton.stories.ts` exists and includes visual stories tagged with `visual` for button states and interaction states.
+- Some current Storybook titles still use paths such as `shared/ui/MDButton` rather than the policy target `Material 3/Components/...` or `Project UI/...`.
+- Several visual helper stories already exist for buttons, icon buttons, chips, lists, and target-hit areas.
+
+Current gaps:
+
+- Story hierarchy is not yet normalized to look like Material 3 documentation.
+- Stories do not consistently record checked Material docs, token status, public API notes, and deviations.
+- Legacy playground components still exist and should not be expanded as the primary documentation surface.
+
+### Visual regression
+
+Confirmed state:
+
+- Visual stories are already present for some high-risk UI surfaces.
+- The repository policy requires Playwright screenshots through Storybook for visual appearance, not Vue unit tests.
+
+Current gaps:
+
+- The project does not yet have a registry-level map from component family to visual coverage.
+- The next visual coverage work should prioritize shared UI primitives, Material state visuals, target hit areas, overlays, and mobile/desktop adaptive surfaces. It should not add screenshots for every component by default.
+
+## Component-family baseline
+
+The expanded registry lives in [Component registry](./component-registry.md). At this audit stage, most components are `partial` because they exist but do not yet have docs-backed API, canonical component tokens, normalized Storybook docs, visual/browser verification, and documented deviations.
+
+The first implementation family should remain Buttons unless a deeper source-backed review contradicts this. Buttons already have a clear implementation surface, Storybook visual states, target-hit stories, and representative Material variants.
+
+## Token inventory plan
+
+Use this classification during component-family conversion:
+
+| Token category | Definition | Current examples | Required action |
+| --- | --- | --- | --- |
+| Reference token | Material reference palette or typeface value. | `--md-ref-palette-primary40`, `--md-ref-typeface-plain` | Keep under Material vocabulary; verify against official roles. |
+| System token | Material system role consumed by many components. | `--md-sys-color-primary`, `--md-sys-shape-corner-large`, `--md-sys-state-hover-state-layer-opacity` | Keep public and stable; fill missing roles only from official docs. |
+| Public component token | Canonical component boundary token. | `--md-comp-progress-indicator-active-indicator-color` | Expand per component family using `--md-comp-*`. |
+| Private implementation variable | Local component CSS variable with no public contract. | `--md-button-height`, `--md-button-padding` | Either convert to `--md-comp-*` or keep private with non-public naming during family migration. |
+| App-specific token | Project/application value outside Material token vocabulary. | `--app-*` target namespace from policy | Move non-Material app values here instead of inventing `--md-*`. |
+| Compatibility alias | Temporary alias for old in-repo usage. | `--md-sys-color-surface-tint-color` | Remove when possible; document if temporarily retained. |
+| Obsolete/debug token | Not part of production contract. | `--unknownColor` | Remove or isolate from production token API. |
+| Unresolved token | Material-looking token without verified source or clear ownership. | Any newly found ad hoc `--md-*` | Block alignment until classified. |
+
+## Typography migration plan
+
+1. Add PostCSS conversion for `sp` through a stable base variable such as `--one-sp`.
+2. Define `--one-sp` where the other unit base variables are defined.
+3. Convert Material typescale token authoring values from `pt` to `sp` in a focused PR.
+4. Verify that rendered typography does not change unless the PR intentionally updates Material values.
+5. Keep non-Material text sizing outside Material tokens unless it maps to an official typescale role.
+
+## Baseline theme gap analysis
+
+| Area | Current state | Gap | Follow-up |
+| --- | --- | --- | --- |
+| Reference palette | Partial palette is present. | Not proven complete against every Material role/tone. | Audit against cache/MCP color role pages. |
+| System color | Light and dark mappings exist. | Needs full role parity check and removal of deprecated alias. | Token validation PR. |
+| Typography | Typescale tokens exist. | Uses `pt`; no `sp` unit conversion. | `sp` foundation PR before typography migration. |
+| Shape | Core corner tokens exist. | Mixed `px`, `dp`, and `cqmin`; needs source-backed review. | Shape token audit. |
+| Elevation | Levels 0-5 exist. | Dark-mode overrides are partial; surface tint behavior not fully verified. | Elevation/color validation. |
+| Motion | Duration and easing tokens exist. | Token names and component usage need source-backed verification. | Motion token audit during component migration. |
+| State | Opacity/focus indicator tokens exist. | Dragged/selected/loading coverage is per-component, not global. | Per-family checklist. |
+| Component tokens | Almost absent globally. | Component CSS owns local variables. | Introduce `--md-comp-*` during each family conversion. |
+
+## Overlay review plan
+
+Preserve the existing overlay ownership model by default. For each overlay family, audit:
+
+- the owning rendered DOM hierarchy;
+- teleport container ownership;
+- outside-interaction containment;
+- escape/back stacking;
+- focus trap and restoration;
+- scroll-container behavior;
+- local z-index usage;
+- mobile viewport behavior.
+
+Do not introduce a numeric z-index ownership model unless a concrete reviewed gap cannot be solved through existing overlay containment.
+
+## Shared UI API migration list
+
+Initial public API risks to review during component-family conversion:
+
+- Buttons: `color` should be reviewed against Material variant vocabulary; `formAction` hides native `type` semantics and should be reviewed; `type="toggle"`, `shape`, `size`, `selected`, and `loading` need official-doc-backed classification as Material, extension, or project-specific behavior.
+- Icon buttons: verify variant, selected/toggle, target area, and icon sizing contracts.
+- FAB: verify size, label/extended behavior, placement helpers, and container responsibilities.
+- Lists: verify interactive list item contract, trailing action behavior, density, supporting text, leading/trailing content, and target-area rules.
+- Dialogs: verify action count, destructive flows, focus behavior, modal semantics, adaptive behavior, and scroll behavior.
+- Text fields/select/checkbox: verify value/update contracts, error/supporting text, labels, accessibility, and menu ownership.
+- Chips/menus/tooltips/snackbars/navigation/sheets: classify project extensions and missing official variants before public API changes.
+
+Do not keep old shared UI APIs only for internal compatibility. Migrate in-repository consumers in the same focused family PR unless a compatibility alias is technically necessary and documented.
+
+## Storybook coverage plan
+
+Use these target roots:
+
+- `Material 3/Components/<Surface>` for official Material-aligned components;
+- `Project UI/<Surface>` for project-specific components that only use Material foundations.
+
+Every aligned component-family story should document:
+
+- official Material pages checked;
+- supported variants/configurations;
+- public props and slots;
+- public component tokens;
+- states and accessibility notes;
+- unsupported official features;
+- project-specific deviations.
+
+Do not expand legacy playgrounds as the primary documentation surface. Convert useful playground examples into deterministic CSF stories.
+
+## Visual regression coverage plan
+
+Prioritize visual screenshots for:
+
+1. Button, icon button, and FAB variants/states/target areas.
+2. List item states, density, leading/trailing content, and trailing action combinations.
+3. Dialog and sheet responsive layouts, focus surfaces, and scroll boundaries.
+4. Text field/select/checkbox states, error/supporting text, and disabled states.
+5. Navigation bar/rail/app bar responsive switching and selected states.
+6. Chips/menus/tooltips/snackbars only where CSS-heavy states or overlays are likely to regress.
+
+Avoid generic screenshots for every component. Each visual story must prove a high-value Material state, layout, target-area, overlay, or previously broken surface.
+
+## Prioritized conversion order
+
+Keep the adoption-plan order:
+
+1. Buttons pilot: `MDButton`, `MDIconButton`, `MDFab`, `MDFabContainer`, deprecated button compatibility exports.
+2. Lists: `MDList`, `MDListItem`, `MDListContainer`.
+3. Dialogs and overlays needed by dialogs.
+4. Text fields and selection controls: `MDTextField`, `MDFieldContainer`, `MDSelectBase`, `MDCheckbox`, `MDCheckboxField`.
+5. Chips and menus: `MDChipBase`, chip wrappers, `MDMenuBase`, `MDMenuItemBase`, context menus.
+6. Navigation, app bars, toolbars, and sheets: navigation bar/rail/path, `MDAppBar`, toolbar containers, bottom sheets.
+7. Cards, progress indicators, tooltips, dividers, snackbars, tables, empty states, panes, and project-specific surfaces.
+
+## Next implementation PR
+
+The smallest safe next implementation PR is the Buttons pilot.
+
+Before editing Button code, the agent must:
+
+- check `components/buttons/overview.md`, `components/buttons/guidelines.md`, `components/buttons/specs.md`, and `components/buttons/accessibility.md` through Material MCP or `m3-docs-cache` fallback;
+- update the Buttons registry row from `partial` toward `aligned`;
+- define public `--md-comp-button-*` tokens at the component boundary;
+- classify every current public prop and slot;
+- document invalid combinations or project-specific extensions;
+- normalize Storybook hierarchy and docs;
+- keep existing target-hit visual coverage and add only missing high-value visual/browser checks.

--- a/docs/material-3/foundation-audit.md
+++ b/docs/material-3/foundation-audit.md
@@ -4,15 +4,32 @@
 
 This audit starts Phase 2 from [Material 3 adoption plan](./adoption-plan.md). It records the current foundation state before any component-family migration.
 
-This document is intentionally documentation-only. It must not migrate component implementations, rename public props, reorganize shared UI source files, or update visual snapshots.
+This document is documentation-only. It must not migrate component implementations, rename public props, reorganize shared UI source files, or update visual snapshots.
+
+Detailed findings are split across related documents:
+
+- [Foundation audit details](./foundation-audit-details.md)
+- [Component family audit](./component-family-audit.md)
+- [Secondary component family audit](./secondary-component-family-audit.md)
+- [Component registry](./component-registry.md)
 
 ## Source status
 
-- Project policy sources checked: every policy listed by `.agents/skills/material3-guidelines/SKILL.md` remains the project contract for UI work.
-- Repository implementation sources checked: `src/shared/lib/md/tokens.css`, `postcss.config.js`, existing `src/shared/ui/**/MD*.vue` surfaces found through repository search, and representative Storybook files such as `src/shared/ui/Button/MDButton.stories.ts`.
-- Official Material 3 MCP status: not available in the current execution environment.
-- Fallback cache status: `Vyachean/m3-docs-cache/index.json` is available, captured from `https://m3.material.io` at `2026-05-19T05:56:22.642Z`, with 357 captured pages, 609 attempted pages, and 20 failed pages.
-- Fallback cache warning: the cache marks several old or internal routes as suspicious/not-found. Use stable cache paths such as `components/buttons/overview.md`, `components/buttons/guidelines.md`, `components/buttons/specs.md`, and `components/buttons/accessibility.md`, not the failed `google-material-3/pages/...` or `m3/pages/...` routes.
+Project sources checked:
+
+- Material 3 project policies listed by `.agents/skills/material3-guidelines/SKILL.md`.
+- `src/shared/lib/md/tokens.css`.
+- `postcss.config.js`.
+- Existing `src/shared/ui/**/MD*.vue` surfaces found through repository search.
+- Representative Storybook files such as `src/shared/ui/Button/MDButton.stories.ts`.
+- `tests/e2e/visual/shared-ui.spec.ts`.
+
+Material source checked:
+
+- `Vyachean/m3-docs-cache`, captured from `https://m3.material.io` at `2026-05-19T05:56:22.642Z`.
+- Component cache pages for Buttons, Icon buttons, FAB, Lists, Dialogs, Text fields, Checkbox, Chips, Menus, Navigation bar, Bottom sheets, Cards, Progress indicators, Tooltips, and Snackbar.
+
+Use stable cache paths under `pages/components/...`. Avoid old failed or suspicious `google-material-3/pages/...` and `m3/pages/...` routes from the cache quality report.
 
 ## Confirmed foundation state
 
@@ -24,7 +41,7 @@ This document is intentionally documentation-only. It must not migrate component
 - reference typeface tokens;
 - system shape corner tokens;
 - light system color role mappings;
-- dark system color role overrides under `@media (prefers-color-scheme: dark)`;
+- dark system color role overrides under `prefers-color-scheme`;
 - system elevation tokens;
 - system typescale tokens;
 - system state opacity and focus-indicator tokens;
@@ -33,15 +50,15 @@ This document is intentionally documentation-only. It must not migrate component
 
 Current gaps:
 
-- Component-family tokens are mostly still local implementation variables inside components, for example `MDButton.vue` uses local `--md-button-*` variables instead of canonical public `--md-comp-button-*` tokens.
+- Component-family tokens are mostly still local implementation variables inside components. For example, `MDButton.vue` uses local `--md-button-*` variables instead of canonical public `--md-comp-button-*` tokens.
 - `--unknownColor` is a debug fallback and should not be treated as a production token.
-- `--md-sys-color-surface-tint-color` is explicitly marked deprecated and should be removed or isolated as a compatibility alias during a focused token cleanup.
-- The token bundle is monolithic. The adoption plan already says structural cleanup should happen later, after the foundation audit and pilot prove the pattern.
-- Baseline theme has light and dark system color mappings, but the audit has not yet proven full parity against every official Material role.
+- `--md-sys-color-surface-tint-color` is explicitly marked deprecated and should be removed or isolated as a compatibility alias during focused token cleanup.
+- The token bundle is monolithic. Keep it until the audit and pilot prove the next structure.
+- Baseline theme has light and dark system color mappings, but full parity with every Material role is not yet validated by tooling.
 
 ### Units and typography
 
-`postcss.config.js` currently converts these custom units:
+`postcss.config.js` currently converts:
 
 - `step` through `--one-step`;
 - `pt` through `--one-pt`;
@@ -50,84 +67,78 @@ Current gaps:
 Confirmed gap:
 
 - `sp` support is not currently present in PostCSS.
-- `src/shared/lib/md/tokens.css` still defines Material typescale sizes, tracking, and line heights with `pt`.
+- `tokens.css` still defines Material typescale sizes, tracking, and line heights with `pt`.
 - The next typography foundation task should add `sp` conversion first, then migrate Material typography authoring values from `pt` to `sp` without changing rendered output unintentionally.
 
 ### State layers
 
-The shared state primitives exist as `src/shared/ui/State/MDStateLayer.vue`, `useStateLayer`, and `useRipple`, and they are already used by `MDButton.vue` for hover, focus, pressed, disabled, and ripple behavior.
+The shared state primitives exist as `MDStateLayer`, `useStateLayer`, and `useRipple`. They are already used by key interactive components.
 
 Current gaps:
 
-- State layer behavior is not yet documented as the canonical primitive for every interactive `MD*` component family.
-- Existing visual stories cover some state surfaces, but the registry must make coverage explicit per component family.
-- Dragged and selected states need per-component review rather than assuming a global state-layer mapping.
+- `MDStateLayer` does not directly consume the declared `--md-sys-state-*-state-layer-opacity` tokens.
+- Dragged and selected states need per-component review rather than a global assumption.
+- State-layer behavior should be documented as the canonical primitive for every interactive `MD*` component family.
 
 ### Icons
 
-`src/shared/ui/Icon/MDSymbol.vue` exists as the Material Symbol primitive.
+`MDSymbol` exists as the Material Symbol primitive.
 
 Current gaps:
 
-- The audit has not yet verified whether every icon-bearing Material component uses `MDSymbol` directly or accepts icon slots that can preserve Material Symbol sizing.
-- The public icon API strategy should be documented per component family: slot-only, symbol-name prop, or project-specific wrapper.
+- Not every icon-bearing component has a verified public icon API strategy.
+- Each family should decide between slot-only, symbol-name prop, or project-specific wrapper APIs.
+- Icon sizes must be checked per family against Material cache pages.
 
 ### Overlays
 
-The adoption plan states that overlay ownership already exists through `useOverlayContainer`, `TeleportContainer`, child teleported container registration, and outside-interaction containment. The audit should preserve this model.
+The project already has overlay ownership policy around `useOverlayContainer`, teleport containers, child teleported container registration, and outside-interaction containment.
 
 Current gaps:
 
-- Overlay component families still need per-surface review: dialogs, menus, tooltips, bottom sheets, select menus, and context menus.
-- Any remaining local z-index usage should be inventoried and either justified as local stacking inside an owned overlay or scheduled for replacement through the existing containment model.
-- Escape/back stacking and focus-trap behavior should be verified by browser smoke or Playwright checks when a specific overlay family is migrated.
+- Menus use the shared overlay and teleport model.
+- Dialogs currently use a separate native dialog and fixed scrim path.
+- Bottom sheets, tooltips, select menus, and context menus still need per-surface overlay review.
+- Escape/back stacking, focus trap, scroll locking, and local z-index usage need browser verification when a specific overlay family is migrated.
 
 ### Storybook
 
-Confirmed state from representative stories:
+Current state:
 
-- `src/shared/ui/Button/MDButton.stories.ts` exists and includes visual stories tagged with `visual` for button states and interaction states.
-- Some current Storybook titles still use paths such as `shared/ui/MDButton` rather than the policy target `Material 3/Components/...` or `Project UI/...`.
-- Several visual helper stories already exist for buttons, icon buttons, chips, lists, and target-hit areas.
+- Representative shared UI stories exist.
+- Visual helper stories already exist for buttons, icon buttons, chips, lists, and target-hit areas.
+- Some stories still use titles such as `shared/ui/MDButton` rather than `Material 3/Components/...` or `Project UI/...`.
 
 Current gaps:
 
 - Story hierarchy is not yet normalized to look like Material 3 documentation.
 - Stories do not consistently record checked Material docs, token status, public API notes, and deviations.
-- Legacy playground components still exist and should not be expanded as the primary documentation surface.
+- Legacy playground components should not be expanded as the primary documentation surface.
 
 ### Visual regression
 
-Confirmed state:
+Current state:
 
-- Visual stories are already present for some high-risk UI surfaces.
-- The repository policy requires Playwright screenshots through Storybook for visual appearance, not Vue unit tests.
+- Visual tests already cover important state surfaces for Buttons, Icon buttons, FABs, Chips, Checkboxes, List items, and State layers.
+- Playwright through Storybook is the correct verification path for visual appearance.
 
 Current gaps:
 
-- The project does not yet have a registry-level map from component family to visual coverage.
-- The next visual coverage work should prioritize shared UI primitives, Material state visuals, target hit areas, overlays, and mobile/desktop adaptive surfaces. It should not add screenshots for every component by default.
-
-## Component-family baseline
-
-The expanded registry lives in [Component registry](./component-registry.md). At this audit stage, most components are `partial` because they exist but do not yet have docs-backed API, canonical component tokens, normalized Storybook docs, visual/browser verification, and documented deviations.
-
-The first implementation family should remain Buttons unless a deeper source-backed review contradicts this. Buttons already have a clear implementation surface, Storybook visual states, target-hit stories, and representative Material variants.
+- Dialogs, text fields, menus, sheets, navigation, cards, tooltips, snackbars, and progress indicators need registry-backed Storybook and visual or browser coverage.
+- Visual coverage should stay focused on high-value states, target areas, overlays, and responsive surfaces. It should not become screenshot coverage for every component by default.
 
 ## Token inventory plan
 
 Use this classification during component-family conversion:
 
-| Token category | Definition | Current examples | Required action |
-| --- | --- | --- | --- |
-| Reference token | Material reference palette or typeface value. | `--md-ref-palette-primary40`, `--md-ref-typeface-plain` | Keep under Material vocabulary; verify against official roles. |
-| System token | Material system role consumed by many components. | `--md-sys-color-primary`, `--md-sys-shape-corner-large`, `--md-sys-state-hover-state-layer-opacity` | Keep public and stable; fill missing roles only from official docs. |
-| Public component token | Canonical component boundary token. | `--md-comp-progress-indicator-active-indicator-color` | Expand per component family using `--md-comp-*`. |
-| Private implementation variable | Local component CSS variable with no public contract. | `--md-button-height`, `--md-button-padding` | Either convert to `--md-comp-*` or keep private with non-public naming during family migration. |
-| App-specific token | Project/application value outside Material token vocabulary. | `--app-*` target namespace from policy | Move non-Material app values here instead of inventing `--md-*`. |
-| Compatibility alias | Temporary alias for old in-repo usage. | `--md-sys-color-surface-tint-color` | Remove when possible; document if temporarily retained. |
-| Obsolete/debug token | Not part of production contract. | `--unknownColor` | Remove or isolate from production token API. |
-| Unresolved token | Material-looking token without verified source or clear ownership. | Any newly found ad hoc `--md-*` | Block alignment until classified. |
+- Reference tokens: Material reference palette or typeface values, such as `--md-ref-palette-primary40` and `--md-ref-typeface-plain`. Keep under Material vocabulary and verify against official roles.
+- System tokens: Material system roles consumed by many components, such as `--md-sys-color-primary`, `--md-sys-shape-corner-large`, and `--md-sys-state-hover-state-layer-opacity`. Keep public and stable.
+- Public component tokens: component boundary tokens such as `--md-comp-progress-indicator-active-indicator-color`. Expand per component family using `--md-comp-*`.
+- Private implementation variables: local component variables such as `--md-button-height` and `--md-button-padding`. Convert to `--md-comp-*` only when they are part of the public component contract.
+- App-specific tokens: project values outside Material vocabulary. Move them to `--app-*` instead of inventing new `--md-*` tokens.
+- Compatibility aliases: temporary aliases for old in-repo usage, such as `--md-sys-color-surface-tint-color`. Remove when possible and document if temporarily retained.
+- Obsolete or debug tokens: values such as `--unknownColor`. Remove or isolate from production token API.
+- Unresolved tokens: Material-looking variables without verified source or clear ownership. Block alignment until classified.
 
 ## Typography migration plan
 
@@ -139,43 +150,26 @@ Use this classification during component-family conversion:
 
 ## Baseline theme gap analysis
 
-| Area | Current state | Gap | Follow-up |
-| --- | --- | --- | --- |
-| Reference palette | Partial palette is present. | Not proven complete against every Material role/tone. | Audit against cache/MCP color role pages. |
-| System color | Light and dark mappings exist. | Needs full role parity check and removal of deprecated alias. | Token validation PR. |
-| Typography | Typescale tokens exist. | Uses `pt`; no `sp` unit conversion. | `sp` foundation PR before typography migration. |
-| Shape | Core corner tokens exist. | Mixed `px`, `dp`, and `cqmin`; needs source-backed review. | Shape token audit. |
-| Elevation | Levels 0-5 exist. | Dark-mode overrides are partial; surface tint behavior not fully verified. | Elevation/color validation. |
-| Motion | Duration and easing tokens exist. | Token names and component usage need source-backed verification. | Motion token audit during component migration. |
-| State | Opacity/focus indicator tokens exist. | Dragged/selected/loading coverage is per-component, not global. | Per-family checklist. |
-| Component tokens | Almost absent globally. | Component CSS owns local variables. | Introduce `--md-comp-*` during each family conversion. |
-
-## Overlay review plan
-
-Preserve the existing overlay ownership model by default. For each overlay family, audit:
-
-- the owning rendered DOM hierarchy;
-- teleport container ownership;
-- outside-interaction containment;
-- escape/back stacking;
-- focus trap and restoration;
-- scroll-container behavior;
-- local z-index usage;
-- mobile viewport behavior.
-
-Do not introduce a numeric z-index ownership model unless a concrete reviewed gap cannot be solved through existing overlay containment.
+- Reference palette: partial palette is present, but completeness across every role and tone is not validated.
+- System color: light and dark mappings exist; full role parity and deprecated alias removal need a token validation PR.
+- Typography: typescale tokens exist, but they use `pt` and need `sp` support before migration.
+- Shape: core corner tokens exist, but mixed `px`, `dp`, and `cqmin` values need source-backed review.
+- Elevation: levels 0-5 exist, but dark-mode overrides and surface tint behavior need validation.
+- Motion: duration and easing tokens exist, but names and component usage need verification during component migration.
+- State: opacity and focus-indicator tokens exist, but dragged, selected, and loading coverage is per-component rather than global.
+- Component tokens: component CSS still owns most local variables. Introduce `--md-comp-*` during each family conversion.
 
 ## Shared UI API migration list
 
 Initial public API risks to review during component-family conversion:
 
-- Buttons: `color` should be reviewed against Material variant vocabulary; `formAction` hides native `type` semantics and should be reviewed; `type="toggle"`, `shape`, `size`, `selected`, and `loading` need official-doc-backed classification as Material, extension, or project-specific behavior.
-- Icon buttons: verify variant, selected/toggle, target area, and icon sizing contracts.
-- FAB: verify size, label/extended behavior, placement helpers, and container responsibilities.
+- Buttons: review `color`, `formAction`, `type`, `shape`, `size`, `selected`, and `loading` against Material vocabulary and project extensions.
+- Icon buttons: verify variant, selected/toggle, target area, width, shape, tooltip, and icon sizing contracts.
+- FAB: verify size, color naming, placement helpers, loading, and container responsibilities.
 - Lists: verify interactive list item contract, trailing action behavior, density, supporting text, leading/trailing content, and target-area rules.
 - Dialogs: verify action count, destructive flows, focus behavior, modal semantics, adaptive behavior, and scroll behavior.
-- Text fields/select/checkbox: verify value/update contracts, error/supporting text, labels, accessibility, and menu ownership.
-- Chips/menus/tooltips/snackbars/navigation/sheets: classify project extensions and missing official variants before public API changes.
+- Text fields and selection controls: verify value/update contracts, error/supporting text, labels, accessibility, and menu ownership.
+- Chips, menus, tooltips, snackbars, navigation, and sheets: classify project extensions and missing official variants before public API changes.
 
 Do not keep old shared UI APIs only for internal compatibility. Migrate in-repository consumers in the same focused family PR unless a compatibility alias is technically necessary and documented.
 
@@ -183,13 +177,13 @@ Do not keep old shared UI APIs only for internal compatibility. Migrate in-repos
 
 Use these target roots:
 
-- `Material 3/Components/<Surface>` for official Material-aligned components;
+- `Material 3/Components/<Surface>` for official Material-aligned components.
 - `Project UI/<Surface>` for project-specific components that only use Material foundations.
 
 Every aligned component-family story should document:
 
 - official Material pages checked;
-- supported variants/configurations;
+- supported variants and configurations;
 - public props and slots;
 - public component tokens;
 - states and accessibility notes;
@@ -202,12 +196,12 @@ Do not expand legacy playgrounds as the primary documentation surface. Convert u
 
 Prioritize visual screenshots for:
 
-1. Button, icon button, and FAB variants/states/target areas.
+1. Button, icon button, and FAB variants, states, and target areas.
 2. List item states, density, leading/trailing content, and trailing action combinations.
 3. Dialog and sheet responsive layouts, focus surfaces, and scroll boundaries.
-4. Text field/select/checkbox states, error/supporting text, and disabled states.
-5. Navigation bar/rail/app bar responsive switching and selected states.
-6. Chips/menus/tooltips/snackbars only where CSS-heavy states or overlays are likely to regress.
+4. Text field, select, and checkbox states, error/supporting text, and disabled states.
+5. Navigation bar, rail, and app bar responsive switching and selected states.
+6. Chips, menus, tooltips, and snackbars only where CSS-heavy states or overlays are likely to regress.
 
 Avoid generic screenshots for every component. Each visual story must prove a high-value Material state, layout, target-area, overlay, or previously broken surface.
 
@@ -215,24 +209,32 @@ Avoid generic screenshots for every component. Each visual story must prove a hi
 
 Keep the adoption-plan order:
 
-1. Buttons pilot: `MDButton`, `MDIconButton`, `MDFab`, `MDFabContainer`, deprecated button compatibility exports.
-2. Lists: `MDList`, `MDListItem`, `MDListContainer`.
+1. Buttons pilot: `MDButton`, `MDIconButton`, `MDFab`, `MDFabContainer`, and deprecated button compatibility exports.
+2. Lists: `MDList`, `MDListItem`, and `MDListContainer`.
 3. Dialogs and overlays needed by dialogs.
-4. Text fields and selection controls: `MDTextField`, `MDFieldContainer`, `MDSelectBase`, `MDCheckbox`, `MDCheckboxField`.
-5. Chips and menus: `MDChipBase`, chip wrappers, `MDMenuBase`, `MDMenuItemBase`, context menus.
-6. Navigation, app bars, toolbars, and sheets: navigation bar/rail/path, `MDAppBar`, toolbar containers, bottom sheets.
+4. Text fields and selection controls: `MDTextField`, `MDFieldContainer`, `MDSelectBase`, `MDCheckbox`, and `MDCheckboxField`.
+5. Chips and menus: `MDChipBase`, chip wrappers, `MDMenuBase`, `MDMenuItemBase`, and context menus.
+6. Navigation, app bars, toolbars, and sheets.
 7. Cards, progress indicators, tooltips, dividers, snackbars, tables, empty states, panes, and project-specific surfaces.
 
 ## Next implementation PR
 
-The smallest safe next implementation PR is the Buttons pilot.
+The smallest safe next implementation PR is foundation token wiring, followed by the Buttons pilot.
 
-Before editing Button code, the agent must:
+Foundation token wiring should:
 
-- check `components/buttons/overview.md`, `components/buttons/guidelines.md`, `components/buttons/specs.md`, and `components/buttons/accessibility.md` through Material MCP or `m3-docs-cache` fallback;
+- add `sp` unit support;
+- wire `MDStateLayer` to system state opacity tokens;
+- decide and document dragged state;
+- isolate or remove `--unknownColor` from public production token API;
+- run focused visual checks for state-layer consumers.
+
+Buttons pilot should:
+
+- check the relevant Material cache pages;
 - update the Buttons registry row from `partial` toward `aligned`;
-- define public `--md-comp-button-*` tokens at the component boundary;
+- define public `--md-comp-button-*`, `--md-comp-icon-button-*`, and `--md-comp-fab-*` tokens;
 - classify every current public prop and slot;
 - document invalid combinations or project-specific extensions;
 - normalize Storybook hierarchy and docs;
-- keep existing target-hit visual coverage and add only missing high-value visual/browser checks.
+- keep existing target-hit visual coverage and add only missing high-value visual or browser checks.

--- a/docs/material-3/secondary-component-family-audit.md
+++ b/docs/material-3/secondary-component-family-audit.md
@@ -1,0 +1,171 @@
+# Secondary Material 3 component family audit
+
+This file covers component families that were only summarized in [Component family audit](./component-family-audit.md). It prevents the registry rows from remaining unaudited placeholders.
+
+## Selection controls: `MDCheckbox`, `MDCheckboxField`, `MDSelectBase`
+
+Material cache confirms checkboxes are for selecting one or more items from a list or toggling an item, labels should be scannable, selected items are more prominent, and M3 adds indeterminate and error states.
+
+Current checkbox state:
+
+- `MDCheckbox` supports selected, unselected, indeterminate, error, disabled, readonly, presentation mode, tooltip, aria label, autofocus, and keyboard toggling.
+- It uses `MDStateLayer`, `useStateLayer`, ripple, `MDSymbol`, and `MDPlainTooltip`.
+- Visual tests cover checkbox states and interaction states.
+
+Gaps:
+
+- no `--md-comp-checkbox-*` token set;
+- checkbox host is a custom label with hidden native input and custom keyboard handling, so browser/accessibility behavior must be verified carefully;
+- `readonly`, `presentation`, and tooltip are project extensions and should be documented;
+- `MDCheckboxField` should be classified as a project-specific wrapper unless it maps to a Material form field pattern;
+- `MDSelectBase` depends on menu/text-field behavior and should not be migrated before menu ownership and field tokens are clear.
+
+Verdict: checkbox can be migrated with selection controls after text fields or alongside the first form-family PR. Select should wait for menu alignment.
+
+## Navigation: bar, rail, and path
+
+Material cache confirms navigation bars are for compact and medium windows, should contain 3-5 stable destinations of equal importance, and M3 Expressive introduces a flexible navigation bar. Language Web implementation is unavailable in the Material cache, so the project must rely on the general Material documentation, not a web reference implementation.
+
+Current navigation bar state:
+
+- `MDNavigationBar` renders buttons from a destination list and has horizontal/vertical type variants.
+- `MDNavigationPath` is a project breadcrumb/path surface, not a confirmed Material component.
+- Navigation rail is present in shared UI but was not deeply checked in this audit.
+
+Gaps:
+
+- no `--md-comp-navigation-bar-*` or `--md-comp-navigation-rail-*` token sets;
+- adaptive ownership is unclear: the component exposes a type prop, but the app shell likely owns compact/medium/expanded switching;
+- destination count/stability is not enforced by the shared component;
+- Storybook and visual coverage were not confirmed for navigation bar/rail responsive states;
+- `MDNavigationPath` should remain `project-specific` unless a Material surface mapping is found.
+
+Verdict: migrate after core input/overlay families, unless navigation visual regressions become product-critical.
+
+## App bars and toolbars
+
+Material app-bar docs exist in the cache, but some top-app-bar routes are marked failed/suspicious in `index.json`. Use stable `pages/components/app-bars/...` paths and avoid old failed routes.
+
+Current state:
+
+- `MDAppBar` exists.
+- `MDToolbarContainer` and toolbar playgrounds exist.
+- Toolbar behavior is also indirectly covered by `MDIconButton` compact-toolbar visual/behavior tests.
+
+Gaps:
+
+- no app-bar or toolbar component-token set;
+- toolbar containers may be project layout helpers, not official Material app bars;
+- scroll behavior, navigation icon ownership, action layout, and responsive behavior need source-backed review;
+- app-bar and toolbar Storybook hierarchy is not normalized.
+
+Verdict: keep toolbars project-specific unless mapped to app-bar guidance during that family migration.
+
+## Bottom sheets
+
+Material cache confirms bottom sheets show secondary content anchored to the bottom, are intended for compact/medium windows, have standard and modal variants, can be dismissed, use 28dp top corner radius, max width 640dp, and may have a drag handle with a 48dp hit target.
+
+Current state:
+
+- `MDBottomSheet` supports `standard` and `modal` type, label, collapsed/fullscreen models, overlay container for modal type, and teleport placeholder positioning.
+- `MDBottomSheet2` and duplicate container/section variants also exist.
+
+Gaps:
+
+- no `--md-comp-bottom-sheet-*` token set;
+- duplicate `*2` sheet family needs architectural resolution before alignment can be claimed;
+- drag handle, 48dp hit target, modal scrim, focus trap, escape/back behavior, scroll locking, and max-width behavior need browser verification;
+- current code has a FIXME to remove `TeleportWithPlaceholder`, so sheet ownership is not stable enough for alignment.
+
+Verdict: migrate after dialogs/menus establish the final overlay model.
+
+## Cards
+
+Material cache confirms cards contain related content/actions about a single subject and have elevated, filled, and outlined variants.
+
+Current state:
+
+- `MDCard` exists but was not deeply checked in this audit.
+
+Gaps:
+
+- no `--md-comp-card-*` token set;
+- official variant support is not confirmed;
+- clickability, content slots, elevation, outline, and action layout need review;
+- visual coverage was not confirmed.
+
+Verdict: low risk if currently simple, but do not mark aligned until variants/tokens/stories are checked.
+
+## Progress indicators
+
+Material cache confirms progress indicators have linear and circular variants, should use consistent configuration for the same process, and have shape/thickness/wavy configuration updates.
+
+Current state:
+
+- Progress indicator components exist and are used by buttons/FABs for loading states.
+- Only one global component token was found: `--md-comp-progress-indicator-active-indicator-color`.
+
+Gaps:
+
+- full linear/circular split and token set are not documented;
+- loading usage inside buttons/FABs is project-specific and should not define the whole progress indicator API;
+- determinate/indeterminate semantics and accessibility need review;
+- registry-backed visual coverage was not confirmed for standalone progress indicators.
+
+Verdict: migrate after core controls unless loading states force earlier token cleanup.
+
+## Tooltips
+
+Material cache confirms plain and rich tooltip variants. Plain tooltips describe icon-only actions; rich tooltips provide additional context and can include title, link, and buttons.
+
+Current state:
+
+- `MDPlainTooltip`, `MDRichTooltip`, and `MDOverlayTooltip` exist.
+- Icon buttons require tooltip text and can render plain or rich tooltip content.
+
+Gaps:
+
+- no `--md-comp-tooltip-*` token set;
+- trigger ownership, hover/focus delay, click behavior, escape handling, nested overlays, and mobile behavior need source-backed browser verification;
+- rich tooltip inside icon button may be a valid project extension but should not be assumed as the default Material icon-button contract.
+
+Verdict: migrate with overlays or after icon-button pilot identifies tooltip API needs.
+
+## Snackbars
+
+Material cache confirms snackbars show short process updates at the bottom, should not interrupt the user, and may disappear automatically or persist until action.
+
+Current state:
+
+- `MDSnackbar` exists.
+
+Gaps:
+
+- no `--md-comp-snackbar-*` token set;
+- placement, action/dismiss behavior, timeout policy, queue ownership, live-region semantics, and portal/overlay ownership need review;
+- visual/browser coverage was not confirmed.
+
+Verdict: migrate after overlay primitives are stable.
+
+## Dividers
+
+`MDDivider` exists, but this audit did not find enough evidence to claim Material alignment.
+
+Gaps:
+
+- token set, inset/full-width behavior, orientation, and Storybook coverage need a focused check.
+
+Verdict: small later migration or opportunistic cleanup when lists/cards are migrated.
+
+## Project-specific surfaces
+
+These should not be forced into official Material component rows unless a source-backed mapping is found:
+
+- `MDTable`
+- `MDEmptyState`
+- `MDPane`
+- `MDSplitLayout`
+- `MDNavigationPath`
+- `MDButtonsBar`
+
+They should use Material foundations for color, typography, shape, spacing, state, and accessibility, but their APIs should remain project-specific.


### PR DESCRIPTION
## Summary

- add `docs/material-3/foundation-audit.md` as the Phase 2 baseline before component-family migration;
- update `docs/material-3/component-registry.md` with a conservative snapshot of current shared UI Material surfaces;
- document confirmed foundation gaps for tokens, `sp` typography unit migration, baseline theme, state layers, icons, overlays, Storybook hierarchy, visual regression coverage, and `MD*` public API migration;
- identify Buttons as the smallest safe next implementation pilot.

## Notes

This PR is documentation-only. It does not migrate components, rename public APIs, reorganize shared UI source files, or update visual snapshots.

The audit records that the Material MCP was not available in this execution environment. `Vyachean/m3-docs-cache` was available and its `index.json` reports a capture from `2026-05-19T05:56:22.642Z`, with some failed/suspicious routes. The audit therefore avoids claiming full Material 3 alignment and keeps rows conservative.

## Verification

VERIFY RESULT
command: pnpm verify
status: not run
reason if not run: changes were made through the GitHub connector without a local repository checkout or installable project workspace in this environment.

BRV RESULT
status: not available
reason: ByteRover tools are not available in this environment.