### PR TITLE
fix(vfs): optimize readDirectory to skip unnecessary file metadata queries

### DIFF
--- a/src/shared/lib/webFileSystemProvider/WebFileSystemProvider.test.ts
+++ b/src/shared/lib/webFileSystemProvider/WebFileSystemProvider.test.ts
@@ -187,19 +187,7 @@ describe('WebFileSystemProvider', () => {
     });
 
     await expect(provider.readDirectory('/')).resolves.toEqual([
-      [
-        'note.txt',
-        {
-          capabilities: {
-            canChangePath: true,
-            canDelete: true,
-          },
-          creationTime: 123,
-          modificationTime: 123,
-          size: 5,
-          type: FSNodeType.File,
-        },
-      ],
+      ['note.txt', { type: FSNodeType.File }],
     ]);
     expect(queryPermissionMock).toHaveBeenNthCalledWith(1, {
       mode: 'read',
@@ -291,6 +279,59 @@ describe('WebFileSystemProvider', () => {
       path: '/',
     });
     expect(rootHandle.requestPermissionMock).not.toHaveBeenCalled();
+  });
+
+  it('does not call getFile for file entries during readDirectory', async () => {
+    const fileHandle = createFileHandleMock({ name: 'note.txt', permissionState: 'granted' });
+    const rootHandle = createDirectoryHandleMock({
+      entries: [fileHandle],
+      name: '',
+      permissionState: 'granted',
+    });
+    const provider = WebFileSystemProvider(rootHandle, {
+      permissionPolicy: 'userSelectedDirectory',
+    });
+
+    await expect(provider.readDirectory('/')).resolves.toEqual([
+      ['note.txt', { type: FSNodeType.File }],
+    ]);
+    expect(fileHandle.getFileMock).not.toHaveBeenCalled();
+  });
+
+  it('does not query permission for child entries during readDirectory', async () => {
+    const childDir = createDirectoryHandleMock({ name: 'sub', permissionState: 'granted' });
+    const rootHandle = createDirectoryHandleMock({
+      entries: [childDir],
+      name: '',
+      permissionState: 'granted',
+    });
+    const provider = WebFileSystemProvider(rootHandle, {
+      permissionPolicy: 'userSelectedDirectory',
+    });
+
+    await expect(provider.readDirectory('/')).resolves.toEqual([
+      ['sub', { type: FSNodeType.Directory }],
+    ]);
+    expect(childDir.queryPermissionMock).not.toHaveBeenCalled();
+  });
+
+  it('stat still returns precise file metadata after readDirectory skips eager stats', async () => {
+    const { fileHandle, rootHandle } = createRootHandle('granted');
+    const provider = WebFileSystemProvider(rootHandle, {
+      permissionPolicy: 'userSelectedDirectory',
+    });
+
+    await provider.readDirectory('/');
+    expect(fileHandle.getFileMock).not.toHaveBeenCalled();
+
+    await expect(provider.stat('/note.txt')).resolves.toEqual({
+      type: FSNodeType.File,
+      size: 5,
+      creationTime: 123,
+      modificationTime: 123,
+      capabilities: { canDelete: true, canChangePath: true },
+    });
+    expect(fileHandle.getFileMock).toHaveBeenCalledTimes(1);
   });
 
   it('rejects writeFile when the target already exists and overwrite is false', async () => {
@@ -386,19 +427,7 @@ describe('WebFileSystemProvider', () => {
     });
 
     await expect(provider.readDirectory('/')).resolves.toEqual([
-      [
-        'note.txt',
-        {
-          capabilities: {
-            canChangePath: true,
-            canDelete: true,
-          },
-          creationTime: 123,
-          modificationTime: 123,
-          size: 5,
-          type: FSNodeType.File,
-        },
-      ],
+      ['note.txt', { type: FSNodeType.File }],
     ]);
     expect(onAccessRequired).not.toHaveBeenCalled();
     expect(rootHandle.requestPermissionMock).not.toHaveBeenCalled();

--- a/src/shared/lib/webFileSystemProvider/WebFileSystemProvider.testUtils.ts
+++ b/src/shared/lib/webFileSystemProvider/WebFileSystemProvider.testUtils.ts
@@ -15,6 +15,7 @@ type BaseHandleOptions = {
 type MockFileSystemFileHandle = FileSystemFileHandle & {
   __sameEntryKey: string;
   __writtenContent: BlobPart[];
+  getFileMock: ReturnType<typeof vi.fn<() => Promise<File>>>;
   queryPermissionMock?: ReturnType<
     typeof vi.fn<(descriptor?: FileSystemHandlePermissionDescriptor) => Promise<PermissionState>>
   >;
@@ -116,11 +117,16 @@ export const createFileHandleMock = ({
     }),
   } satisfies FileSystemWritableFileStream;
 
+  const getFileMock = vi.fn(() =>
+    Promise.resolve(new File(writtenContent, name, { lastModified })),
+  );
+
   const handle: MockFileSystemFileHandle = {
     kind: 'file',
     name,
     __sameEntryKey: sameEntryKey,
     __writtenContent: writtenContent,
+    getFileMock,
     ...(queryPermissionMock === undefined ? {} : { queryPermission: queryPermissionMock }),
     ...(queryPermissionMock === undefined ? {} : { queryPermissionMock }),
     requestPermission: requestPermissionMock,
@@ -129,7 +135,7 @@ export const createFileHandleMock = ({
       Promise.resolve((other.__sameEntryKey ?? other.name) === sameEntryKey),
     ),
     createWritable: vi.fn(() => Promise.resolve(writable)),
-    getFile: vi.fn(() => Promise.resolve(new File(writtenContent, name, { lastModified }))),
+    getFile: getFileMock,
     createSyncAccessHandle: vi.fn(() => Promise.reject(new Error('Method not implemented.'))),
     isFile: true,
     isDirectory: false,

--- a/src/shared/lib/webFileSystemProvider/WebFileSystemProvider.ts
+++ b/src/shared/lib/webFileSystemProvider/WebFileSystemProvider.ts
@@ -314,7 +314,10 @@ export const WebFileSystemProvider = (
     const entries: [string, FSNodeStat][] = [];
 
     for await (const [name, childHandle] of directoryHandle.entries()) {
-      entries.push([name, await fileHandleStat(childHandle)]);
+      entries.push([
+        name,
+        { type: childHandle.kind === 'file' ? FSNodeType.File : FSNodeType.Directory },
+      ]);
     }
 
     return entries;


### PR DESCRIPTION
## Summary

Optimizes `WebFileSystemProvider.readDirectory()` by making directory listing lightweight. The provider now returns only cheap entry type data during listing and avoids eager per-file `getFile()` calls and child permission checks.

This improves performance for slow browser-backed directory handles while keeping precise metadata available through explicit `stat(path)` calls.

## Verification

- Added tests proving `readDirectory()` does not call `getFile()` for file entries.
- Added tests proving child entry permissions are not queried during directory listing.
- Kept coverage for precise file metadata through `stat(path)`.
- `pnpm verify` passed in CI.