### PR TITLE
fix(vfs): implement write access recovery for browser operations

### DIFF
--- a/src/shared/lib/webFileSystemProvider/WebFileSystemProvider.test.ts
+++ b/src/shared/lib/webFileSystemProvider/WebFileSystemProvider.test.ts
@@ -760,6 +760,97 @@ describe('WebFileSystemProvider', () => {
     });
   });
 
+  it('converts a new-file getFileHandle failure to WebFileSystemAccessRequiredError when readwrite is no longer granted', async () => {
+    const rootHandle = createDirectoryHandleMock({
+      entries: [],
+      name: '',
+      permissionState: 'granted',
+    });
+    const queryPermissionMock = vi
+      .fn<(descriptor?: FileSystemHandlePermissionDescriptor) => Promise<PermissionState>>()
+      .mockResolvedValueOnce('granted')
+      .mockResolvedValueOnce('prompt');
+    Object.defineProperty(rootHandle, 'queryPermission', {
+      configurable: true,
+      value: queryPermissionMock,
+    });
+    rootHandle.getFileHandleMock.mockImplementation((_name, options) => {
+      if (options?.create) {
+        return Promise.reject(new DOMException('Not allowed', 'NotAllowedError'));
+      }
+      return Promise.reject(new DOMException('Not found', 'NotFoundError'));
+    });
+    const provider = WebFileSystemProvider(rootHandle, {
+      permissionPolicy: 'userSelectedDirectory',
+      onAccessRequired: ({ mode }) => ({ spaceName: 'Work', mode }),
+    });
+
+    await expect(
+      provider.writeFile('/new.txt', 'x', { create: true, overwrite: false }),
+    ).rejects.toMatchObject({
+      code: WEB_FILE_SYSTEM_ACCESS_REQUIRED_CODE,
+      mode: 'readwrite',
+      name: 'WebFileSystemAccessRequiredError',
+      spaceName: 'Work',
+    });
+  });
+
+  it('converts a createDirectory getDirectoryHandle failure to WebFileSystemAccessRequiredError when readwrite is no longer granted', async () => {
+    const rootHandle = createDirectoryHandleMock({
+      entries: [],
+      name: '',
+      permissionState: 'granted',
+    });
+    const queryPermissionMock = vi
+      .fn<(descriptor?: FileSystemHandlePermissionDescriptor) => Promise<PermissionState>>()
+      .mockResolvedValueOnce('granted')
+      .mockResolvedValueOnce('prompt');
+    Object.defineProperty(rootHandle, 'queryPermission', {
+      configurable: true,
+      value: queryPermissionMock,
+    });
+    rootHandle.getDirectoryHandleMock.mockImplementation((_name, options) => {
+      if (options?.create) {
+        return Promise.reject(new DOMException('Not allowed', 'NotAllowedError'));
+      }
+      return Promise.reject(new DOMException('Not found', 'NotFoundError'));
+    });
+    const provider = WebFileSystemProvider(rootHandle, {
+      permissionPolicy: 'userSelectedDirectory',
+      onAccessRequired: ({ mode }) => ({ spaceName: 'Work', mode }),
+    });
+
+    await expect(provider.createDirectory('/newdir')).rejects.toMatchObject({
+      code: WEB_FILE_SYSTEM_ACCESS_REQUIRED_CODE,
+      mode: 'readwrite',
+      name: 'WebFileSystemAccessRequiredError',
+      spaceName: 'Work',
+    });
+  });
+
+  it('rethrows original error from new-file getFileHandle failure when readwrite is still granted', async () => {
+    const rootHandle = createDirectoryHandleMock({
+      entries: [],
+      name: '',
+      permissionState: 'granted',
+    });
+    const storageError = new DOMException('Quota exceeded', 'QuotaExceededError');
+    rootHandle.getFileHandleMock.mockImplementation((_name, options) => {
+      if (options?.create) {
+        return Promise.reject(storageError);
+      }
+      return Promise.reject(new DOMException('Not found', 'NotFoundError'));
+    });
+    const provider = WebFileSystemProvider(rootHandle, {
+      permissionPolicy: 'userSelectedDirectory',
+      onAccessRequired: ({ mode }) => ({ spaceName: 'Work', mode }),
+    });
+
+    await expect(
+      provider.writeFile('/new.txt', 'x', { create: true, overwrite: false }),
+    ).rejects.toThrow(storageError);
+  });
+
   it('blocks move immediately when destination canEditChildren capability is explicitly false', async () => {
     const sourceFile = createFileHandleMock({
       name: 'note.txt',

--- a/src/shared/lib/webFileSystemProvider/WebFileSystemProvider.test.ts
+++ b/src/shared/lib/webFileSystemProvider/WebFileSystemProvider.test.ts
@@ -415,6 +415,77 @@ describe('WebFileSystemProvider', () => {
     expect(JSON.stringify(thrownError.toJSON())).not.toContain('FileSystemDirectoryHandle');
   });
 
+  it('converts a write-side browser failure to WebFileSystemAccessRequiredError when readwrite is no longer granted after ensureAccess', async () => {
+    const { fileHandle, rootHandle } = createRootHandle('granted');
+    const queryPermissionMock = vi
+      .fn<(descriptor?: FileSystemHandlePermissionDescriptor) => Promise<PermissionState>>()
+      .mockResolvedValueOnce('granted')
+      .mockResolvedValueOnce('prompt');
+    Object.defineProperty(rootHandle, 'queryPermission', {
+      configurable: true,
+      value: queryPermissionMock,
+    });
+    fileHandle.createWritable = vi.fn(() =>
+      Promise.reject(new DOMException('Not allowed', 'NotAllowedError')),
+    );
+    const provider = WebFileSystemProvider(rootHandle, {
+      permissionPolicy: 'userSelectedDirectory',
+      onAccessRequired: ({ mode }) => ({ spaceName: 'Work', mode }),
+    });
+
+    await expect(
+      provider.writeFile('/note.txt', 'x', { create: true, overwrite: true }),
+    ).rejects.toMatchObject({
+      code: WEB_FILE_SYSTEM_ACCESS_REQUIRED_CODE,
+      mode: 'readwrite',
+      name: 'WebFileSystemAccessRequiredError',
+      spaceName: 'Work',
+    });
+  });
+
+  it('rethrows the original error from a write-side failure when readwrite is still granted', async () => {
+    const { fileHandle, rootHandle } = createRootHandle('granted');
+    const storageError = new DOMException('Quota exceeded', 'QuotaExceededError');
+    fileHandle.createWritable = vi.fn(() => Promise.reject(storageError));
+    const provider = WebFileSystemProvider(rootHandle, {
+      permissionPolicy: 'userSelectedDirectory',
+      onAccessRequired: ({ mode }) => ({ spaceName: 'Work', mode }),
+    });
+
+    await expect(
+      provider.writeFile('/note.txt', 'x', { create: true, overwrite: true }),
+    ).rejects.toThrow(storageError);
+  });
+
+  it('converts a removeEntry browser failure to WebFileSystemAccessRequiredError when readwrite is no longer granted', async () => {
+    const { fileHandle, rootHandle } = createRootHandle('granted');
+    const queryPermissionMock = vi
+      .fn<(descriptor?: FileSystemHandlePermissionDescriptor) => Promise<PermissionState>>()
+      .mockResolvedValueOnce('granted')
+      .mockResolvedValueOnce('prompt');
+    Object.defineProperty(rootHandle, 'queryPermission', {
+      configurable: true,
+      value: queryPermissionMock,
+    });
+    rootHandle.removeEntryMock.mockRejectedValueOnce(
+      new DOMException('Not allowed', 'NotAllowedError'),
+    );
+    fileHandle.queryPermission = vi.fn<
+      (descriptor?: FileSystemHandlePermissionDescriptor) => Promise<PermissionState>
+    >(() => Promise.resolve('granted'));
+    const provider = WebFileSystemProvider(rootHandle, {
+      permissionPolicy: 'userSelectedDirectory',
+      onAccessRequired: ({ mode }) => ({ spaceName: 'Work', mode }),
+    });
+
+    await expect(provider.delete('/note.txt', false)).rejects.toMatchObject({
+      code: WEB_FILE_SYSTEM_ACCESS_REQUIRED_CODE,
+      mode: 'readwrite',
+      name: 'WebFileSystemAccessRequiredError',
+      spaceName: 'Work',
+    });
+  });
+
   it('does not route Browser Storage providers through local access recovery', async () => {
     const { rootHandle } = createRootHandle('prompt');
     const onAccessRequired = vi.fn(() => ({

--- a/src/shared/lib/webFileSystemProvider/WebFileSystemProvider.ts
+++ b/src/shared/lib/webFileSystemProvider/WebFileSystemProvider.ts
@@ -107,6 +107,41 @@ export const WebFileSystemProvider = (
     }
   };
 
+  /**
+   * Runs a write-side browser operation and, on failure, re-checks the root handle readwrite
+   * permission. If readwrite is no longer granted, triggers the onAccessRequired flow and throws
+   * WebFileSystemAccessRequiredError. If readwrite is still granted, rethrows the original error.
+   * No-op for originPrivateStorage providers.
+   * @param fn - Write-side browser operation to run with recovery on permission loss.
+   * @returns The resolved value of the operation.
+   */
+  const withWriteAccessRecovery = async <T>(fn: () => Promise<T>): Promise<T> => {
+    if (permissionPolicy === 'originPrivateStorage') {
+      return fn();
+    }
+
+    try {
+      return await fn();
+    } catch (error) {
+      const permissionState = await queryModePermission(rootHandle, 'readwrite');
+
+      if (permissionState !== 'granted') {
+        const accessRequiredDetails = onAccessRequired?.({
+          handle: rootHandle,
+          mode: 'readwrite',
+        });
+
+        if (accessRequiredDetails) {
+          throw new WebFileSystemAccessRequiredError(accessRequiredDetails);
+        }
+
+        throw new VfsError(FileSystemError.NoPermissions, 'Permission required');
+      }
+
+      throw error;
+    }
+  };
+
   const isLookupMiss = (
     error: unknown,
     expectedCode: FileSystemError.FileIsADirectory | FileSystemError.FileNotADirectory,
@@ -275,30 +310,33 @@ export const WebFileSystemProvider = (
     { create, overwrite }: WriteOptions,
   ): Promise<WriteFileResult> => {
     await ensureAccess('readwrite');
-    let handle: FileSystemFileHandle | undefined;
 
-    try {
-      handle = await getHandle(path, false, 'file');
-      if (!overwrite) {
-        throw new VfsError(FileSystemError.FileExists, `File exists: ${path}`);
-      }
-    } catch (error) {
-      if (error instanceof VfsError && error.code === FileSystemError.FileNotFound) {
-        if (!create) {
-          throw error;
+    const resolvedHandle = await (async () => {
+      try {
+        const handle = await getHandle(path, false, 'file');
+        if (!overwrite) {
+          throw new VfsError(FileSystemError.FileExists, `File exists: ${path}`);
         }
-        handle = await getHandle(path, true, 'file');
-      } else {
+        return handle;
+      } catch (error) {
+        if (error instanceof VfsError && error.code === FileSystemError.FileNotFound) {
+          if (!create) {
+            throw error;
+          }
+          return getHandle(path, true, 'file');
+        }
         throw error;
       }
-    }
+    })();
 
-    const writable = await handle.createWritable();
-    await writable.write(content);
-    await writable.close();
+    await withWriteAccessRecovery(async () => {
+      const writable = await resolvedHandle.createWritable();
+      await writable.write(content);
+      await writable.close();
+    });
 
     return {
-      stat: await fileHandleStat(handle),
+      stat: await fileHandleStat(resolvedHandle),
     };
   };
 
@@ -360,7 +398,7 @@ export const WebFileSystemProvider = (
     const parentHandle = await getHandle(parentPath, false, 'directory');
 
     try {
-      await parentHandle.removeEntry(name, { recursive });
+      await withWriteAccessRecovery(() => parentHandle.removeEntry(name, { recursive }));
     } catch (error) {
       if (error instanceof DOMException) {
         if (error.name === 'NotFoundError') {
@@ -425,7 +463,9 @@ export const WebFileSystemProvider = (
     const destinationDirHandle = destinationHandle;
 
     if (sourceHandle.move) {
-      await sourceHandle.move(destinationDirHandle, newName);
+      await withWriteAccessRecovery(
+        () => sourceHandle.move?.(destinationDirHandle, newName) ?? Promise.resolve(),
+      );
       return;
     }
 
@@ -434,9 +474,11 @@ export const WebFileSystemProvider = (
       const newFileHandle = await destinationDirHandle.getFileHandle(newName, {
         create: true,
       });
-      const writable = await newFileHandle.createWritable();
-      await writable.write(file);
-      await writable.close();
+      await withWriteAccessRecovery(async () => {
+        const writable = await newFileHandle.createWritable();
+        await writable.write(file);
+        await writable.close();
+      });
 
       await remove(normalizedOld, false);
       return;
@@ -456,9 +498,11 @@ export const WebFileSystemProvider = (
           const newFileHandle = await destDir.getFileHandle(entry.name, {
             create: true,
           });
-          const writable = await newFileHandle.createWritable();
-          await writable.write(file);
-          await writable.close();
+          await withWriteAccessRecovery(async () => {
+            const writable = await newFileHandle.createWritable();
+            await writable.write(file);
+            await writable.close();
+          });
           continue;
         }
 

--- a/src/shared/lib/webFileSystemProvider/WebFileSystemProvider.ts
+++ b/src/shared/lib/webFileSystemProvider/WebFileSystemProvider.ts
@@ -142,6 +142,46 @@ export const WebFileSystemProvider = (
     }
   };
 
+  /**
+   * Creates a new file handle inside `parent` with write access recovery.
+   * @param parent - Parent directory handle.
+   * @param name - Name of the new file.
+   * @returns Resolved file handle for the newly created file.
+   */
+  const createFileHandleWithWriteRecovery = (
+    parent: FileSystemDirectoryHandle,
+    name: string,
+  ): Promise<FileSystemFileHandle> =>
+    withWriteAccessRecovery(() => parent.getFileHandle(name, { create: true }));
+
+  /**
+   * Creates a new directory handle inside `parent` with write access recovery.
+   * @param parent - Parent directory handle.
+   * @param name - Name of the new directory.
+   * @returns Resolved directory handle for the newly created directory.
+   */
+  const createDirectoryHandleWithWriteRecovery = (
+    parent: FileSystemDirectoryHandle,
+    name: string,
+  ): Promise<FileSystemDirectoryHandle> =>
+    withWriteAccessRecovery(() => parent.getDirectoryHandle(name, { create: true }));
+
+  /**
+   * Writes `content` to `handle` via createWritable, applying write access recovery once.
+   * @param handle - File handle to write to.
+   * @param content - Content to write.
+   * @returns Promise that resolves when the write is complete.
+   */
+  const writeFileHandleContent = (
+    handle: FileSystemFileHandle,
+    content: FileContent,
+  ): Promise<void> =>
+    withWriteAccessRecovery(async () => {
+      const writable = await handle.createWritable();
+      await writable.write(content);
+      await writable.close();
+    });
+
   const isLookupMiss = (
     error: unknown,
     expectedCode: FileSystemError.FileIsADirectory | FileSystemError.FileNotADirectory,
@@ -311,33 +351,30 @@ export const WebFileSystemProvider = (
   ): Promise<WriteFileResult> => {
     await ensureAccess('readwrite');
 
-    const resolvedHandle = await (async () => {
-      try {
-        const handle = await getHandle(path, false, 'file');
-        if (!overwrite) {
-          throw new VfsError(FileSystemError.FileExists, `File exists: ${path}`);
-        }
-        return handle;
-      } catch (error) {
-        if (error instanceof VfsError && error.code === FileSystemError.FileNotFound) {
-          if (!create) {
-            throw error;
-          }
-          return getHandle(path, true, 'file');
-        }
-        throw error;
+    let resolvedHandle: FileSystemFileHandle;
+    try {
+      resolvedHandle = await getHandle(path, false, 'file');
+      if (!overwrite) {
+        throw new VfsError(FileSystemError.FileExists, `File exists: ${path}`);
       }
-    })();
+    } catch (lookupError) {
+      if (!(lookupError instanceof VfsError && lookupError.code === FileSystemError.FileNotFound)) {
+        throw lookupError;
+      }
+      if (!create) {
+        throw lookupError;
+      }
+      const normalized = PathUtils.normalize(path);
+      const parentDir = await getHandle(PathUtils.dirname(normalized), false, 'directory');
+      resolvedHandle = await createFileHandleWithWriteRecovery(
+        parentDir,
+        PathUtils.basename(normalized),
+      );
+    }
 
-    await withWriteAccessRecovery(async () => {
-      const writable = await resolvedHandle.createWritable();
-      await writable.write(content);
-      await writable.close();
-    });
+    await writeFileHandleContent(resolvedHandle, content);
 
-    return {
-      stat: await fileHandleStat(resolvedHandle),
-    };
+    return { stat: await fileHandleStat(resolvedHandle) };
   };
 
   const writeFile = async (
@@ -367,11 +404,12 @@ export const WebFileSystemProvider = (
       await getHandle(path, false, 'directory');
       throw new VfsError(FileSystemError.FileExists, `Directory already exists: ${path}`);
     } catch (error) {
-      if (error instanceof VfsError && error.code === FileSystemError.FileNotFound) {
-        await getHandle(path, true, 'directory');
-        return;
+      if (!(error instanceof VfsError && error.code === FileSystemError.FileNotFound)) {
+        throw error;
       }
-      throw error;
+      const normalized = PathUtils.normalize(path);
+      const parentDir = await getHandle(PathUtils.dirname(normalized), false, 'directory');
+      await createDirectoryHandleWithWriteRecovery(parentDir, PathUtils.basename(normalized));
     }
   };
 
@@ -471,22 +509,16 @@ export const WebFileSystemProvider = (
 
     if (sourceHandle.kind === 'file') {
       const file = await sourceHandle.getFile();
-      const newFileHandle = await destinationDirHandle.getFileHandle(newName, {
-        create: true,
-      });
-      await withWriteAccessRecovery(async () => {
-        const writable = await newFileHandle.createWritable();
-        await writable.write(file);
-        await writable.close();
-      });
-
+      const newFileHandle = await createFileHandleWithWriteRecovery(destinationDirHandle, newName);
+      await writeFileHandleContent(newFileHandle, file);
       await remove(normalizedOld, false);
       return;
     }
 
-    const newDirHandle = await destinationDirHandle.getDirectoryHandle(newName, {
-      create: true,
-    });
+    const newDirHandle = await createDirectoryHandleWithWriteRecovery(
+      destinationDirHandle,
+      newName,
+    );
 
     const copyDirectoryContents = async (
       sourceDir: FileSystemDirectoryHandle,
@@ -495,20 +527,12 @@ export const WebFileSystemProvider = (
       for await (const entry of sourceDir.values()) {
         if (entry.kind === 'file') {
           const file = await entry.getFile();
-          const newFileHandle = await destDir.getFileHandle(entry.name, {
-            create: true,
-          });
-          await withWriteAccessRecovery(async () => {
-            const writable = await newFileHandle.createWritable();
-            await writable.write(file);
-            await writable.close();
-          });
+          const newFileHandle = await createFileHandleWithWriteRecovery(destDir, entry.name);
+          await writeFileHandleContent(newFileHandle, file);
           continue;
         }
 
-        const newSubDir = await destDir.getDirectoryHandle(entry.name, {
-          create: true,
-        });
+        const newSubDir = await createDirectoryHandleWithWriteRecovery(destDir, entry.name);
         await copyDirectoryContents(entry, newSubDir);
       }
     };


### PR DESCRIPTION
## Summary

Fixes unreliable write-access recovery for browser-backed local directories.

`WebFileSystemProvider` now converts write-side browser permission loss into the existing `WebFileSystemAccessRequiredError` flow even when the failure happens after the initial `readwrite` permission check.

## Changes

- Added provider-local write access recovery helpers.
- Covered write-side file and directory creation.
- Covered writable stream writes and `removeEntry`.
- Preserved original storage/browser errors when `readwrite` permission is still granted.
- Kept recovery inside `WebFileSystemProvider` without UI, registry, or Google Drive provider changes.

## Verification

- Added focused `WebFileSystemProvider` tests.
- `pnpm verify` passed in CI.