### PR TITLE
fix(vfs): handle undefined capabilities during file operations

### DIFF
--- a/src/shared/lib/virtualFileSystem/VirtualFileSystem.test.ts
+++ b/src/shared/lib/virtualFileSystem/VirtualFileSystem.test.ts
@@ -572,6 +572,15 @@ describe('VirtualFileSystem', () => {
       await expect(vfs.delete('/mnt/test/nonexistent.txt')).rejects.toThrow();
     });
 
+    it('attempts provider delete when stat capabilities are undefined', async () => {
+      await memoryFS.writeFile('/test.txt', 'content', { create: true, overwrite: true });
+      vfs.mount(
+        '/mnt/test',
+        createCapabilityProvider((_path, stat) => ({ type: stat.type, size: stat.size })),
+      );
+      await expect(vfs.delete('/mnt/test/test.txt')).resolves.toBeUndefined();
+    });
+
     it('should block deletion when capabilities.canDelete is false', async () => {
       await memoryFS.writeFile('/locked.txt', 'content', {
         overwrite: true,
@@ -680,6 +689,31 @@ describe('VirtualFileSystem', () => {
       // Moving to the same path should not throw - it just returns silently
       await expect(
         vfs.move('/mnt/test/source.txt', '/mnt/test/source.txt'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('attempts provider move when source canChangePath capability is undefined', async () => {
+      await memoryFS.writeFile('/source.txt', 'content', { create: true, overwrite: true });
+      vfs.mount(
+        '/mnt/test',
+        createCapabilityProvider((path, stat) =>
+          path === '/source.txt' ? { ...stat, capabilities: { canChangePath: undefined } } : stat,
+        ),
+      );
+      await expect(vfs.move('/mnt/test/source.txt', '/mnt/test/dest.txt')).resolves.toBeUndefined();
+    });
+
+    it('attempts provider move when target parent canEditChildren capability is undefined', async () => {
+      await memoryFS.writeFile('/source.txt', 'content', { create: true, overwrite: true });
+      await memoryFS.createDirectory('/dest-dir');
+      vfs.mount(
+        '/mnt/test',
+        createCapabilityProvider((path, stat) =>
+          path === '/dest-dir' ? { ...stat, capabilities: { canEditChildren: undefined } } : stat,
+        ),
+      );
+      await expect(
+        vfs.move('/mnt/test/source.txt', '/mnt/test/dest-dir/source.txt'),
       ).resolves.toBeUndefined();
     });
 

--- a/src/shared/lib/virtualFileSystem/VirtualFileSystem.ts
+++ b/src/shared/lib/virtualFileSystem/VirtualFileSystem.ts
@@ -374,7 +374,7 @@ export class VirtualFileSystem {
 
     // Check delete capability before deletion
     const stat = await provider.stat(relativePath);
-    if (stat.capabilities?.canDelete !== true) {
+    if (stat.capabilities?.canDelete === false) {
       throw new VfsError(
         FileSystemError.NoPermissions,
         'File system delete operation is not allowed',
@@ -442,13 +442,13 @@ export class VirtualFileSystem {
     const stat = await this.stat(oldPath);
     const targetParentStat = await this.stat(PathUtils.dirname(newPath));
 
-    if (stat.capabilities?.canChangePath !== true) {
+    if (stat.capabilities?.canChangePath === false) {
       throw new VfsError(
         FileSystemError.NoPermissions,
         'The selected item does not support moving',
       );
     }
-    if (targetParentStat.capabilities?.canEditChildren !== true) {
+    if (targetParentStat.capabilities?.canEditChildren === false) {
       throw new VfsError(
         FileSystemError.NoPermissions,
         'The destination directory is not writable',

--- a/src/shared/lib/webFileSystemProvider/WebFileSystemProvider.test.ts
+++ b/src/shared/lib/webFileSystemProvider/WebFileSystemProvider.test.ts
@@ -851,6 +851,48 @@ describe('WebFileSystemProvider', () => {
     ).rejects.toThrow(storageError);
   });
 
+  it('resolves successfully when post-write getFile metadata fails after the write stream closes', async () => {
+    const fileHandle = createFileHandleMock({
+      fileContent: ['hello'],
+      name: 'note.txt',
+      permissionState: 'granted',
+    });
+    const metadataError = new DOMException('Not allowed', 'NotAllowedError');
+    fileHandle.getFile = vi.fn(() => Promise.reject(metadataError));
+    const rootHandle = createDirectoryHandleMock({
+      entries: [fileHandle],
+      name: '',
+      permissionState: 'granted',
+    });
+    const provider = WebFileSystemProvider(rootHandle, {
+      permissionPolicy: 'userSelectedDirectory',
+    });
+
+    await expect(
+      provider.writeFile('/note.txt', 'world', { create: true, overwrite: true }),
+    ).resolves.toMatchObject({ stat: { type: FSNodeType.File } });
+  });
+
+  it('stat still fails precisely when getFile fails even after a successful write', async () => {
+    const fileHandle = createFileHandleMock({
+      fileContent: ['hello'],
+      name: 'note.txt',
+      permissionState: 'granted',
+    });
+    const metadataError = new DOMException('Not allowed', 'NotAllowedError');
+    fileHandle.getFile = vi.fn(() => Promise.reject(metadataError));
+    const rootHandle = createDirectoryHandleMock({
+      entries: [fileHandle],
+      name: '',
+      permissionState: 'granted',
+    });
+    const provider = WebFileSystemProvider(rootHandle, {
+      permissionPolicy: 'userSelectedDirectory',
+    });
+
+    await expect(provider.stat('/note.txt')).rejects.toThrow(metadataError);
+  });
+
   it('blocks move immediately when destination canEditChildren capability is explicitly false', async () => {
     const sourceFile = createFileHandleMock({
       name: 'note.txt',

--- a/src/shared/lib/webFileSystemProvider/WebFileSystemProvider.ts
+++ b/src/shared/lib/webFileSystemProvider/WebFileSystemProvider.ts
@@ -374,7 +374,11 @@ export const WebFileSystemProvider = (
 
     await writeFileHandleContent(resolvedHandle, content);
 
-    return { stat: await fileHandleStat(resolvedHandle) };
+    try {
+      return { stat: await fileHandleStat(resolvedHandle) };
+    } catch {
+      return { stat: { type: FSNodeType.File } };
+    }
   };
 
   const writeFile = async (

--- a/src/shared/service/repositories/repositoryStorageFiles.integration.test.ts
+++ b/src/shared/service/repositories/repositoryStorageFiles.integration.test.ts
@@ -110,4 +110,28 @@ describe('repositoryStorageFiles integration', () => {
 
     await expect(getDocumentStorageFiles(vfs, path, documentId)).resolves.toEqual([]);
   });
+
+  it('reloads a document created via browser-backed provider and reads the original content', async () => {
+    const path = '/repo';
+    const vfs = new VirtualFileSystem();
+
+    vfs.mount('/', createAndroidLikeProvider(new MemoryFileSystem()));
+    await vfs.createDirectory(path);
+
+    const originalContent = { name: 'Reload test', type: 'note', version: 2, body: ['hello'] };
+
+    const repo1 = new Repo({ storage: createVFSAdapter(vfs, path) });
+    const documentId = repo1.create(originalContent).documentId;
+
+    await waitForDocumentStorageFiles(vfs, path, documentId);
+    await repo1.shutdown();
+
+    const repo2 = new Repo({ storage: createVFSAdapter(vfs, path) });
+    const handle = await repo2.find<typeof originalContent>(documentId);
+    await handle.whenReady();
+
+    expect(handle.doc()).toMatchObject(originalContent);
+
+    await repo2.shutdown();
+  });
 });

--- a/src/shared/service/repositories/repositoryStorageFiles.integration.test.ts
+++ b/src/shared/service/repositories/repositoryStorageFiles.integration.test.ts
@@ -3,11 +3,40 @@ import { describe, expect, it } from 'vitest';
 import type { AMDocumentId } from '@shared/lib/automerge';
 import { createVFSAdapter } from '@shared/lib/automergeAdapter/createVFSAdapter';
 import { MemoryFileSystem } from '@shared/lib/virtualFileSystem/MemoryFileSystem';
-import { VirtualFileSystem } from '@shared/lib/virtualFileSystem';
+import type { IFileSystemProvider } from '@shared/lib/virtualFileSystem';
+import { FSNodeType, VirtualFileSystem } from '@shared/lib/virtualFileSystem';
 import {
   cleanupDeletedDocumentStorageFiles,
   getDocumentStorageFiles,
 } from './repositoryStorageFiles';
+
+/**
+ * Creates a mock provider that models Android browser-backed local directory behavior:
+ * - readDirectory returns entries with only type (no capabilities)
+ * - stat returns no capabilities (undefined)
+ * - write/delete succeed at runtime despite unknown capabilities
+ * - post-write metadata is minimal (no getFile call simulated by returning cheap stat)
+ * @param memFs - In-memory backing store for the provider operations.
+ * @returns VFS provider that behaves like a browser-backed local directory on Android.
+ */
+const createAndroidLikeProvider = (memFs: MemoryFileSystem): IFileSystemProvider => ({
+  stat: async (path) => {
+    const s = await memFs.stat(path);
+    return { type: s.type };
+  },
+  readFile: (path) => memFs.readFile(path),
+  writeFile: async (path, content, options) => {
+    await memFs.writeFile(path, content, options);
+    return { stat: { type: FSNodeType.File } };
+  },
+  readDirectory: async (path) => {
+    const entries = await memFs.readDirectory(path);
+    return entries.map(([name, s]) => [name, { type: s.type }]);
+  },
+  createDirectory: (path) => memFs.createDirectory(path),
+  delete: (path, recursive) => memFs.delete(path, recursive),
+  move: (oldPath, newPath) => memFs.move(oldPath, newPath),
+});
 
 const wait = async (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
@@ -32,6 +61,31 @@ const waitForDocumentStorageFiles = async (
 };
 
 describe('repositoryStorageFiles integration', () => {
+  it('cleans Automerge storage files using a browser-backed provider with undefined capabilities', async () => {
+    const path = '/repo';
+    const vfs = new VirtualFileSystem();
+
+    vfs.mount('/', createAndroidLikeProvider(new MemoryFileSystem()));
+    await vfs.createDirectory(path);
+
+    const repo = new Repo({ storage: createVFSAdapter(vfs, path) });
+    const documentId = repo.create({
+      name: 'Document',
+      type: 'document',
+      version: 1,
+      body: [],
+    }).documentId;
+
+    await waitForDocumentStorageFiles(vfs, path, documentId);
+
+    repo.delete(documentId);
+    await wait(100);
+    await cleanupDeletedDocumentStorageFiles(vfs, path, documentId);
+    await repo.shutdown();
+
+    await expect(getDocumentStorageFiles(vfs, path, documentId)).resolves.toEqual([]);
+  });
+
   it('cleans files created by a real Automerge Repo after document deletion', async () => {
     const path = '/repo';
     const vfs = new VirtualFileSystem();


### PR DESCRIPTION
## Summary

Fixes browser-backed local storage regressions around unknown file capabilities and post-write metadata retrieval.

The VFS now treats undefined capabilities as unknown instead of denial, so delete and move operations are attempted unless the provider explicitly reports `false`. `WebFileSystemProvider.writeFile()` also no longer fails a successful write only because precise post-write metadata cannot be read.

## Changes

- Allow delete/move attempts when capabilities are undefined.
- Preserve explicit capability denial when a provider reports `false`.
- Make `WebFileSystemProvider.writeFile()` return a cheap successful file stat if post-write metadata lookup fails after the write stream closes.
- Add browser-backed provider regression tests for undefined capabilities.
- Add integration coverage for Automerge storage cleanup with browser-backed provider behavior.
- Add integration coverage for create → reload → read document content using browser-backed provider behavior.

## Verification

- Added focused unit and integration tests.
- `pnpm verify` passed in CI.