### PR TITLE
chore: clean up repository rename leftovers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@ SENTRY_AUTH_TOKEN=
 
 # Storybook / visual testing env
 # Internal flag that marks Storybook builds so product-only Vite plugins stay disabled.
-BEAVER_STORYBOOK=
+APP_STORYBOOK=
 
 # Disables Storybook telemetry, including early boot telemetry during CLI startup.
 STORYBOOK_DISABLE_TELEMETRY=

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Build
         env:
-          BASE_URL: /${{ github.event.repository.name }}
+          BASE_URL: /${{ github.event.repository.name }}/
           VITE_GOOGLE_CLIENT_ID: ${{ secrets.VITE_GOOGLE_CLIENT_ID }}
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -64,8 +64,8 @@
 ### 1. Clone and Install
 
 ```bash
-git clone https://github.com/Vyachean/beaver.git
-cd beaver
+git clone https://github.com/Vyachean/mioframe.git
+cd mioframe
 pnpm install
 ```
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -82,8 +82,8 @@ Mioframe 0.1 does not use Sentry Session Replay. Error diagnostics do not record
 
 For questions about privacy, open a GitHub Discussion:
 
-[https://github.com/Vyachean/beaver/discussions](https://github.com/Vyachean/beaver/discussions)
+[https://github.com/Vyachean/mioframe/discussions](https://github.com/Vyachean/mioframe/discussions)
 
 To report a privacy-related bug or data handling issue, open a GitHub Issue:
 
-[https://github.com/Vyachean/beaver/issues](https://github.com/Vyachean/beaver/issues)
+[https://github.com/Vyachean/mioframe/issues](https://github.com/Vyachean/mioframe/issues)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A simple local app for your data. No cloud lock-in, no subscriptions, no extra friction.
 
-[👉 Open Mioframe](https://vyachean.github.io/beaver/)
+[👉 Open Mioframe](https://vyachean.github.io/mioframe/)
 
 ## Why I Built It
 
@@ -50,8 +50,8 @@ User documentation is available in [docs/user/README.md](./docs/user/README.md).
 
 Mioframe is still under active development, and your feedback genuinely helps shape where it goes next. If you want to share thoughts, report a problem, or suggest an idea, feel free to reach out on GitHub:
 
-- Found a bug? Please open an [Issue](https://github.com/Vyachean/beaver/issues).
-- Have an idea or a question? Join the [Discussions](https://github.com/Vyachean/beaver/discussions).
+- Found a bug? Please open an [Issue](https://github.com/Vyachean/mioframe/issues).
+- Have an idea or a question? Join the [Discussions](https://github.com/Vyachean/mioframe/discussions).
 
 ## Development
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -4,7 +4,7 @@
 
 [English version](./README.md)
 
-[👉 Запустить Mioframe](https://vyachean.github.io/beaver/)
+[👉 Запустить Mioframe](https://vyachean.github.io/mioframe/)
 
 ## Зачем я это сделал?
 
@@ -49,8 +49,8 @@ Mioframe — это приложение для тех, кто хочет сам
 
 Проект находится в активной разработке, поэтому ваш фидбек — это то, что помогает Mioframe развиваться. Вы можете поделиться им на GitHub:
 
-- Нашли баг? Пожалуйста, создайте [Issue](https://github.com/Vyachean/beaver/issues).
-- Есть идея или вопрос? Добро пожаловать в [Обсуждения](https://github.com/Vyachean/beaver/discussions).
+- Нашли баг? Пожалуйста, создайте [Issue](https://github.com/Vyachean/mioframe/issues).
+- Есть идея или вопрос? Добро пожаловать в [Обсуждения](https://github.com/Vyachean/mioframe/discussions).
 
 ## Разработка
 

--- a/docs/user/data-storage-and-recovery.md
+++ b/docs/user/data-storage-and-recovery.md
@@ -10,8 +10,8 @@ Use these focused guides instead:
 
 If you have a question about storage or recovery, use GitHub Discussions:
 
-[https://github.com/Vyachean/beaver/discussions](https://github.com/Vyachean/beaver/discussions)
+[https://github.com/Vyachean/mioframe/discussions](https://github.com/Vyachean/mioframe/discussions)
 
 If you found a bug or need to report a storage or data recovery problem, use GitHub Issues:
 
-[https://github.com/Vyachean/beaver/issues](https://github.com/Vyachean/beaver/issues)
+[https://github.com/Vyachean/mioframe/issues](https://github.com/Vyachean/mioframe/issues)

--- a/scripts/storybook.mjs
+++ b/scripts/storybook.mjs
@@ -30,7 +30,7 @@ const child = spawn(args[0], args.slice(1), {
   stdio: 'inherit',
   env: {
     ...process.env,
-    BEAVER_STORYBOOK: '1',
+    APP_STORYBOOK: '1',
     STORYBOOK_DISABLE_TELEMETRY: '1',
   },
 });

--- a/src/features/exportDocument/useExportDocument.ts
+++ b/src/features/exportDocument/useExportDocument.ts
@@ -8,7 +8,7 @@ import { ExportDocumentErrorCode } from './exportDocumentErrorCode';
 
 /**
  * Creates JSON document export actions for a document in a directory.
- * @returns Export actions for Beaver JSON documents.
+ * @returns Export actions for Mioframe JSON documents.
  */
 export const useExportDocument = () => {
   const {
@@ -16,7 +16,7 @@ export const useExportDocument = () => {
   } = useMainServiceClient();
 
   /**
-   * Exports a Beaver document to a JSON file chosen by the user.
+   * Exports a Mioframe document to a JSON file chosen by the user.
    * @param path - The directory path that owns the document.
    * @param documentId - The document id to export.
    * @returns `true` when the export succeeds, or `false` when the user cancels the save dialog.

--- a/src/features/importDocument/useImportDocument.test.ts
+++ b/src/features/importDocument/useImportDocument.test.ts
@@ -48,7 +48,7 @@ describe('useImportDocument', () => {
     expect(createDocumentMock).not.toHaveBeenCalled();
   });
 
-  it('wraps non-Beaver JSON with a user-facing DomainError', async () => {
+  it('wraps non-Mioframe JSON with a user-facing DomainError', async () => {
     fileOpenMock.mockResolvedValue({
       text: vi.fn().mockResolvedValue(JSON.stringify({ name: 'Doc' })),
     });
@@ -59,7 +59,7 @@ describe('useImportDocument', () => {
 
     expect(error).toBeInstanceOf(DomainError);
     expect(error).toMatchObject({
-      message: 'The selected JSON file is not a Beaver document',
+      message: 'The selected JSON file is not a Mioframe document',
     });
     expect(error).toHaveProperty('cause');
     expect(createDocumentMock).not.toHaveBeenCalled();
@@ -103,7 +103,7 @@ describe('useImportDocument', () => {
     expect(error).not.toHaveProperty('cause.message', rawCause.message);
   });
 
-  it('creates a document from valid Beaver JSON and returns its id', async () => {
+  it('creates a document from valid Mioframe JSON and returns its id', async () => {
     fileOpenMock.mockResolvedValue({
       text: vi.fn().mockResolvedValue(
         JSON.stringify({
@@ -138,7 +138,7 @@ describe('useImportDocument', () => {
       ),
     });
 
-    const cause = new DomainError('The selected JSON file is not a Beaver document');
+    const cause = new DomainError('The selected JSON file is not a Mioframe document');
     createDocumentMock.mockRejectedValueOnce(cause);
 
     const { importJsonFile } = useImportDocument();

--- a/src/features/importDocument/useImportDocument.ts
+++ b/src/features/importDocument/useImportDocument.ts
@@ -7,7 +7,7 @@ import { ImportDocumentErrorCode } from './importDocumentErrorCode';
 
 /**
  * Creates JSON document import actions for a target directory.
- * @returns Import actions for Beaver JSON documents.
+ * @returns Import actions for Mioframe JSON documents.
  */
 export const useImportDocument = () => {
   const {
@@ -15,7 +15,7 @@ export const useImportDocument = () => {
   } = useMainServiceClient();
 
   /**
-   * Imports a Beaver document from a selected JSON file into the target directory.
+   * Imports a Mioframe document from a selected JSON file into the target directory.
    * @param path - The directory path where the imported document should be created.
    * @returns The created document id, or `undefined` when the user cancels file selection.
    */
@@ -70,7 +70,7 @@ export const useImportDocument = () => {
     try {
       initialValue = zodCFRDocumentContent.parse(data);
     } catch (error) {
-      throw new DomainError('The selected JSON file is not a Beaver document', {
+      throw new DomainError('The selected JSON file is not a Mioframe document', {
         cause: error,
         code: ImportDocumentErrorCode.invalidDocumentFormat,
       });

--- a/src/shared/lib/error/httpStatus.ts
+++ b/src/shared/lib/error/httpStatus.ts
@@ -1,5 +1,5 @@
 /**
- * Standard HTTP response status codes used by Beaver.
+ * Standard HTTP response status codes used by Mioframe.
  *
  * This enum provides typed constants for standard HTTP status codes used in
  * error handling and Google Drive API adapters.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,7 @@ import {
 export default defineConfig(({ mode, isPreview }) => {
   const env = loadEnv(mode, process.cwd(), '');
   const isPreviewBuild = !!isPreview;
-  const isStorybookBuild = process.env.BEAVER_STORYBOOK === '1';
+  const isStorybookBuild = process.env.APP_STORYBOOK === '1';
 
   const sslPlugins = isStorybookBuild ? [] : getSslPlugins({ mode, isPreview: isPreviewBuild });
   const pwaPlugins = isStorybookBuild ? [] : getPwaPlugins({ mode, isPreview: isPreviewBuild });


### PR DESCRIPTION
## Summary

- Update public README, privacy, development, and user documentation links from `beaver` to `mioframe`.
- Normalize the GitHub Pages `BASE_URL` with a trailing slash for project Pages deployment.
- Rename the Storybook-only build flag from `BEAVER_STORYBOOK` to the repository-neutral `APP_STORYBOOK`.
- Update Mioframe import/export TSDoc, user-facing import validation text, and matching unit test expectations.

## Verification

- Not run locally. Changes were applied through GitHub file edits and checked with GitHub compare for the expected file set.
