### PR TITLE
feat(exampleDocuments): add success card for document creation

### DIFF
--- a/src/features/exampleDocumentsCreate/DatabaseExampleDocumentCreateSuccessCard.test.ts
+++ b/src/features/exampleDocumentsCreate/DatabaseExampleDocumentCreateSuccessCard.test.ts
@@ -1,0 +1,32 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import DatabaseExampleDocumentCreateSuccessCard from './DatabaseExampleDocumentCreateSuccessCard.vue';
+
+describe('DatabaseExampleDocumentCreateSuccessCard', () => {
+  it('renders the headline and supporting text', () => {
+    const wrapper = mount(DatabaseExampleDocumentCreateSuccessCard);
+
+    expect(wrapper.find('.database-example-document-create-success-card__headline').text()).toBe(
+      'Example created',
+    );
+    expect(
+      wrapper.find('.database-example-document-create-success-card__supporting-text').text(),
+    ).toContain('regular Mioframe document');
+  });
+
+  it('renders a "Got it" button', () => {
+    const wrapper = mount(DatabaseExampleDocumentCreateSuccessCard);
+
+    const button = wrapper.find('button');
+    expect(button.exists()).toBe(true);
+    expect(button.text()).toContain('Got it');
+  });
+
+  it('emits dismiss when the Got it button is clicked', async () => {
+    const wrapper = mount(DatabaseExampleDocumentCreateSuccessCard);
+
+    await wrapper.find('button').trigger('click');
+
+    expect(wrapper.emitted('dismiss')).toHaveLength(1);
+  });
+});

--- a/src/features/exampleDocumentsCreate/DatabaseExampleDocumentCreateSuccessCard.vue
+++ b/src/features/exampleDocumentsCreate/DatabaseExampleDocumentCreateSuccessCard.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import { MDCard } from '@shared/ui/Card';
+import { MDButton } from '@shared/ui/Button';
+
+const emit = defineEmits<{
+  dismiss: [];
+}>();
+
+const onDismiss = () => {
+  emit('dismiss');
+};
+</script>
+
+<template>
+  <MDCard class="database-example-document-create-success-card" variant="outlined">
+    <div class="database-example-document-create-success-card__content">
+      <h3 class="database-example-document-create-success-card__headline">Example created</h3>
+      <p class="database-example-document-create-success-card__supporting-text">
+        This is a regular Mioframe document. You can edit rows or add your own records.
+      </p>
+    </div>
+
+    <div class="database-example-document-create-success-card__actions">
+      <MDButton label="Got it" color="text" @click="onDismiss" />
+    </div>
+  </MDCard>
+</template>
+
+<style lang="css" scoped>
+.database-example-document-create-success-card {
+  width: 100%;
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: 4dp;
+  }
+
+  &__headline {
+    margin: 0;
+    font-family: var(--md-sys-typescale-title-medium-font);
+    font-size: var(--md-sys-typescale-title-medium-size);
+    line-height: var(--md-sys-typescale-title-medium-line-height);
+    letter-spacing: var(--md-sys-typescale-title-medium-tracking);
+    font-weight: var(--md-sys-typescale-title-medium-weight);
+  }
+
+  &__supporting-text {
+    margin: 0;
+    color: var(--md-sys-color-on-surface-variant);
+    font-family: var(--md-sys-typescale-body-medium-font);
+    font-size: var(--md-sys-typescale-body-medium-size);
+    line-height: var(--md-sys-typescale-body-medium-line-height);
+    letter-spacing: var(--md-sys-typescale-body-medium-tracking);
+    font-weight: var(--md-sys-typescale-body-medium-weight);
+  }
+
+  &__actions {
+    display: flex;
+    justify-content: flex-end;
+  }
+}
+</style>

--- a/src/features/exampleDocumentsCreate/index.ts
+++ b/src/features/exampleDocumentsCreate/index.ts
@@ -1,3 +1,8 @@
+export { default as DatabaseExampleDocumentCreateSuccessCard } from './DatabaseExampleDocumentCreateSuccessCard.vue';
 export { default as ExampleDocumentCreateCard } from './ExampleDocumentCreateCard.vue';
 export { createStarterExampleDocument } from './createStarterExampleDocument';
 export { useExampleDocumentsCreate } from './useExampleDocumentsCreate';
+export {
+  markDatabaseExampleDocumentCreateSuccess,
+  useDatabaseExampleDocumentCreateSuccess,
+} from './useDatabaseExampleDocumentCreateSuccess';

--- a/src/features/exampleDocumentsCreate/useDatabaseExampleDocumentCreateSuccess.test.ts
+++ b/src/features/exampleDocumentsCreate/useDatabaseExampleDocumentCreateSuccess.test.ts
@@ -1,5 +1,5 @@
 import { Repo } from '@automerge/automerge-repo';
-import { ref } from 'vue';
+import { nextTick, ref } from 'vue';
 import { describe, expect, it } from 'vitest';
 import {
   markDatabaseExampleDocumentCreateSuccess,
@@ -72,5 +72,80 @@ describe('useDatabaseExampleDocumentCreateSuccess', () => {
     const docId = createDocumentId();
     const { isVisible } = useDatabaseExampleDocumentCreateSuccess(ref(DIR), ref(docId));
     expect(isVisible.value).toBe(false);
+  });
+
+  describe('reactive identity changes', () => {
+    it('shows card when refs change from unmatched doc A to marked doc B', async () => {
+      const docA = createDocumentId();
+      const docB = createDocumentId();
+      markDatabaseExampleDocumentCreateSuccess(DIR, docB);
+
+      const dirRef = ref(DIR);
+      const idRef = ref(docA);
+      const { isVisible } = useDatabaseExampleDocumentCreateSuccess(dirRef, idRef);
+      expect(isVisible.value).toBe(false);
+
+      idRef.value = docB;
+      await nextTick();
+
+      expect(isVisible.value).toBe(true);
+    });
+
+    it('hides card when refs change away from consumed doc B to doc C', async () => {
+      const docB = createDocumentId();
+      const docC = createDocumentId();
+      markDatabaseExampleDocumentCreateSuccess(DIR, docB);
+
+      const dirRef = ref(DIR);
+      const idRef = ref(docB);
+      const { isVisible } = useDatabaseExampleDocumentCreateSuccess(dirRef, idRef);
+      expect(isVisible.value).toBe(true);
+
+      idRef.value = docC;
+      await nextTick();
+
+      expect(isVisible.value).toBe(false);
+    });
+
+    it('remains hidden when refs change back to already-consumed doc B', async () => {
+      const docB = createDocumentId();
+      const docC = createDocumentId();
+      markDatabaseExampleDocumentCreateSuccess(DIR, docB);
+
+      const dirRef = ref(DIR);
+      const idRef = ref(docB);
+      const { isVisible } = useDatabaseExampleDocumentCreateSuccess(dirRef, idRef);
+      expect(isVisible.value).toBe(true);
+
+      idRef.value = docC;
+      await nextTick();
+      expect(isVisible.value).toBe(false);
+
+      idRef.value = docB;
+      await nextTick();
+
+      expect(isVisible.value).toBe(false);
+    });
+
+    it('second composable for already-consumed doc B does not show the card', async () => {
+      const docA = createDocumentId();
+      const docB = createDocumentId();
+      markDatabaseExampleDocumentCreateSuccess(DIR, docB);
+
+      const dirRef = ref(DIR);
+      const idRef = ref(docA);
+      const first = useDatabaseExampleDocumentCreateSuccess(dirRef, idRef);
+      expect(first.isVisible.value).toBe(false);
+
+      idRef.value = docB;
+      await nextTick();
+      expect(first.isVisible.value).toBe(true);
+
+      const { isVisible: secondVisible } = useDatabaseExampleDocumentCreateSuccess(
+        ref(DIR),
+        ref(docB),
+      );
+      expect(secondVisible.value).toBe(false);
+    });
   });
 });

--- a/src/features/exampleDocumentsCreate/useDatabaseExampleDocumentCreateSuccess.test.ts
+++ b/src/features/exampleDocumentsCreate/useDatabaseExampleDocumentCreateSuccess.test.ts
@@ -1,6 +1,6 @@
 import { Repo } from '@automerge/automerge-repo';
 import { ref } from 'vue';
-import { afterEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
   markDatabaseExampleDocumentCreateSuccess,
   useDatabaseExampleDocumentCreateSuccess,
@@ -11,11 +11,6 @@ const OTHER_DIR = '/Device Files/Browser Storage/Examples 2';
 
 const createDocumentId = () => new Repo().create({}).documentId;
 
-afterEach(() => {
-  // Module-level state is cleared between tests by dismissing any previously marked keys.
-  // Tests that mark keys should dismiss them in afterEach or use separate IDs per test.
-});
-
 describe('useDatabaseExampleDocumentCreateSuccess', () => {
   it('is not visible when no mark has been set', () => {
     const docId = createDocumentId();
@@ -23,23 +18,35 @@ describe('useDatabaseExampleDocumentCreateSuccess', () => {
     expect(isVisible.value).toBe(false);
   });
 
-  it('becomes visible after markDatabaseExampleDocumentCreateSuccess is called', () => {
+  it('is visible on first use when marked', () => {
     const docId = createDocumentId();
     markDatabaseExampleDocumentCreateSuccess(DIR, docId);
-
-    const { isVisible, dismiss } = useDatabaseExampleDocumentCreateSuccess(ref(DIR), ref(docId));
+    const { isVisible } = useDatabaseExampleDocumentCreateSuccess(ref(DIR), ref(docId));
     expect(isVisible.value).toBe(true);
-
-    dismiss();
   });
 
-  it('is hidden after dismiss is called', () => {
+  it('is not visible on second use after the first use consumed the marker', () => {
     const docId = createDocumentId();
     markDatabaseExampleDocumentCreateSuccess(DIR, docId);
+    useDatabaseExampleDocumentCreateSuccess(ref(DIR), ref(docId));
+    const { isVisible } = useDatabaseExampleDocumentCreateSuccess(ref(DIR), ref(docId));
+    expect(isVisible.value).toBe(false);
+  });
 
+  it('does not show on remount when first use was not dismissed', () => {
+    const docId = createDocumentId();
+    markDatabaseExampleDocumentCreateSuccess(DIR, docId);
+    const first = useDatabaseExampleDocumentCreateSuccess(ref(DIR), ref(docId));
+    expect(first.isVisible.value).toBe(true);
+    const { isVisible } = useDatabaseExampleDocumentCreateSuccess(ref(DIR), ref(docId));
+    expect(isVisible.value).toBe(false);
+  });
+
+  it('dismiss hides the currently visible card', () => {
+    const docId = createDocumentId();
+    markDatabaseExampleDocumentCreateSuccess(DIR, docId);
     const { isVisible, dismiss } = useDatabaseExampleDocumentCreateSuccess(ref(DIR), ref(docId));
     expect(isVisible.value).toBe(true);
-
     dismiss();
     expect(isVisible.value).toBe(false);
   });
@@ -48,67 +55,22 @@ describe('useDatabaseExampleDocumentCreateSuccess', () => {
     const docId = createDocumentId();
     const otherDocId = createDocumentId();
     markDatabaseExampleDocumentCreateSuccess(DIR, docId);
-
-    const { isVisible, dismiss: d } = useDatabaseExampleDocumentCreateSuccess(
-      ref(DIR),
-      ref(otherDocId),
-    );
+    const { isVisible } = useDatabaseExampleDocumentCreateSuccess(ref(DIR), ref(otherDocId));
     expect(isVisible.value).toBe(false);
-
-    // Cleanup
-    useDatabaseExampleDocumentCreateSuccess(ref(DIR), ref(docId)).dismiss();
-    d();
+    useDatabaseExampleDocumentCreateSuccess(ref(DIR), ref(docId));
   });
 
   it('does not show for a different documentDirectory', () => {
     const docId = createDocumentId();
     markDatabaseExampleDocumentCreateSuccess(DIR, docId);
-
     const { isVisible } = useDatabaseExampleDocumentCreateSuccess(ref(OTHER_DIR), ref(docId));
     expect(isVisible.value).toBe(false);
-
-    // Cleanup
-    useDatabaseExampleDocumentCreateSuccess(ref(DIR), ref(docId)).dismiss();
-  });
-
-  it('does not affect other document keys when dismissed', () => {
-    const docId = createDocumentId();
-    const otherDocId = createDocumentId();
-    markDatabaseExampleDocumentCreateSuccess(DIR, docId);
-    markDatabaseExampleDocumentCreateSuccess(OTHER_DIR, otherDocId);
-
-    const target = useDatabaseExampleDocumentCreateSuccess(ref(DIR), ref(docId));
-    const other = useDatabaseExampleDocumentCreateSuccess(ref(OTHER_DIR), ref(otherDocId));
-
-    target.dismiss();
-
-    expect(target.isVisible.value).toBe(false);
-    expect(other.isVisible.value).toBe(true);
-
-    other.dismiss();
+    useDatabaseExampleDocumentCreateSuccess(ref(DIR), ref(docId));
   });
 
   it('remains hidden without a mark — simulates normal document open or reload', () => {
     const docId = createDocumentId();
     const { isVisible } = useDatabaseExampleDocumentCreateSuccess(ref(DIR), ref(docId));
     expect(isVisible.value).toBe(false);
-  });
-
-  it('reacts to documentId ref change', () => {
-    const docId = createDocumentId();
-    const otherDocId = createDocumentId();
-    markDatabaseExampleDocumentCreateSuccess(DIR, docId);
-
-    const dirRef = ref(DIR);
-    const docRef = ref(docId);
-    const { isVisible, dismiss } = useDatabaseExampleDocumentCreateSuccess(dirRef, docRef);
-
-    expect(isVisible.value).toBe(true);
-
-    docRef.value = otherDocId;
-    expect(isVisible.value).toBe(false);
-
-    dismiss();
-    useDatabaseExampleDocumentCreateSuccess(ref(DIR), ref(docId)).dismiss();
   });
 });

--- a/src/features/exampleDocumentsCreate/useDatabaseExampleDocumentCreateSuccess.test.ts
+++ b/src/features/exampleDocumentsCreate/useDatabaseExampleDocumentCreateSuccess.test.ts
@@ -1,0 +1,114 @@
+import { Repo } from '@automerge/automerge-repo';
+import { ref } from 'vue';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  markDatabaseExampleDocumentCreateSuccess,
+  useDatabaseExampleDocumentCreateSuccess,
+} from './useDatabaseExampleDocumentCreateSuccess';
+
+const DIR = '/Device Files/Browser Storage/Examples';
+const OTHER_DIR = '/Device Files/Browser Storage/Examples 2';
+
+const createDocumentId = () => new Repo().create({}).documentId;
+
+afterEach(() => {
+  // Module-level state is cleared between tests by dismissing any previously marked keys.
+  // Tests that mark keys should dismiss them in afterEach or use separate IDs per test.
+});
+
+describe('useDatabaseExampleDocumentCreateSuccess', () => {
+  it('is not visible when no mark has been set', () => {
+    const docId = createDocumentId();
+    const { isVisible } = useDatabaseExampleDocumentCreateSuccess(ref(DIR), ref(docId));
+    expect(isVisible.value).toBe(false);
+  });
+
+  it('becomes visible after markDatabaseExampleDocumentCreateSuccess is called', () => {
+    const docId = createDocumentId();
+    markDatabaseExampleDocumentCreateSuccess(DIR, docId);
+
+    const { isVisible, dismiss } = useDatabaseExampleDocumentCreateSuccess(ref(DIR), ref(docId));
+    expect(isVisible.value).toBe(true);
+
+    dismiss();
+  });
+
+  it('is hidden after dismiss is called', () => {
+    const docId = createDocumentId();
+    markDatabaseExampleDocumentCreateSuccess(DIR, docId);
+
+    const { isVisible, dismiss } = useDatabaseExampleDocumentCreateSuccess(ref(DIR), ref(docId));
+    expect(isVisible.value).toBe(true);
+
+    dismiss();
+    expect(isVisible.value).toBe(false);
+  });
+
+  it('does not show for a different documentId', () => {
+    const docId = createDocumentId();
+    const otherDocId = createDocumentId();
+    markDatabaseExampleDocumentCreateSuccess(DIR, docId);
+
+    const { isVisible, dismiss: d } = useDatabaseExampleDocumentCreateSuccess(
+      ref(DIR),
+      ref(otherDocId),
+    );
+    expect(isVisible.value).toBe(false);
+
+    // Cleanup
+    useDatabaseExampleDocumentCreateSuccess(ref(DIR), ref(docId)).dismiss();
+    d();
+  });
+
+  it('does not show for a different documentDirectory', () => {
+    const docId = createDocumentId();
+    markDatabaseExampleDocumentCreateSuccess(DIR, docId);
+
+    const { isVisible } = useDatabaseExampleDocumentCreateSuccess(ref(OTHER_DIR), ref(docId));
+    expect(isVisible.value).toBe(false);
+
+    // Cleanup
+    useDatabaseExampleDocumentCreateSuccess(ref(DIR), ref(docId)).dismiss();
+  });
+
+  it('does not affect other document keys when dismissed', () => {
+    const docId = createDocumentId();
+    const otherDocId = createDocumentId();
+    markDatabaseExampleDocumentCreateSuccess(DIR, docId);
+    markDatabaseExampleDocumentCreateSuccess(OTHER_DIR, otherDocId);
+
+    const target = useDatabaseExampleDocumentCreateSuccess(ref(DIR), ref(docId));
+    const other = useDatabaseExampleDocumentCreateSuccess(ref(OTHER_DIR), ref(otherDocId));
+
+    target.dismiss();
+
+    expect(target.isVisible.value).toBe(false);
+    expect(other.isVisible.value).toBe(true);
+
+    other.dismiss();
+  });
+
+  it('remains hidden without a mark — simulates normal document open or reload', () => {
+    const docId = createDocumentId();
+    const { isVisible } = useDatabaseExampleDocumentCreateSuccess(ref(DIR), ref(docId));
+    expect(isVisible.value).toBe(false);
+  });
+
+  it('reacts to documentId ref change', () => {
+    const docId = createDocumentId();
+    const otherDocId = createDocumentId();
+    markDatabaseExampleDocumentCreateSuccess(DIR, docId);
+
+    const dirRef = ref(DIR);
+    const docRef = ref(docId);
+    const { isVisible, dismiss } = useDatabaseExampleDocumentCreateSuccess(dirRef, docRef);
+
+    expect(isVisible.value).toBe(true);
+
+    docRef.value = otherDocId;
+    expect(isVisible.value).toBe(false);
+
+    dismiss();
+    useDatabaseExampleDocumentCreateSuccess(ref(DIR), ref(docId)).dismiss();
+  });
+});

--- a/src/features/exampleDocumentsCreate/useDatabaseExampleDocumentCreateSuccess.test.ts
+++ b/src/features/exampleDocumentsCreate/useDatabaseExampleDocumentCreateSuccess.test.ts
@@ -1,8 +1,9 @@
 import { Repo } from '@automerge/automerge-repo';
 import { nextTick, ref } from 'vue';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import {
   markDatabaseExampleDocumentCreateSuccess,
+  resetDatabaseExampleDocumentCreateSuccessForTest,
   useDatabaseExampleDocumentCreateSuccess,
 } from './useDatabaseExampleDocumentCreateSuccess';
 
@@ -12,6 +13,10 @@ const OTHER_DIR = '/Device Files/Browser Storage/Examples 2';
 const createDocumentId = () => new Repo().create({}).documentId;
 
 describe('useDatabaseExampleDocumentCreateSuccess', () => {
+  afterEach(() => {
+    resetDatabaseExampleDocumentCreateSuccessForTest();
+  });
+
   it('is not visible when no mark has been set', () => {
     const docId = createDocumentId();
     const { isVisible } = useDatabaseExampleDocumentCreateSuccess(ref(DIR), ref(docId));

--- a/src/features/exampleDocumentsCreate/useDatabaseExampleDocumentCreateSuccess.ts
+++ b/src/features/exampleDocumentsCreate/useDatabaseExampleDocumentCreateSuccess.ts
@@ -8,6 +8,14 @@ const makeKey = (documentDirectory: string, documentId: AMDocumentId): string =>
   JSON.stringify([documentDirectory, documentId]);
 
 /**
+ * Clears all pending markers to prevent state leakage between test cases.
+ * @internal
+ */
+export const resetDatabaseExampleDocumentCreateSuccessForTest = (): void => {
+  pendingKeys.clear();
+};
+
+/**
  * Marks a database document as having just been created from a starter example.
  * The state is in-memory only and is consumed on the first matching render.
  * @param documentDirectory - Directory path of the created document

--- a/src/features/exampleDocumentsCreate/useDatabaseExampleDocumentCreateSuccess.ts
+++ b/src/features/exampleDocumentsCreate/useDatabaseExampleDocumentCreateSuccess.ts
@@ -1,0 +1,43 @@
+import type { AMDocumentId } from '@shared/lib/automerge';
+import { computed, reactive } from 'vue';
+import type { Ref } from 'vue';
+
+const pendingKeys = reactive(new Set<string>());
+
+const makeKey = (documentDirectory: string, documentId: AMDocumentId): string =>
+  `${documentDirectory}::${documentId}`;
+
+/**
+ * Marks a database document as having just been created from a starter example.
+ * The state is in-memory only and is cleared when dismissed.
+ * @param documentDirectory - Directory path of the created document
+ * @param documentId - ID of the created database document
+ */
+export const markDatabaseExampleDocumentCreateSuccess = (
+  documentDirectory: string,
+  documentId: AMDocumentId,
+): void => {
+  pendingKeys.add(makeKey(documentDirectory, documentId));
+};
+
+/**
+ * Returns reactive visibility state for the post-create success card for a specific database document.
+ * The card is visible only immediately after starter example creation and is cleared on dismiss.
+ * @param documentDirectory - Reactive directory path of the document
+ * @param documentId - Reactive ID of the database document
+ * @returns `isVisible` computed ref and `dismiss` function
+ */
+export const useDatabaseExampleDocumentCreateSuccess = (
+  documentDirectory: Ref<string>,
+  documentId: Ref<AMDocumentId>,
+) => {
+  const isVisible = computed(() =>
+    pendingKeys.has(makeKey(documentDirectory.value, documentId.value)),
+  );
+
+  const dismiss = () => {
+    pendingKeys.delete(makeKey(documentDirectory.value, documentId.value));
+  };
+
+  return { isVisible, dismiss };
+};

--- a/src/features/exampleDocumentsCreate/useDatabaseExampleDocumentCreateSuccess.ts
+++ b/src/features/exampleDocumentsCreate/useDatabaseExampleDocumentCreateSuccess.ts
@@ -1,11 +1,11 @@
 import type { AMDocumentId } from '@shared/lib/automerge';
-import { readonly, ref } from 'vue';
+import { readonly, ref, watch } from 'vue';
 import type { Ref } from 'vue';
 
 const pendingKeys = new Set<string>();
 
 const makeKey = (documentDirectory: string, documentId: AMDocumentId): string =>
-  `${documentDirectory}::${documentId}`;
+  JSON.stringify([documentDirectory, documentId]);
 
 /**
  * Marks a database document as having just been created from a starter example.
@@ -22,7 +22,9 @@ export const markDatabaseExampleDocumentCreateSuccess = (
 
 /**
  * Returns visibility state for the post-create success card for a specific database document.
- * The marker is consumed immediately on the first matching use. `dismiss` only hides the local card.
+ * Reacts to identity changes: the marker is consumed immediately when the matching identity is
+ * observed, and the card is hidden whenever the identity no longer matches. `dismiss` only hides
+ * the local card without affecting the marker.
  * @param documentDirectory - Reactive directory path of the document
  * @param documentId - Reactive ID of the database document
  * @returns `isVisible` readonly ref and `dismiss` function
@@ -31,13 +33,21 @@ export const useDatabaseExampleDocumentCreateSuccess = (
   documentDirectory: Ref<string>,
   documentId: Ref<AMDocumentId>,
 ) => {
-  const key = makeKey(documentDirectory.value, documentId.value);
-  const wasMarked = pendingKeys.has(key);
-  if (wasMarked) {
-    pendingKeys.delete(key);
-  }
+  const isVisible = ref(false);
 
-  const isVisible = ref(wasMarked);
+  watch(
+    [documentDirectory, documentId],
+    ([dir, id]) => {
+      const key = makeKey(dir, id);
+      if (pendingKeys.has(key)) {
+        pendingKeys.delete(key);
+        isVisible.value = true;
+      } else {
+        isVisible.value = false;
+      }
+    },
+    { immediate: true },
+  );
 
   const dismiss = () => {
     isVisible.value = false;

--- a/src/features/exampleDocumentsCreate/useDatabaseExampleDocumentCreateSuccess.ts
+++ b/src/features/exampleDocumentsCreate/useDatabaseExampleDocumentCreateSuccess.ts
@@ -1,15 +1,15 @@
 import type { AMDocumentId } from '@shared/lib/automerge';
-import { computed, reactive } from 'vue';
+import { readonly, ref } from 'vue';
 import type { Ref } from 'vue';
 
-const pendingKeys = reactive(new Set<string>());
+const pendingKeys = new Set<string>();
 
 const makeKey = (documentDirectory: string, documentId: AMDocumentId): string =>
   `${documentDirectory}::${documentId}`;
 
 /**
  * Marks a database document as having just been created from a starter example.
- * The state is in-memory only and is cleared when dismissed.
+ * The state is in-memory only and is consumed on the first matching render.
  * @param documentDirectory - Directory path of the created document
  * @param documentId - ID of the created database document
  */
@@ -21,23 +21,27 @@ export const markDatabaseExampleDocumentCreateSuccess = (
 };
 
 /**
- * Returns reactive visibility state for the post-create success card for a specific database document.
- * The card is visible only immediately after starter example creation and is cleared on dismiss.
+ * Returns visibility state for the post-create success card for a specific database document.
+ * The marker is consumed immediately on the first matching use. `dismiss` only hides the local card.
  * @param documentDirectory - Reactive directory path of the document
  * @param documentId - Reactive ID of the database document
- * @returns `isVisible` computed ref and `dismiss` function
+ * @returns `isVisible` readonly ref and `dismiss` function
  */
 export const useDatabaseExampleDocumentCreateSuccess = (
   documentDirectory: Ref<string>,
   documentId: Ref<AMDocumentId>,
 ) => {
-  const isVisible = computed(() =>
-    pendingKeys.has(makeKey(documentDirectory.value, documentId.value)),
-  );
+  const key = makeKey(documentDirectory.value, documentId.value);
+  const wasMarked = pendingKeys.has(key);
+  if (wasMarked) {
+    pendingKeys.delete(key);
+  }
+
+  const isVisible = ref(wasMarked);
 
   const dismiss = () => {
-    pendingKeys.delete(makeKey(documentDirectory.value, documentId.value));
+    isVisible.value = false;
   };
 
-  return { isVisible, dismiss };
+  return { isVisible: readonly(isVisible), dismiss };
 };

--- a/src/pages/HomePane/HomePane.test.ts
+++ b/src/pages/HomePane/HomePane.test.ts
@@ -1,6 +1,9 @@
 /* eslint-disable vue/one-component-per-file -- This test file intentionally defines several tiny inline stub components. */
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
 import { createApp, defineComponent, h, nextTick, ref } from 'vue';
+
+const openMock = vi.hoisted(() => vi.fn());
 
 const settings = ref<{ googleDriveIntegrationEnabled?: boolean }>({});
 let googleDriveIntegrationAvailable = true;
@@ -13,7 +16,7 @@ vi.mock('@entity/localSettings', () => ({
 
 vi.mock('@page/routes', () => ({
   useStackNavigation: () => ({
-    open: vi.fn(),
+    open: openMock,
   }),
 }));
 
@@ -96,6 +99,7 @@ describe('HomePane', () => {
     googleDriveIntegrationAvailable = true;
     settings.value = {};
     document.body.innerHTML = '';
+    openMock.mockReset();
   });
 
   it('hides the Google Drive widget when integration is not explicitly enabled', async () => {
@@ -131,6 +135,48 @@ describe('HomePane', () => {
     expect(root.querySelector('[data-testid="google-drive-widget"]')).toBeNull();
 
     unmount();
+  });
+
+  it('navigates to the document when StarterExamplesWidget emits createdDocument', async () => {
+    const { default: HomePane } = await import('./HomePane.vue');
+    const wrapper = mount(HomePane);
+
+    await wrapper.findComponent({ name: 'StarterExamplesWidgetStub' }).vm.$emit('createdDocument', {
+      documentDirectory: '/Examples',
+      documentId: 'doc-1',
+    });
+
+    expect(openMock).toHaveBeenCalledWith(
+      'document',
+      { documentDirectory: '/Examples', documentId: 'doc-1' },
+      { target: 'document' },
+    );
+  });
+
+  it('navigates to the repo when LocalFSWidget emits click-path', async () => {
+    const { default: HomePane } = await import('./HomePane.vue');
+    const wrapper = mount(HomePane);
+
+    await wrapper.findComponent({ name: 'LocalFSWidgetStub' }).vm.$emit('clickPath', '/my/path');
+
+    expect(openMock).toHaveBeenCalledWith('repo', { repoPath: '/my/path' }, { target: 'repo' });
+  });
+
+  it('navigates to the repo when GoogleDriveWidget emits click-user', async () => {
+    settings.value = { googleDriveIntegrationEnabled: true };
+    googleDriveIntegrationAvailable = true;
+    const { default: HomePane } = await import('./HomePane.vue');
+    const wrapper = mount(HomePane);
+
+    await wrapper
+      .findComponent({ name: 'GoogleDriveWidgetStub' })
+      .vm.$emit('clickUser', 'user@example.com');
+
+    expect(openMock).toHaveBeenCalledWith(
+      'repo',
+      { repoPath: '/Google Drive/user@example.com' },
+      { target: 'repo' },
+    );
   });
 });
 /* eslint-enable vue/one-component-per-file -- Re-enable the rule after the inline component stubs used in this file. */

--- a/src/pages/HomePane/HomePane.vue
+++ b/src/pages/HomePane/HomePane.vue
@@ -46,7 +46,7 @@ const openDocument = async (documentDirectory: string, documentId: AMDocumentId)
   );
 };
 
-const onOpenStarterExampleDocument = ({
+const onCreatedStarterExampleDocument = ({
   documentDirectory,
   documentId,
 }: {
@@ -67,7 +67,7 @@ const onOpenStarterExampleDocument = ({
 
     <StarterExamplesWidget
       v-if="!settings.hideStarterWidget"
-      @open-document="onOpenStarterExampleDocument"
+      @created-document="onCreatedStarterExampleDocument"
     />
 
     <LocalFSWidget @click-path="onClickLocalPath" />

--- a/src/widgets/DocumentView/Database/DatabaseViewWidget.vue
+++ b/src/widgets/DocumentView/Database/DatabaseViewWidget.vue
@@ -207,6 +207,7 @@ const onUpdatedEditItemDialog = () => {
   flex: 1 0;
   overflow: auto;
   padding: 0 4step 0;
+  gap: 2step;
 
   &__success-card {
     flex-shrink: 0;

--- a/src/widgets/DocumentView/Database/DatabaseViewWidget.vue
+++ b/src/widgets/DocumentView/Database/DatabaseViewWidget.vue
@@ -20,6 +20,10 @@ import { useDatabaseProperties } from '@entity/databaseProperty';
 import { DomainError } from '@shared/lib/error';
 import { useDatabaseViewSelection } from '@entity/databaseView';
 import { useDatabaseData } from '@entity/databaseData/useDatabaseData';
+import {
+  DatabaseExampleDocumentCreateSuccessCard,
+  useDatabaseExampleDocumentCreateSuccess,
+} from '@feature/exampleDocumentsCreate';
 
 const props = defineProps<{
   documentId: AMDocumentId;
@@ -27,6 +31,8 @@ const props = defineProps<{
 }>();
 
 const { directoryPath: path, documentId } = toRefs(props);
+const { isVisible: isSuccessCardVisible, dismiss: dismissSuccessCard } =
+  useDatabaseExampleDocumentCreateSuccess(path, documentId);
 const stateExplicitViewId = shallowRef<DatabaseViewId>();
 const {
   viewList: databaseViewList,
@@ -111,6 +117,12 @@ const onUpdatedEditItemDialog = () => {
 
 <template>
   <div ref="databaseViewRef" class="database-view">
+    <DatabaseExampleDocumentCreateSuccessCard
+      v-if="isSuccessCardVisible"
+      class="database-view__success-card"
+      @dismiss="dismissSuccessCard"
+    />
+
     <div v-if="documentError" class="database-view__error">
       <pre>{{ documentError }}</pre>
     </div>
@@ -195,6 +207,10 @@ const onUpdatedEditItemDialog = () => {
   flex: 1 0;
   overflow: auto;
   padding: 0 4step 0;
+
+  &__success-card {
+    flex-shrink: 0;
+  }
 
   &__controls {
     margin-top: auto;

--- a/src/widgets/StarterExamplesWidget/StarterExamplesWidget.vue
+++ b/src/widgets/StarterExamplesWidget/StarterExamplesWidget.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue';
 import { starterExampleDefinitions, type StarterExampleId } from '@entity/starterExample';
 import {
   ExampleDocumentCreateCard,
+  markDatabaseExampleDocumentCreateSuccess,
   useExampleDocumentsCreate,
 } from '@feature/exampleDocumentsCreate';
 import { StarterExamplesDismissButton } from '@feature/starterExamplesDismiss';
@@ -10,7 +11,7 @@ import type { AMDocumentId } from '@shared/lib/automerge';
 import { MDCard } from '@shared/ui/Card';
 
 const emit = defineEmits<{
-  openDocument: [payload: { documentDirectory: string; documentId: AMDocumentId }];
+  createdDocument: [payload: { documentDirectory: string; documentId: AMDocumentId }];
 }>();
 
 const {
@@ -25,7 +26,7 @@ const {
 const isBusy = computed(() => isCreatingWeeklyPlanExample.value || isCreatingShoppingExample.value);
 
 const onOpenDocument = (payload: { documentDirectory: string; documentId: AMDocumentId }) => {
-  emit('openDocument', payload);
+  emit('createdDocument', payload);
 };
 
 const onCreateExample = async (exampleId: StarterExampleId) => {
@@ -33,6 +34,10 @@ const onCreateExample = async (exampleId: StarterExampleId) => {
     exampleId === 'weeklyPlan' ? await createWeeklyPlanExample() : await createShoppingExample();
 
   if (createdExample) {
+    markDatabaseExampleDocumentCreateSuccess(
+      createdExample.documentDirectory,
+      createdExample.documentId,
+    );
     onOpenDocument(createdExample);
   }
 };

--- a/src/widgets/StarterExamplesWidget/StarterExamplesWidget.vue
+++ b/src/widgets/StarterExamplesWidget/StarterExamplesWidget.vue
@@ -25,10 +25,6 @@ const {
 
 const isBusy = computed(() => isCreatingWeeklyPlanExample.value || isCreatingShoppingExample.value);
 
-const onOpenDocument = (payload: { documentDirectory: string; documentId: AMDocumentId }) => {
-  emit('createdDocument', payload);
-};
-
 const onCreateExample = async (exampleId: StarterExampleId) => {
   const createdExample =
     exampleId === 'weeklyPlan' ? await createWeeklyPlanExample() : await createShoppingExample();
@@ -38,7 +34,7 @@ const onCreateExample = async (exampleId: StarterExampleId) => {
       createdExample.documentDirectory,
       createdExample.documentId,
     );
-    onOpenDocument(createdExample);
+    emit('createdDocument', createdExample);
   }
 };
 </script>


### PR DESCRIPTION
- implement DatabaseExampleDocumentCreateSuccessCard component
- integrate success card visibility logic in database document creation
- update event handling in StarterExamplesWidget and HomePane
- add tests for success card rendering and behavior