### PR TITLE
fix(exampleDocumentsCreate): wrap boundary errors in DomainError with…

### DIFF
--- a/.agents/skills/diagnostic-events/SKILL.md
+++ b/.agents/skills/diagnostic-events/SKILL.md
@@ -216,7 +216,18 @@ captureDiagnosticException(caughtError, {
 });
 ```
 
-For flow-specific classification (e.g. whether a `DOMException` means browser file state changed), use a local helper near the boundary that understands the operation. Do not create shared error registries.
+Pass the **real error object** to `captureDiagnosticException`. The Sentry `beforeSend` sanitizer scrubs exception messages, linked cause messages, tags, extras, contexts, breadcrumbs, and user fields at the outgoing event boundary — feature code does not need to pre-sanitize cause messages.
+
+**Forbidden in feature, entity, widget, and page code:**
+
+- `createSafeErrorCause` — do not create synthetic safe-cause objects; pass the raw caught error as `DomainError.cause` instead.
+- `buildSafeCause`, `buildReportedError`, `toReportedError`, or similar wrappers that replace the raw cause with a synthetic plain Error.
+- `classify*Error`, `map*ErrorToCause`, `toSafe*Error`, or any local helper that inspects the caught error and produces a new synthetic error for the sole purpose of safe reporting. The Sentry sanitizer owns that responsibility.
+- Feature-local VFS-to-feature error mappings or error classifiers added only to control what Sentry receives.
+
+A local helper is acceptable only when it centralizes a user-facing message, a stable enum code, and the raw cause — without inspecting or transforming the caught error's contents.
+
+For flow-specific decisions (e.g. whether to skip reporting user cancellation, or whether a `DOMException` means a specific browser condition), a local boolean helper near the boundary is acceptable. It must control flow, not build synthetic diagnostic errors.
 
 Forbidden error fields in any diagnostic event or breadcrumb data:
 

--- a/.agents/skills/privacy-safe-errors/SKILL.md
+++ b/.agents/skills/privacy-safe-errors/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: privacy-safe-errors
-description: 'Use this skill when adding or reviewing error handling that can show user-facing messages, create DomainError instances, preserve error causes, call reportHandledError, send diagnostics, or handle browser, storage, network, File API, Google API, Automerge, Zod, VFS, or other external errors.'
+description: 'Use this skill when adding or reviewing error handling that can show user-facing messages, create DomainError instances, preserve error causes, call captureDiagnosticException, send diagnostics, or handle browser, storage, network, File API, Google API, Automerge, Zod, VFS, or other external errors.'
 ---
 
 # Privacy-safe errors
@@ -13,39 +13,68 @@ This skill does not require masking every unexpected error. Sentry must still re
 
 Use this skill when code does any of the following:
 
-- calls `reportHandledError`;
+- calls `captureDiagnosticException`;
 - creates or rethrows `DomainError` in a flow that may later be reported;
 - preserves an unknown, boundary, or external `error` as `cause`;
 - handles browser APIs, File API, File System API, Google API, network, IndexedDB, VFS, Automerge/repo internals, Zod, or other external libraries;
 - builds user-facing error messages, snackbar text, details panels, or copyable diagnostic text.
 
-## Core rule
+## Two concerns — keep them distinct
 
-Errors that can reach handled diagnostics must be privacy-safe by construction.
+**Trusted in-app runtime and proxy transfer**
 
-Decide safety at the boundary where an error is created or converted. Do not rely on later callers, `reportHandledError`, or Sentry `beforeSend` to make arbitrary exception messages and stacks privacy-safe.
+`DomainError.cause` may hold the original raw runtime error inside the app and across trusted proxy boundaries. Preserving the raw cause is correct and intended for runtime debugging. Do not sanitize it at the error-creation site.
 
-Privacy-safe does not mean low-information. Internal programmer errors and project-controlled invariant failures may keep their original `Error` object when their message is stable and does not contain user-controlled values.
+**External diagnostics export**
 
-## Classify the error source first
+The Sentry `beforeSend` sanitizer scrubs outgoing events: exception value messages (including linked cause chains), tags, extras, contexts, breadcrumbs, and user fields. Sensitive data is removed before reaching Sentry.
+
+## Error construction rules
+
+Wrap boundary failures using this pattern:
+
+```ts
+throw new DomainError('Could not save changes.', {
+  code: RepositoryErrorCode.SaveFailed,
+  cause: error,
+});
+```
+
+- `DomainError.message` — user-safe short string; no paths, names, ids, URLs, or raw external text.
+- `DomainError.code` — stable string enum value defined close to the error's source. Do not create a global registry.
+- `DomainError.cause` — raw runtime cause preserved for debugging; the sanitizer handles Sentry export.
+
+## Error code rules
+
+Define each string enum close to the boundary where the error originates:
+
+```ts
+export enum RepositoryErrorCode {
+  SaveFailed = 'repository.saveFailed',
+  ReplayFailed = 'repository.replayFailed',
+}
+
+export enum ExampleDocumentsCreateErrorCode {
+  CreateFailed = 'exampleDocumentsCreate.createFailed',
+  DirectoryLimitExceeded = 'exampleDocumentsCreate.directoryLimitExceeded',
+}
+```
+
+Do not create a global error-code registry. Do not create feature-local classifiers or manual VFS-to-feature error mappings.
+
+## Classify the error source
 
 ### External or user-data boundary errors
 
-Sanitize these before they can reach `reportHandledError`:
+These must be wrapped before `captureDiagnosticException`:
 
-- browser APIs;
-- File API;
-- File System Access API;
-- IndexedDB;
-- Google APIs;
-- storage adapters;
-- Automerge/repo internals;
-- VFS;
-- Zod parsing of user-controlled payloads;
-- network responses;
-- any library error that may include paths, file names, ids, URLs, document contents, record values, or raw user data.
+- browser APIs, File API, File System Access API;
+- IndexedDB, storage adapters, Automerge/repo internals;
+- Google APIs, network responses;
+- VFS, Zod parsing of user-controlled payloads;
+- any library error that may include paths, names, ids, URLs, contents, or raw user data.
 
-Use a project-controlled `DomainError.message`, a safe technical cause such as `createSafeErrorCause`, stable domain codes, and safe metadata only.
+Wrap with a project-controlled `DomainError.message`, stable enum `code`, and preserve raw `cause`. Sentry sanitizes the cause chain on export.
 
 ### Internal programmer errors
 
@@ -55,13 +84,6 @@ Internal programmer errors and project-controlled invariant failures may be repo
 - the message does not include user-controlled paths, names, ids, URLs, contents, payloads, or raw external text.
 
 Do not wrap these errors only to satisfy privacy wording. Losing the original message or stack makes Sentry less useful.
-
-Examples that may remain raw when their message is stable:
-
-- unreachable state assertions;
-- unknown enum or action key errors;
-- project invariant failures;
-- component contract violations generated by project code.
 
 ### Expected user outcomes
 
@@ -74,18 +96,6 @@ Expected user outcomes usually should not be reported:
 
 ## Reporting pattern
 
-When reporting from a feature-level helper:
-
-1. Separate expected user outcomes from failures.
-2. Identify whether the failure came from a privacy-risk boundary or from project-controlled internal logic.
-3. Do not report expected outcomes such as user cancellation, invalid user input, unsupported user-selected file format, or validation failures that are part of normal UX.
-4. Convert boundary errors into a project-controlled safe `DomainError` or safe `Error` before reporting.
-5. Keep project-controlled internal programmer errors raw when their message and stack are safe and useful.
-6. Pass only stable metadata to `reportHandledError`, such as `feature` and `action`.
-7. Do not pass path, name, id, URL, file content, raw external message, or raw error object if it may contain private data.
-
-Example shape:
-
 ```ts
 try {
   await runAction();
@@ -95,41 +105,47 @@ try {
     return;
   }
 
-  reportHandledError(toReportableErrorBySource(error), {
-    feature: 'featureName',
-    action: 'actionName',
-  });
+  captureDiagnosticException(
+    new DomainError('Safe user message.', {
+      code: MyErrorCode.ActionFailed,
+      cause: error,
+    }),
+    { feature: 'featureName', action: 'actionName' },
+  );
 }
 ```
 
+Do not:
+
+- create local classifiers or safe-cause builders for each error type;
+- pass path, name, id, URL, or user-controlled values in context, tags, or extras.
+
 ## DomainError rules
 
-- `DomainError.message` may be user-facing. Keep it safe and avoid paths, names, ids, URLs, record values, or raw external text.
-- `DomainError.cause` may be reported later. Use `createSafeErrorCause` or another project-controlled safe cause for external/browser/storage/network/Zod errors.
-- `reportHandledError` reports an `Error` cause from a `DomainError` instead of the wrapper error. Passing a `DomainError` directly is safe only when its cause is also privacy-safe or absent.
-- Raw `Error` may be preserved only when the message is project-controlled and cannot contain user-controlled values.
-- Expected user-input errors can keep detailed causes only when the flow guarantees they will not be reported. Prefer safe causes anyway if future reuse is likely.
+- `DomainError.message` — user-facing; keep it safe.
+- `DomainError.code` — stable enum value; define near the source.
+- `DomainError.cause` — may hold the raw runtime cause; `beforeSend` sanitizes Sentry export.
+- Do not create a synthetic safe cause via `createSafeErrorCause` in feature code. Use raw cause and rely on the sanitizer.
+- `createSafeErrorCause` remains valid at shared lib adapter boundaries (e.g. `googleDriveFileSystemProvider`) where the cause goes into shared diagnostics infrastructure that does not yet benefit from the outgoing sanitizer.
 
 ## Review checklist
 
 Before final handoff, check touched error flows:
 
-- Can this error reach `reportHandledError` now or through an existing helper?
-- Is the error from a privacy-risk boundary or from project-controlled internal logic?
-- Does any `Error.message`, `DomainError.message`, or `cause.message` include path, name, id, URL, content, raw external text, or validation payload?
-- If a `DomainError` reaches `reportHandledError`, is its `cause` either absent or privacy-safe by construction?
+- Can this error reach `captureDiagnosticException` now or through an existing helper?
+- Is `DomainError.message` free of paths, names, ids, URLs, content, and raw external text?
+- Is `DomainError.code` a stable string enum value defined near the source?
+- Is `DomainError.cause` the raw runtime cause (not a synthetic safe wrapper)?
 - Are expected user outcomes excluded from reporting?
-- Are boundary errors converted to safe reportable errors before reporting?
-- Are internal programmer errors preserved when their original message/stack is safe and useful?
-- Are `reportHandledError` options limited to stable safe metadata?
-- Are tests covering cancellation, expected invalid input, and reportable unexpected failure when the flow is user-facing or security-sensitive?
+- Are internal programmer errors kept raw when their message and stack are safe?
+- Is `captureDiagnosticException` context limited to stable safe metadata (`feature`, `action`, `operation`)?
+- Are tests covering raw cause preservation and the sanitizer scrubbing sensitive values from Sentry events?
 
 ## Final reporting
 
 When this skill applies, include a short note in the final summary:
 
 - which expected errors are not reported;
-- how boundary errors are made reportable safely;
+- how boundary errors are wrapped (message, code, raw cause);
 - which internal errors remain raw and why their messages are safe;
-- how unexpected errors are made reportable safely;
 - which focused tests or checks cover the flow.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ reason:
 - Pages may compose panes and own route navigation state, but must not orchestrate provider/service recovery flows, permission or auth prompts, pending request registries, or duplicate entity data reads. Put provider recovery state and user actions in entities/features/widgets.
 - Errors must be defined next to the boundary that owns and detects the failure. Provider failures belong next to the provider; service failures belong next to the service. Do not define a provider error in a service module only because the service supplies surrounding context.
 - UI-facing display records must not expose capabilities, credentials, clients, adapters, provider instances, callbacks, or service bags. Expose these only through explicit action or recovery APIs.
-- Any `DomainError` crossing a worker or service boundary must use the project service-transfer-safe constructor or transformer pattern and contain only safe serializable metadata. Do not place capabilities, clients, callbacks, provider objects, or raw external errors in `message`, `cause`, `toJSON`, diagnostics, or user-facing payloads.
+- Any `DomainError` crossing a worker or service boundary must use the project service-transfer-safe constructor or transformer pattern. Raw `cause` may be preserved in trusted in-app proxy transfer. Do not place capabilities, clients, callbacks, or provider objects in `message`, `cause`, `toJSON`, or user-facing payloads.
 - Keep files small enough for agents to reason about locally. Prefer 100-300 lines for new production implementation files, treat 300-500 lines as acceptable only when the file is cohesive, and avoid growing ordinary implementation files beyond 500 lines without a clear reason.
 - Treat 500+ line implementation files as an extraction review trigger, not an automatic rewrite trigger. Before adding logic to such a file, identify its current responsibilities and extract the smallest stable unit that matches the change.
 - Avoid keeping 700+ line implementation files unless they are linear, generated-like, schema-heavy, registry-like, or mostly repetitive config/test data.
@@ -179,14 +179,21 @@ reason:
 
 ## Privacy-safe errors
 
-- Any error that can reach `reportHandledError` must be privacy-safe by construction.
-- Raw `Error` may be preserved in reportable flows only when its message is project-controlled and does not include user-controlled values.
-- Errors from browser APIs, storage, network, Google API, File API, Automerge/repo internals, Zod, or any external library are untrusted by default and must be wrapped with a safe project-controlled cause message before they can reach handled diagnostics.
-- Do not include local paths, virtual paths, file names, folder names, document names, document ids, file ids, Google Drive file ids, record values, document contents, or raw external error text in `Error.message`, `DomainError.message`, or `DomainError.cause.message` when the error may be reported.
-- Do not add path/name/id-bearing messages to reportable error flows. Avoid messages like `Failed for <path>` or `Could not remove <name>`.
-- Do not pass raw browser, filesystem, File API, File System API, Google API, IndexedDB, VFS, Automerge, Zod, or other low-level external errors as `cause` when the error may be reported. Wrap them in a project-controlled safe technical cause message instead.
-- Do not pass path, name, id, URL parameters, or other user-controlled values to `reportHandledError` options, Sentry `extra`, or Sentry `tags`.
-- Prefer stable domain error codes, safe user-facing messages, safe technical cause messages, and `feature` or `action` metadata.
+Two concerns are distinct and must not be conflated:
+
+1. **Trusted in-app runtime and proxy transfer**: `DomainError.cause` may hold raw runtime errors inside the app and across trusted proxy boundaries. This preserves debuggability and does not require sanitization.
+2. **External diagnostics export**: Sensitive values must not leave the app via Sentry, logs, or copied diagnostic payloads. The `beforeSend` sanitizer enforces this at the outgoing event boundary by scrubbing exception messages, tags, extras, contexts, and breadcrumbs.
+
+Rules:
+
+- `DomainError.message` is a safe user-facing message. Do not put paths, names, ids, URLs, or raw external text in it.
+- `DomainError.code` is a stable string enum value defined close to the error's source. Do not create a global error-code registry.
+- `DomainError.cause` may hold the original runtime cause. Raw `cause` is allowed inside the app and in trusted proxy transfer.
+- Sentry `beforeSend` sanitizes outgoing events: exception messages, linked cause messages, tags, extras, contexts, breadcrumbs, and user fields.
+- Do not create feature-local error classifiers or manual VFS-to-feature error mappings. Use enum codes and raw cause instead.
+- Do not pass path, name, id, URL, or other user-controlled values to `captureDiagnosticException` context, Sentry `extra`, or Sentry `tags`.
+- Do not replace real Sentry exceptions with synthetic masked errors. Pass the original error object so native stack and grouping work correctly.
+- Do not send raw paths, names, ids, URLs with secrets, provider payloads, document content, or raw external messages to Sentry.
 
 ## Anti-patterns
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -258,9 +258,30 @@ Adding a new diagnostic step should not require editing global interfaces.
 
 ---
 
+## Error construction
+
+Wrap boundary failures using `DomainError` with a safe message, a stable enum code, and the raw runtime cause:
+
+```ts
+throw new DomainError('Could not save changes.', {
+  code: RepositoryErrorCode.SaveFailed,
+  cause: error,
+});
+```
+
+- `DomainError.message` — user-safe short string; no paths, names, ids, URLs, or raw external text.
+- `DomainError.code` — stable string enum value defined close to the error's source; no global registry.
+- `DomainError.cause` — raw runtime cause preserved for in-app debugging; `beforeSend` scrubs it from Sentry export.
+
+Do not create feature-local classifiers or manual VFS-to-feature error mappings. Use enum codes and raw cause.
+
+Raw `cause` is allowed inside the app and in trusted in-app proxy transfer. It must not reach Sentry, logs, or external reports without going through the sanitizer.
+
+---
+
 ## Privacy boundary
 
-Forbidden everywhere in diagnostics, breadcrumbs, logs, tags, contexts, extras, and test sinks:
+Forbidden in Sentry outgoing events, breadcrumbs, logs, tags, contexts, extras, and test sinks:
 
 - absolute or relative paths;
 - file names;
@@ -268,19 +289,21 @@ Forbidden everywhere in diagnostics, breadcrumbs, logs, tags, contexts, extras, 
 - document ids;
 - Automerge storage keys;
 - URLs;
-- raw external/browser error messages;
-- raw causes;
+- raw external/browser error messages in exception values, linked causes, or breadcrumb data;
 - file contents or bytes;
 - handles, provider objects, callbacks, capabilities, credentials, clients;
 - user-entered text;
 - long-term user/device/account identifiers.
 
-Allowed values:
+`DomainError.cause` may hold raw runtime errors inside the app. The `beforeSend` sanitizer removes sensitive content from outgoing Sentry events.
+
+Allowed values in Sentry events:
 
 - project-controlled short strings;
 - booleans;
 - small integers;
-- generated attempt IDs.
+- generated attempt IDs;
+- stable error codes and exception types.
 
 Session identity is memory-only and session-scoped. `beforeSend` must keep only a valid `session:<uuid>` user id and strip all other user fields.
 
@@ -301,6 +324,7 @@ The shared runtime uses `beforeBreadcrumb` and `beforeSend` as the final client-
 `beforeSend` must:
 
 - strip `request` entirely;
+- sanitize exception value messages for all entries in the exception chain (including linked `cause` exceptions);
 - sanitize breadcrumbs again;
 - sanitize contexts, tags, extras, and user fields using denylist-based filtering (no fixed allowlists);
 - drop contexts and extras whose keys or values fail the denylist check;
@@ -358,7 +382,10 @@ Do not introduce:
 - breadcrumbs or logs that track user behavior;
 - event fields that duplicate a breadcrumb history;
 - allowlists that must be expanded for every new operation, provider, or breadcrumb category;
-- rewritten/classified error summaries passed to `captureDiagnosticException` — pass the real error.
+- rewritten/classified error summaries passed to `captureDiagnosticException` — pass the real error;
+- feature-local error classifiers or manual VFS-to-feature error mappings — use enum codes and raw cause;
+- `createSafeErrorCause` in feature code to paper over raw causes — keep raw cause and rely on `beforeSend` sanitization;
+- a global error-code registry — define each string enum close to its source boundary.
 
 ---
 

--- a/scripts/lib/localCommandGuard.test.mjs
+++ b/scripts/lib/localCommandGuard.test.mjs
@@ -209,7 +209,7 @@ describe('runGuardedExpensiveLocalCommand', () => {
       env: {
         ...process.env,
         MIOFRAME_EXPENSIVE_COMMAND_LOCK_HELD: '1',
-        MIOFRAME_VERIFY_LOCK_HELD: '1',
+        MIOFRAME_MACHINE_LOCK_HELD: '1',
       },
     });
   });

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -70,17 +70,23 @@ This section refines the root `Privacy-safe errors` rules for source code under 
 
 The goal is not to hide all unexpected errors from diagnostics. Sentry must still receive actionable internal failures so real bugs can be fixed.
 
-Distinguish error sources before reporting:
+**Two concerns are distinct:**
 
-- External or user-data boundary errors must be privacy-safe before they reach `captureDiagnosticException`. This includes browser APIs, File API, File System Access API, IndexedDB, Google APIs, storage adapters, Automerge/repo internals, Zod parsing of user-controlled payloads, network responses, and any library error that may include paths, names, ids, file contents, document contents, URLs, or raw user data.
-- Internal programmer errors and project-controlled invariant failures may be reported as raw `Error` objects when their messages are stable and do not include user-controlled values. Do not wrap these only to satisfy privacy wording, because losing the original message/stack makes Sentry less useful.
-- Expected user outcomes such as cancelled file picking, invalid user input, unsupported file format, permission denial handled by a recovery UI, or validation errors that are already part of normal UX should usually be handled without diagnostics reporting unless there is a product reason to track them.
+1. **Trusted in-app runtime and proxy transfer**: `DomainError.cause` may hold raw runtime errors inside the app and across trusted proxy boundaries. This does not require sanitization.
+2. **External diagnostics export**: The `beforeSend` sanitizer enforces privacy at the outgoing Sentry event boundary. It scrubs exception value messages, linked cause messages, tags, extras, contexts, breadcrumbs, and user fields using denylist-based filtering.
 
-When wrapping boundary errors:
+**Error construction rules for `src` code:**
 
-- Use a project-controlled user-facing `DomainError.message`.
-- Use `createSafeErrorCause` or another project-controlled safe technical cause before diagnostics can see the cause.
-- Keep machine-readable codes stable and free of user data.
-- Do not attach local paths, virtual paths, file names, folder names, document names, document ids, file ids, Google Drive ids, URLs, record values, document contents, or raw external error text to `captureDiagnosticException` context, Sentry tags, Sentry extra, error messages, or causes.
+- Wrap boundary failures in a `DomainError` with a project-controlled user-facing `message`, a stable `code` enum value, and the raw runtime error as `cause`.
+- Do not create feature-local classifiers or manual VFS-to-feature error mappings. Use enum codes and raw cause instead.
+- Keep `DomainError.message` free of paths, names, ids, URLs, and raw external text.
+- `DomainError.cause` may hold the original raw error — the Sentry sanitizer handles scrubbing at the outgoing event boundary.
+- Internal programmer errors and project-controlled invariant failures may be reported as raw `Error` objects when their messages are stable and do not include user-controlled values.
+- Expected user outcomes (cancelled picker, invalid input, permission denied with recovery UI) should not be reported unless there is a specific product reason.
 
-Sentry `beforeSend` provides a final client-side denylist-based privacy boundary, but it does not make arbitrary exception messages and stacks privacy-safe. Treat the boundary where the error is created or converted as the place to decide whether the original error is safe to report.
+**Error code rules:**
+
+- Define each string enum close to the boundary where the error originates (e.g., `RepositoryErrorCode` in the repository layer, `ExampleDocumentsCreateErrorCode` in that feature).
+- Do not create a global error-code registry.
+
+Do not attach local paths, virtual paths, file names, document names, document ids, file ids, Google Drive ids, URLs, record values, document contents, or raw external error text to `captureDiagnosticException` context, Sentry tags, or Sentry extra.

--- a/src/features/entryRemove/useRemoveFSEntry.test.ts
+++ b/src/features/entryRemove/useRemoveFSEntry.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useRemoveFSEntry } from './useRemoveFSEntry';
-import { createSafeErrorCause, DomainError } from '@shared/lib/error';
+import { DomainError } from '@shared/lib/error';
 import { FileSystemError, VfsError } from '@shared/lib/virtualFileSystem';
 
 const { addSnackbarMock, confirmMock, removeEntryMock, captureDiagnosticExceptionMock } =
@@ -41,52 +41,6 @@ describe('useRemoveFSEntry', () => {
     captureDiagnosticExceptionMock.mockReset();
   });
 
-  const expectSafeReportedDomainError = ({
-    action,
-    code,
-    message,
-    causeMessage,
-  }: {
-    action: 'removeEntry' | 'removeEntryRecursive';
-    code: 'remove-failed' | 'recursive-remove-failed';
-    message: string;
-    causeMessage: string;
-  }) => {
-    expect(captureDiagnosticExceptionMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message,
-        code,
-        cause: expect.objectContaining({
-          message: causeMessage,
-        }),
-      }),
-      {
-        feature: 'entryRemove',
-        action,
-      },
-    );
-
-    const [reportedError] = captureDiagnosticExceptionMock.mock.calls.at(-1) ?? [];
-    expect(reportedError).toBeInstanceOf(DomainError);
-    expect(reportedError).not.toBeInstanceOf(VfsError);
-    if (!(reportedError instanceof DomainError)) {
-      throw new Error('Expected a DomainError to be reported');
-    }
-    expect(reportedError.message).not.toContain('/docs/file.json');
-    expect(reportedError.message).not.toContain('/docs/folder/private');
-    expect(reportedError.message).not.toContain('file.json');
-    expect(reportedError.message).not.toContain('gd-123');
-    expect(reportedError.cause).toBeInstanceOf(Error);
-    if (!(reportedError.cause instanceof Error)) {
-      throw new Error('Expected a safe Error cause to be reported');
-    }
-    expect(reportedError.cause.message).toBe(causeMessage);
-    expect(reportedError.cause.message).not.toContain('/docs');
-    expect(reportedError.cause.message).not.toContain('file.json');
-    expect(reportedError.cause.message).not.toContain('gd-');
-    expect(reportedError.cause.message).not.toContain('provider');
-  };
-
   it('uses basename-only confirmation copy for removal', async () => {
     confirmMock.mockResolvedValueOnce(false);
 
@@ -115,15 +69,19 @@ describe('useRemoveFSEntry', () => {
     expect(addSnackbarMock).toHaveBeenCalledWith({
       text: 'Could not remove the item',
     });
-    expectSafeReportedDomainError({
-      action: 'removeEntry',
-      code: 'remove-failed',
+    const [reportedError, options] = captureDiagnosticExceptionMock.mock.calls.at(-1) ?? [];
+    expect(options).toEqual({ feature: 'entryRemove', action: 'removeEntry' });
+    expect(reportedError).toBeInstanceOf(DomainError);
+    expect(reportedError).toMatchObject({
       message: 'Could not remove the item',
-      causeMessage: 'File system remove operation failed',
+      code: 'entryRemove.removeFailed',
     });
+    expect(reportedError.cause).toBe(error);
+    expect(reportedError.message).not.toContain('/docs');
+    expect(reportedError.message).not.toContain('gd-123');
   });
 
-  it('wraps VfsError removal failures into a safe reportable DomainError', async () => {
+  it('preserves VfsError as raw cause for non-recursive remove failures', async () => {
     const error = new VfsError(
       FileSystemError.NoPermissions,
       'File system delete operation is not allowed for /docs/file.json in provider gd-123',
@@ -138,19 +96,20 @@ describe('useRemoveFSEntry', () => {
     expect(addSnackbarMock).toHaveBeenCalledWith({
       text: 'Could not remove the item',
     });
-    expectSafeReportedDomainError({
-      action: 'removeEntry',
-      code: 'remove-failed',
+    const [reportedError] = captureDiagnosticExceptionMock.mock.calls.at(-1) ?? [];
+    expect(reportedError).toBeInstanceOf(DomainError);
+    expect(reportedError).toMatchObject({
       message: 'Could not remove the item',
-      causeMessage: 'File system remove operation failed',
+      code: 'entryRemove.removeFailed',
     });
+    expect(reportedError.cause).toBe(error);
+    expect(reportedError.message).not.toContain('/docs');
+    expect(reportedError.message).not.toContain('gd-123');
   });
 
   it('shows a snackbar, reports, and does not rethrow when recursive remove fails', async () => {
     const directoryNotEmptyError = new VfsError(FileSystemError.DirectoryNotEmpty);
-    const recursiveError = new DomainError('Could not remove the directory', {
-      cause: createSafeErrorCause('Unexpected storage backend detail for /docs/folder/private'),
-    });
+    const recursiveError = new Error('Failed to remove /docs/folder/private recursively');
     confirmMock.mockResolvedValueOnce(true).mockResolvedValueOnce(true);
     removeEntryMock
       .mockRejectedValueOnce(directoryNotEmptyError)
@@ -168,15 +127,18 @@ describe('useRemoveFSEntry', () => {
     expect(addSnackbarMock).toHaveBeenNthCalledWith(2, {
       text: 'Could not remove the directory',
     });
-    expectSafeReportedDomainError({
-      action: 'removeEntryRecursive',
-      code: 'recursive-remove-failed',
+    const [reportedError, options] = captureDiagnosticExceptionMock.mock.calls.at(-1) ?? [];
+    expect(options).toEqual({ feature: 'entryRemove', action: 'removeEntryRecursive' });
+    expect(reportedError).toBeInstanceOf(DomainError);
+    expect(reportedError).toMatchObject({
       message: 'Could not remove the directory',
-      causeMessage: 'File system recursive remove operation failed',
+      code: 'entryRemove.recursiveRemoveFailed',
     });
+    expect(reportedError.cause).toBe(recursiveError);
+    expect(reportedError.message).not.toContain('/docs');
   });
 
-  it('wraps untrusted recursive removal errors before reporting', async () => {
+  it('preserves upstream error as raw cause for recursive removal failures', async () => {
     const directoryNotEmptyError = new VfsError(FileSystemError.DirectoryNotEmpty);
     const recursiveError = new Error('Failed to remove /docs/folder/private for gd-456');
     confirmMock.mockResolvedValueOnce(true).mockResolvedValueOnce(true);
@@ -188,17 +150,19 @@ describe('useRemoveFSEntry', () => {
 
     await expect(remove('/docs/folder')).resolves.toBeUndefined();
 
-    expectSafeReportedDomainError({
-      action: 'removeEntryRecursive',
-      code: 'recursive-remove-failed',
+    const [reportedError] = captureDiagnosticExceptionMock.mock.calls.at(-1) ?? [];
+    expect(reportedError).toBeInstanceOf(DomainError);
+    expect(reportedError).toMatchObject({
       message: 'Could not remove the directory',
-      causeMessage: 'File system recursive remove operation failed',
+      code: 'entryRemove.recursiveRemoveFailed',
     });
+    expect(reportedError.cause).toBe(recursiveError);
+    expect(reportedError.message).not.toContain('/docs');
+    expect(reportedError.message).not.toContain('gd-456');
   });
 
-  it('does not forward arbitrary DomainError message or cause text into remove diagnostics', async () => {
+  it('preserves upstream DomainError as raw cause for non-recursive remove failures', async () => {
     const error = new DomainError('Could not remove /docs/file.json for gd-123', {
-      cause: createSafeErrorCause('Provider error for storage key gd-123 at /docs/file.json'),
       code: 'upstream-remove-failed',
     });
     confirmMock.mockResolvedValueOnce(true);
@@ -211,12 +175,15 @@ describe('useRemoveFSEntry', () => {
     expect(addSnackbarMock).toHaveBeenCalledWith({
       text: 'Could not remove the item',
     });
-    expectSafeReportedDomainError({
-      action: 'removeEntry',
-      code: 'remove-failed',
+    const [reportedError] = captureDiagnosticExceptionMock.mock.calls.at(-1) ?? [];
+    expect(reportedError).toBeInstanceOf(DomainError);
+    expect(reportedError).toMatchObject({
       message: 'Could not remove the item',
-      causeMessage: 'File system remove operation failed',
+      code: 'entryRemove.removeFailed',
     });
+    expect(reportedError.cause).toBe(error);
+    expect(reportedError.message).not.toContain('/docs');
+    expect(reportedError.message).not.toContain('gd-123');
   });
 
   it('does not remove or report when the user cancels confirmation', async () => {

--- a/src/features/entryRemove/useRemoveFSEntry.ts
+++ b/src/features/entryRemove/useRemoveFSEntry.ts
@@ -1,20 +1,14 @@
 import { useFileSystem } from '@entity/mountedDirectories';
-import { createSafeErrorCause, DomainError } from '@shared/lib/error';
+import { DomainError } from '@shared/lib/error';
 import { captureDiagnosticException } from '@shared/lib/diagnostics';
 import { PathUtils, VfsError, FileSystemError } from '@shared/lib/virtualFileSystem';
 import { useDialog } from '@shared/ui/Dialog';
 import { useSnackbar } from '@shared/ui/Snackbar';
 
 enum EntryRemoveErrorCode {
-  removeFailed = 'remove-failed',
-  recursiveRemoveFailed = 'recursive-remove-failed',
+  removeFailed = 'entryRemove.removeFailed',
+  recursiveRemoveFailed = 'entryRemove.recursiveRemoveFailed',
 }
-
-const toReportedRemoveError = (message: string, causeMessage: string, code: EntryRemoveErrorCode) =>
-  new DomainError(message, {
-    cause: createSafeErrorCause(causeMessage),
-    code,
-  });
 
 /**
  * Creates a user-triggered remove action for file-system entries.
@@ -63,12 +57,11 @@ export const useRemoveFSEntry = () => {
             });
             try {
               await removeEntry(path, true);
-            } catch {
-              const reportedError = toReportedRemoveError(
-                'Could not remove the directory',
-                'File system recursive remove operation failed',
-                EntryRemoveErrorCode.recursiveRemoveFailed,
-              );
+            } catch (recursiveError) {
+              const reportedError = new DomainError('Could not remove the directory', {
+                cause: recursiveError,
+                code: EntryRemoveErrorCode.recursiveRemoveFailed,
+              });
 
               addSnackbar({
                 text: 'Could not remove the directory',
@@ -80,11 +73,10 @@ export const useRemoveFSEntry = () => {
             }
           }
         } else {
-          const reportedError = toReportedRemoveError(
-            'Could not remove the item',
-            'File system remove operation failed',
-            EntryRemoveErrorCode.removeFailed,
-          );
+          const reportedError = new DomainError('Could not remove the item', {
+            cause: error,
+            code: EntryRemoveErrorCode.removeFailed,
+          });
 
           addSnackbar({
             text: 'Could not remove the item',

--- a/src/features/exampleDocumentsCreate/useExampleDocumentsCreate.test.ts
+++ b/src/features/exampleDocumentsCreate/useExampleDocumentsCreate.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { FileSystemError, VfsError } from '@shared/lib/virtualFileSystem';
 import { DomainError } from '@shared/lib/error';
-import { useExampleDocumentsCreate } from './useExampleDocumentsCreate';
+import {
+  ExampleDocumentsCreateErrorCode,
+  useExampleDocumentsCreate,
+} from './useExampleDocumentsCreate';
 
 const {
   createDirectoryMock,
@@ -151,7 +154,8 @@ describe('useExampleDocumentsCreate', () => {
   });
 
   it('reports a safe handled diagnostic and sets a safe error message on final failure', async () => {
-    createDirectoryMock.mockRejectedValueOnce(new Error('No permission to create directory'));
+    const originalError = new Error('No permission to create directory');
+    createDirectoryMock.mockRejectedValueOnce(originalError);
 
     const { createWeeklyPlanExample, weeklyPlanErrorMessage } = useExampleDocumentsCreate();
 
@@ -170,15 +174,14 @@ describe('useExampleDocumentsCreate', () => {
       action: 'createWeeklyPlanExample',
     });
     if (!(reportedError instanceof DomainError)) return;
-    expect(reportedError.cause).toBeInstanceOf(Error);
-    if (!(reportedError.cause instanceof Error)) return;
-    expect(reportedError.cause.message).toBe('example-create-unexpected');
+    expect(reportedError.message).toBe('Could not create example');
+    expect(reportedError.code).toBe(ExampleDocumentsCreateErrorCode.CreateFailed);
+    expect(reportedError.cause).toBe(originalError);
   });
 
-  it('does not include raw paths, directory names, or raw error messages in the reported diagnostic', async () => {
-    createDirectoryMock.mockRejectedValueOnce(
-      new Error('ENOENT: no such file or directory, mkdir /private/Examples'),
-    );
+  it('wraps the raw cause in a DomainError with safe message and enum code — raw cause preserved for runtime debugging', async () => {
+    const rawError = new Error('ENOENT: no such file or directory, mkdir /private/Examples');
+    createDirectoryMock.mockRejectedValueOnce(rawError);
 
     const { createWeeklyPlanExample } = useExampleDocumentsCreate();
 
@@ -188,20 +191,16 @@ describe('useExampleDocumentsCreate', () => {
     expect(reportedError).toBeInstanceOf(DomainError);
     if (!(reportedError instanceof DomainError)) return;
 
+    expect(reportedError.message).toBe('Could not create example');
     expect(reportedError.message).not.toContain('/');
     expect(reportedError.message).not.toContain('Examples');
     expect(reportedError.message).not.toContain('ENOENT');
-    expect(reportedError.message).not.toContain('mkdir');
+    expect(reportedError.code).toBe(ExampleDocumentsCreateErrorCode.CreateFailed);
 
-    expect(reportedError.cause).toBeInstanceOf(Error);
-    if (!(reportedError.cause instanceof Error)) return;
-    expect(reportedError.cause.message).toBe('example-create-unexpected');
-    expect(reportedError.cause.message).not.toContain('/');
-    expect(reportedError.cause.message).not.toContain('Examples');
-    expect(reportedError.cause.message).not.toContain('ENOENT');
+    expect(reportedError.cause).toBe(rawError);
   });
 
-  it('does not pass an arbitrary lower-layer DomainError as-is to diagnostics', async () => {
+  it('wraps a lower-layer DomainError as the raw cause, not by re-using it as the reported error', async () => {
     const lowerLayerDomainError = new DomainError('Internal storage failure', {
       code: 'storage-internal',
     });
@@ -216,15 +215,16 @@ describe('useExampleDocumentsCreate', () => {
     expect(reportedError).toBeInstanceOf(DomainError);
     if (!(reportedError instanceof DomainError)) return;
     expect(reportedError.message).toBe('Could not create example');
-    expect(reportedError.cause).toBeInstanceOf(Error);
-    if (!(reportedError.cause instanceof Error)) return;
-    expect(reportedError.cause.message).toBe('example-create-unexpected');
+    expect(reportedError.code).toBe(ExampleDocumentsCreateErrorCode.CreateFailed);
+    expect(reportedError.cause).toBe(lowerLayerDomainError);
   });
 
   it('does not retry directory creation for VfsError codes other than FileExists', async () => {
-    createDirectoryMock.mockRejectedValueOnce(
-      new VfsError(FileSystemError.NoPermissions, 'No permission to create directory'),
+    const vfsError = new VfsError(
+      FileSystemError.NoPermissions,
+      'No permission to create directory',
     );
+    createDirectoryMock.mockRejectedValueOnce(vfsError);
 
     const { createWeeklyPlanExample, weeklyPlanErrorMessage } = useExampleDocumentsCreate();
 
@@ -238,16 +238,17 @@ describe('useExampleDocumentsCreate', () => {
     const [weeklyReportedError] = captureDiagnosticExceptionMock.mock.calls[0] ?? [];
     expect(weeklyReportedError).toBeInstanceOf(DomainError);
     if (!(weeklyReportedError instanceof DomainError)) return;
-    expect(weeklyReportedError.cause).toBeInstanceOf(Error);
-    if (!(weeklyReportedError.cause instanceof Error)) return;
-    expect(weeklyReportedError.cause.message).toBe('example-create-vfs-EACCES');
+    expect(weeklyReportedError.code).toBe(ExampleDocumentsCreateErrorCode.CreateFailed);
+    expect(weeklyReportedError.cause).toBe(vfsError);
+    expect(vfsError.code).toBe(FileSystemError.NoPermissions);
   });
 
-  it('creates a shopping example and reports safe diagnostics when creation fails', async () => {
+  it('creates a shopping example and reports raw cause wrapped in DomainError when creation fails', async () => {
+    const writeError = new Error('Cannot write document');
     createDocumentMock
       .mockReset()
       .mockResolvedValueOnce('purchase-types-doc-id')
-      .mockRejectedValueOnce(new Error('Cannot write document'));
+      .mockRejectedValueOnce(writeError);
 
     const { createShoppingExample, shoppingErrorMessage, isCreatingShoppingExample } =
       useExampleDocumentsCreate();
@@ -267,15 +268,17 @@ describe('useExampleDocumentsCreate', () => {
     });
     expect(shoppingReportedError).toBeInstanceOf(DomainError);
     if (!(shoppingReportedError instanceof DomainError)) return;
-    expect(shoppingReportedError.cause).toBeInstanceOf(Error);
-    if (!(shoppingReportedError.cause instanceof Error)) return;
-    expect(shoppingReportedError.cause.message).toBe('example-create-unexpected');
+    expect(shoppingReportedError.message).toBe('Could not create example');
+    expect(shoppingReportedError.code).toBe(ExampleDocumentsCreateErrorCode.CreateFailed);
+    expect(shoppingReportedError.cause).toBe(writeError);
   });
 
-  it('classifies a VfsError from shopping example directory creation as a safe vfs cause', async () => {
-    createDirectoryMock.mockRejectedValueOnce(
-      new VfsError(FileSystemError.NoPermissions, 'No permission to create directory'),
+  it('preserves a VfsError from shopping example directory creation as the raw cause', async () => {
+    const vfsError = new VfsError(
+      FileSystemError.NoPermissions,
+      'No permission to create directory',
     );
+    createDirectoryMock.mockRejectedValueOnce(vfsError);
 
     const { createShoppingExample, shoppingErrorMessage } = useExampleDocumentsCreate();
 
@@ -287,12 +290,12 @@ describe('useExampleDocumentsCreate', () => {
     const [reportedError] = captureDiagnosticExceptionMock.mock.calls[0] ?? [];
     expect(reportedError).toBeInstanceOf(DomainError);
     if (!(reportedError instanceof DomainError)) return;
-    expect(reportedError.cause).toBeInstanceOf(Error);
-    if (!(reportedError.cause instanceof Error)) return;
-    expect(reportedError.cause.message).toBe('example-create-vfs-EACCES');
+    expect(reportedError.code).toBe(ExampleDocumentsCreateErrorCode.CreateFailed);
+    expect(reportedError.cause).toBe(vfsError);
+    expect(vfsError.code).toBe(FileSystemError.NoPermissions);
   });
 
-  it('stops directory creation after the safety limit and reports a privacy-safe diagnostic', async () => {
+  it('stops directory creation after the safety limit and reports using DirectoryLimitExceeded cause', async () => {
     createDirectoryMock.mockRejectedValue(
       new VfsError(FileSystemError.FileExists, 'Directory already exists'),
     );
@@ -310,15 +313,14 @@ describe('useExampleDocumentsCreate', () => {
     expect(reportedError).toBeInstanceOf(DomainError);
     if (!(reportedError instanceof DomainError)) return;
 
+    expect(reportedError.message).toBe('Could not create example');
     expect(reportedError.message).not.toContain('/');
     expect(reportedError.message).not.toContain('Examples');
+    expect(reportedError.code).toBe(ExampleDocumentsCreateErrorCode.CreateFailed);
 
-    expect(reportedError.cause).toBeInstanceOf(Error);
-    if (!(reportedError.cause instanceof Error)) return;
-    expect(reportedError.cause.message).toBe('example-create-directory-limit-exceeded');
-    expect(reportedError.cause.message).not.toContain('/');
-    expect(reportedError.cause.message).not.toContain('Examples');
-    expect(reportedError.cause.message).not.toContain('already exists');
+    expect(reportedError.cause).toBeInstanceOf(DomainError);
+    if (!(reportedError.cause instanceof DomainError)) return;
+    expect(reportedError.cause.code).toBe(ExampleDocumentsCreateErrorCode.DirectoryLimitExceeded);
   });
 
   it('exposes weekly loading while creation is in flight and clears it after completion', async () => {

--- a/src/features/exampleDocumentsCreate/useExampleDocumentsCreate.ts
+++ b/src/features/exampleDocumentsCreate/useExampleDocumentsCreate.ts
@@ -11,31 +11,26 @@ import {
   statusesStarterExample,
 } from '@entity/starterExample';
 import { captureDiagnosticException } from '@shared/lib/diagnostics';
-import { createSafeErrorCause, DomainError } from '@shared/lib/error';
+import { DomainError } from '@shared/lib/error';
 import { createStarterExampleDocument } from './createStarterExampleDocument';
 
 const EXAMPLES_DIRECTORY_NAME = 'Examples';
 const EXAMPLE_CREATE_ERROR_MESSAGE = 'Could not create example';
 const MAX_EXAMPLE_DIRECTORY_ATTEMPTS = 100;
 
+/** Stable error codes for example document creation failures. */
+export enum ExampleDocumentsCreateErrorCode {
+  CreateFailed = 'exampleDocumentsCreate.createFailed',
+  DirectoryLimitExceeded = 'exampleDocumentsCreate.directoryLimitExceeded',
+}
+
 type ExampleResult = {
   documentDirectory: string;
   documentId: AMDocumentId;
 };
 
-const DIRECTORY_LIMIT_ERROR_CODE = 'example-create-directory-limit-exceeded';
-
 const isAlreadyExistingDirectoryError = (error: unknown) =>
   error instanceof VfsError && error.code === FileSystemError.FileExists;
-
-const isDirectoryLimitError = (error: unknown) =>
-  error instanceof DomainError && error.code === DIRECTORY_LIMIT_ERROR_CODE;
-
-const buildExampleCreateCause = (error: unknown): string => {
-  if (isDirectoryLimitError(error)) return DIRECTORY_LIMIT_ERROR_CODE;
-  if (error instanceof VfsError) return `example-create-vfs-${error.code}`;
-  return 'example-create-unexpected';
-};
 
 /**
  * Composable for creating starter example documents in the first available indexed OPFS directory.
@@ -72,8 +67,7 @@ export const useExampleDocumentsCreate = () => {
     for (;;) {
       if (index > MAX_EXAMPLE_DIRECTORY_ATTEMPTS) {
         throw new DomainError(EXAMPLE_CREATE_ERROR_MESSAGE, {
-          cause: createSafeErrorCause(DIRECTORY_LIMIT_ERROR_CODE),
-          code: DIRECTORY_LIMIT_ERROR_CODE,
+          code: ExampleDocumentsCreateErrorCode.DirectoryLimitExceeded,
         });
       }
 
@@ -103,12 +97,6 @@ export const useExampleDocumentsCreate = () => {
     }
   };
 
-  const makeExampleCreateError = (error: unknown): DomainError =>
-    new DomainError(EXAMPLE_CREATE_ERROR_MESSAGE, {
-      cause: createSafeErrorCause(buildExampleCreateCause(error)),
-      code: 'example-create-failed',
-    });
-
   const createWeeklyPlanExample = async (): Promise<ExampleResult | undefined> => {
     weeklyPlanErrorMessage.value = undefined;
     activeExample.value = 'weekly';
@@ -134,10 +122,13 @@ export const useExampleDocumentsCreate = () => {
       };
     } catch (error) {
       weeklyPlanErrorMessage.value = EXAMPLE_CREATE_ERROR_MESSAGE;
-      captureDiagnosticException(makeExampleCreateError(error), {
-        feature: 'exampleDocumentsCreate',
-        action: 'createWeeklyPlanExample',
-      });
+      captureDiagnosticException(
+        new DomainError(EXAMPLE_CREATE_ERROR_MESSAGE, {
+          code: ExampleDocumentsCreateErrorCode.CreateFailed,
+          cause: error,
+        }),
+        { feature: 'exampleDocumentsCreate', action: 'createWeeklyPlanExample' },
+      );
       return undefined;
     } finally {
       activeExample.value = undefined;
@@ -169,10 +160,13 @@ export const useExampleDocumentsCreate = () => {
       };
     } catch (error) {
       shoppingErrorMessage.value = EXAMPLE_CREATE_ERROR_MESSAGE;
-      captureDiagnosticException(makeExampleCreateError(error), {
-        feature: 'exampleDocumentsCreate',
-        action: 'createShoppingExample',
-      });
+      captureDiagnosticException(
+        new DomainError(EXAMPLE_CREATE_ERROR_MESSAGE, {
+          code: ExampleDocumentsCreateErrorCode.CreateFailed,
+          cause: error,
+        }),
+        { feature: 'exampleDocumentsCreate', action: 'createShoppingExample' },
+      );
       return undefined;
     } finally {
       activeExample.value = undefined;

--- a/src/features/exportDocument/exportDocumentErrorCode.ts
+++ b/src/features/exportDocument/exportDocumentErrorCode.ts
@@ -1,5 +1,5 @@
 /**
- * Stable error codes for Beaver document export failures.
+ * Stable error codes for Mioframe document export failures.
  */
 export enum ExportDocumentErrorCode {
   documentExportUnavailable = 'exportDocument.documentExportUnavailable',

--- a/src/features/exportDocument/exportDocumentErrorCode.ts
+++ b/src/features/exportDocument/exportDocumentErrorCode.ts
@@ -2,6 +2,6 @@
  * Stable error codes for Beaver document export failures.
  */
 export enum ExportDocumentErrorCode {
-  documentExportUnavailable = 'document-export-unavailable',
-  documentExportFailed = 'document-export-failed',
+  documentExportUnavailable = 'exportDocument.documentExportUnavailable',
+  documentExportFailed = 'exportDocument.documentExportFailed',
 }

--- a/src/features/exportDocument/useExportDocument.test.ts
+++ b/src/features/exportDocument/useExportDocument.test.ts
@@ -52,7 +52,7 @@ describe('useExportDocument', () => {
     expect(fileSaveMock).not.toHaveBeenCalled();
   });
 
-  it('replaces raw document load failure details with a safe cause', async () => {
+  it('preserves raw document load failure as cause when fetch fails', async () => {
     const rawCause = new Error(
       'Could not load /Device files/Private/Tax 2025/document.json for document-id 4Z1fFANPScpDsLXmC1KsBCn4mWYu',
     );
@@ -67,12 +67,12 @@ describe('useExportDocument', () => {
     expect(error).toBeInstanceOf(DomainError);
     expect(error).toMatchObject({
       message: 'Could not export the document',
-      code: 'document-export-failed',
-      cause: expect.objectContaining({
-        message: 'Document repository read operation failed',
-      }),
+      code: 'exportDocument.documentExportFailed',
     });
-    expect(error).not.toHaveProperty('cause.message', rawCause.message);
+    if (!(error instanceof DomainError)) throw new Error('expected DomainError');
+    expect(error.cause).toBe(rawCause);
+    expect(error.message).not.toContain('/Device files');
+    expect(error.message).not.toContain('gd-');
     expect(fileSaveMock).not.toHaveBeenCalled();
   });
 
@@ -128,7 +128,7 @@ describe('useExportDocument', () => {
     );
   });
 
-  it('does not treat non-AbortError save failures as user cancellation', async () => {
+  it('preserves raw save failure as cause when file save fails with a non-cancel error', async () => {
     const rawCause = new DOMException(
       'Could not save /Device files/Private/Tax 2025/4Z1fFANPScpDsLXmC1KsBCn4mWYu.json',
       'NotAllowedError',
@@ -144,32 +144,11 @@ describe('useExportDocument', () => {
     expect(error).toBeInstanceOf(DomainError);
     expect(error).toMatchObject({
       message: 'Could not export the document',
-      code: 'document-export-failed',
-      cause: expect.objectContaining({
-        message: 'Selected file save operation failed',
-      }),
+      code: 'exportDocument.documentExportFailed',
     });
-    expect(error).not.toHaveProperty('cause.message', rawCause.message);
-  });
-
-  it('preserves a safe cause message for reporting when export loading fails', async () => {
-    fetchMock.mockRejectedValueOnce(
-      new Error('Could not load /Device files/Private/Tax 2025/document.json'),
-    );
-
-    const { saveJsonFile } = useExportDocument();
-
-    const error = await saveJsonFile('/documents', documentId).catch(
-      (caughtError: unknown) => caughtError,
-    );
-
-    expect(error).toBeInstanceOf(DomainError);
-    expect(error).toMatchObject({
-      message: 'Could not export the document',
-      cause: expect.objectContaining({
-        message: 'Document repository read operation failed',
-      }),
-    });
+    if (!(error instanceof DomainError)) throw new Error('expected DomainError');
+    expect(error.cause).toBe(rawCause);
+    expect(error.message).not.toContain('/Device files');
   });
 
   it('preserves an existing DomainError when saving fails', async () => {

--- a/src/features/exportDocument/useExportDocument.ts
+++ b/src/features/exportDocument/useExportDocument.ts
@@ -1,5 +1,5 @@
 import type { AMDocumentId } from '@shared/lib/automerge';
-import { createSafeErrorCause, DomainError } from '@shared/lib/error';
+import { DomainError } from '@shared/lib/error';
 import { isUserFileSelectionCancel } from '@shared/lib/fileSystem';
 import { useMainServiceClient } from '@shared/service';
 import { stringify } from 'safe-stable-stringify';
@@ -35,7 +35,7 @@ export const useExportDocument = () => {
       }
 
       throw new DomainError('Could not export the document', {
-        cause: createSafeErrorCause('Document repository read operation failed'),
+        cause: error,
         code: ExportDocumentErrorCode.documentExportFailed,
       });
     }
@@ -70,7 +70,7 @@ export const useExportDocument = () => {
       }
 
       throw new DomainError('Could not export the document', {
-        cause: createSafeErrorCause('Selected file save operation failed'),
+        cause: error,
         code: ExportDocumentErrorCode.documentExportFailed,
       });
     }

--- a/src/features/importDocument/importDocumentErrorCode.ts
+++ b/src/features/importDocument/importDocumentErrorCode.ts
@@ -2,9 +2,9 @@
  * Stable error codes for Beaver document import failures.
  */
 export enum ImportDocumentErrorCode {
-  fileOpenFailed = 'file-open-failed',
-  fileReadFailed = 'file-read-failed',
-  invalidJson = 'invalid-json',
-  invalidDocumentFormat = 'invalid-document-format',
-  documentImportFailed = 'document-import-failed',
+  fileOpenFailed = 'importDocument.fileOpenFailed',
+  fileReadFailed = 'importDocument.fileReadFailed',
+  invalidJson = 'importDocument.invalidJson',
+  invalidDocumentFormat = 'importDocument.invalidDocumentFormat',
+  documentImportFailed = 'importDocument.documentImportFailed',
 }

--- a/src/features/importDocument/importDocumentErrorCode.ts
+++ b/src/features/importDocument/importDocumentErrorCode.ts
@@ -1,5 +1,5 @@
 /**
- * Stable error codes for Beaver document import failures.
+ * Stable error codes for Mioframe document import failures.
  */
 export enum ImportDocumentErrorCode {
   fileOpenFailed = 'importDocument.fileOpenFailed',

--- a/src/features/importDocument/useImportDocument.test.ts
+++ b/src/features/importDocument/useImportDocument.test.ts
@@ -93,7 +93,7 @@ describe('useImportDocument', () => {
     expect(createDocumentMock).not.toHaveBeenCalled();
   });
 
-  it('replaces raw repository failure details with a safe cause when document creation fails', async () => {
+  it('preserves raw repository failure as cause when document creation fails', async () => {
     const rawCause = new Error(
       'Failed to write /Device files/Private/Tax 2025/document.json for file-id gd-123',
     );
@@ -110,12 +110,12 @@ describe('useImportDocument', () => {
     expect(error).toBeInstanceOf(DomainError);
     expect(error).toMatchObject({
       message: 'Could not import the document',
-      code: 'document-import-failed',
-      cause: expect.objectContaining({
-        message: 'Document repository write operation failed',
-      }),
+      code: 'importDocument.documentImportFailed',
     });
-    expect(error).not.toHaveProperty('cause.message', rawCause.message);
+    if (!(error instanceof DomainError)) throw new Error('expected DomainError');
+    expect(error.cause).toBe(rawCause);
+    expect(error.message).not.toContain('/Device files');
+    expect(error.message).not.toContain('gd-123');
   });
 
   it('creates a document from a validated draft and returns its id', async () => {
@@ -144,7 +144,7 @@ describe('useImportDocument', () => {
     ).rejects.toBe(cause);
   });
 
-  it('wraps file read errors with a privacy-safe technical cause', async () => {
+  it('preserves raw file read error as cause when file reading fails', async () => {
     const rawCause = new Error('Could not read /Device files/Private/Tax 2025/document.json');
     fileOpenMock.mockResolvedValue({
       text: vi.fn().mockRejectedValue(rawCause),
@@ -158,12 +158,11 @@ describe('useImportDocument', () => {
     expect(error).toBeInstanceOf(DomainError);
     expect(error).toMatchObject({
       message: 'Could not import the document',
-      code: 'file-read-failed',
-      cause: expect.objectContaining({
-        message: 'Selected file read failed',
-      }),
+      code: 'importDocument.fileReadFailed',
     });
-    expect(error).not.toHaveProperty('cause.message', rawCause.message);
+    if (!(error instanceof DomainError)) throw new Error('expected DomainError');
+    expect(error.cause).toBe(rawCause);
+    expect(error.message).not.toContain('/Device files');
     expect(createDocumentMock).not.toHaveBeenCalled();
   });
 
@@ -176,7 +175,7 @@ describe('useImportDocument', () => {
     expect(createDocumentMock).not.toHaveBeenCalled();
   });
 
-  it('does not treat non-AbortError picker failures as user cancellation', async () => {
+  it('preserves raw picker error as cause when file open fails with a non-cancel error', async () => {
     const rawCause = new DOMException(
       'Could not access /Device files/Private/Tax 2025/document.json',
       'NotAllowedError',
@@ -190,32 +189,11 @@ describe('useImportDocument', () => {
     expect(error).toBeInstanceOf(DomainError);
     expect(error).toMatchObject({
       message: 'Could not open the selected file',
-      code: 'file-open-failed',
-      cause: expect.objectContaining({
-        message: 'Selected file open operation failed',
-      }),
+      code: 'importDocument.fileOpenFailed',
     });
-    expect(error).not.toHaveProperty('cause.message', rawCause.message);
+    if (!(error instanceof DomainError)) throw new Error('expected DomainError');
+    expect(error.cause).toBe(rawCause);
+    expect(error.message).not.toContain('/Device files');
     expect(createDocumentMock).not.toHaveBeenCalled();
-  });
-
-  it('preserves a safe cause message for reporting when document creation fails', async () => {
-    const cause = new Error('Could not write the imported document');
-    createDocumentMock.mockRejectedValueOnce(cause);
-
-    const { createImportedDocument } = useImportDocument();
-
-    const error = await createImportedDocument('/documents', {
-      fileName: 'Doc.json',
-      initialValue: validDocument,
-    }).catch((caughtError: unknown) => caughtError);
-
-    expect(error).toBeInstanceOf(DomainError);
-    expect(error).toMatchObject({
-      message: 'Could not import the document',
-      cause: expect.objectContaining({
-        message: 'Document repository write operation failed',
-      }),
-    });
   });
 });

--- a/src/features/importDocument/useImportDocument.ts
+++ b/src/features/importDocument/useImportDocument.ts
@@ -1,4 +1,4 @@
-import { createSafeErrorCause, DomainError } from '@shared/lib/error';
+import { DomainError } from '@shared/lib/error';
 import { isUserFileSelectionCancel } from '@shared/lib/fileSystem';
 import { useMainServiceClient } from '@shared/service';
 import { fileOpen } from 'browser-fs-access';
@@ -47,7 +47,7 @@ export const useImportDocument = () => {
       }
 
       throw new DomainError('Could not open the selected file', {
-        cause: createSafeErrorCause('Selected file open operation failed'),
+        cause: error,
         code: ImportDocumentErrorCode.fileOpenFailed,
       });
     }
@@ -56,9 +56,9 @@ export const useImportDocument = () => {
 
     try {
       text = await file.text();
-    } catch {
+    } catch (error) {
       throw new DomainError('Could not import the document', {
-        cause: createSafeErrorCause('Selected file read failed'),
+        cause: error,
         code: ImportDocumentErrorCode.fileReadFailed,
       });
     }
@@ -108,7 +108,7 @@ export const useImportDocument = () => {
       }
 
       throw new DomainError('Could not import the document', {
-        cause: createSafeErrorCause('Document repository write operation failed'),
+        cause: error,
         code: ImportDocumentErrorCode.documentImportFailed,
       });
     }

--- a/src/features/importDocument/useImportDocumentAction.test.ts
+++ b/src/features/importDocument/useImportDocumentAction.test.ts
@@ -137,7 +137,7 @@ describe('useImportDocumentAction', () => {
     expect(captureDiagnosticExceptionMock).not.toHaveBeenCalled();
   });
 
-  it('reports unexpected import failures with safe metadata', async () => {
+  it('reports unexpected import failures and preserves raw error as cause', async () => {
     const error = new Error('unexpected failure at /private/path/notes.json');
     readImportDocumentDraftMock.mockResolvedValue({
       fileName: 'draft.json',
@@ -153,9 +153,14 @@ describe('useImportDocumentAction', () => {
       text: 'Could not import the document',
     });
     expect(captureDiagnosticExceptionMock).toHaveBeenCalledTimes(1);
+    const [reportedError] = captureDiagnosticExceptionMock.mock.calls[0] ?? [];
+    const { DomainError } = await import('@shared/lib/error');
+    expect(reportedError).toBeInstanceOf(DomainError);
+    expect(reportedError.cause).toBe(error);
+    expect(reportedError.message).not.toContain('/private/path');
   });
 
-  it('does not report an inbound domain error with a private cause directly', async () => {
+  it('passes original DomainError directly to diagnostics without wrapping', async () => {
     const { DomainError } = await import('@shared/lib/error');
     const { ImportDocumentErrorCode } = await import('./importDocumentErrorCode');
     const rawCause = new Error('failed to import /Users/alice/Documents/private.json');
@@ -177,6 +182,8 @@ describe('useImportDocumentAction', () => {
       text: 'Could not import the document',
     });
     expect(captureDiagnosticExceptionMock).toHaveBeenCalledTimes(1);
+    const [reportedError] = captureDiagnosticExceptionMock.mock.calls[0] ?? [];
+    expect(reportedError).toBe(error);
   });
 
   it('does not request permission and shows a safe message when user cancels the grant dialog', async () => {
@@ -257,7 +264,8 @@ describe('useImportDocumentAction', () => {
     expect(captureDiagnosticExceptionMock).not.toHaveBeenCalled();
   });
 
-  it('reports retry failure through safe import error path without reopening the file picker', async () => {
+  it('reports retry failure through import error path without reopening the file picker', async () => {
+    const retryError = new Error('disk full');
     readImportDocumentDraftMock.mockResolvedValue({
       fileName: 'draft.json',
       initialValue: {},
@@ -269,7 +277,7 @@ describe('useImportDocumentAction', () => {
           spaceName: 'Work',
         }),
       )
-      .mockRejectedValueOnce(new Error('disk full'));
+      .mockRejectedValueOnce(retryError);
     confirmMock.mockResolvedValue(true);
     requestAccessMock.mockResolvedValue({ status: 'granted' });
 
@@ -283,6 +291,10 @@ describe('useImportDocumentAction', () => {
       text: 'Could not import the document',
     });
     expect(captureDiagnosticExceptionMock).toHaveBeenCalledTimes(1);
+    const [reportedError] = captureDiagnosticExceptionMock.mock.calls[0] ?? [];
+    const { DomainError } = await import('@shared/lib/error');
+    expect(reportedError).toBeInstanceOf(DomainError);
+    expect(reportedError.cause).toBe(retryError);
   });
 
   it('requests write access after a write-required import failure and retries the repository write', async () => {

--- a/src/features/importDocument/useImportDocumentAction.test.ts
+++ b/src/features/importDocument/useImportDocumentAction.test.ts
@@ -121,7 +121,7 @@ describe('useImportDocumentAction', () => {
     const { DomainError } = await import('@shared/lib/error');
     const { ImportDocumentErrorCode } = await import('./importDocumentErrorCode');
     readImportDocumentDraftMock.mockRejectedValue(
-      new DomainError('The selected JSON file is not a Beaver document', {
+      new DomainError('The selected JSON file is not a Mioframe document', {
         cause: new Error('zod'),
         code: ImportDocumentErrorCode.invalidDocumentFormat,
       }),
@@ -132,7 +132,7 @@ describe('useImportDocumentAction', () => {
 
     await expect(importDocument('/documents')).resolves.toBeUndefined();
     expect(addSnackbarMock).toHaveBeenCalledWith({
-      text: 'The selected JSON file is not a Beaver document',
+      text: 'The selected JSON file is not a Mioframe document',
     });
     expect(captureDiagnosticExceptionMock).not.toHaveBeenCalled();
   });

--- a/src/features/importDocument/useImportDocumentAction.ts
+++ b/src/features/importDocument/useImportDocumentAction.ts
@@ -1,4 +1,4 @@
-import { createSafeErrorCause, DomainError } from '@shared/lib/error';
+import { DomainError } from '@shared/lib/error';
 import { isUserFileSelectionCancel } from '@shared/lib/fileSystem';
 import { getFileSystemAccessRecovery } from '@shared/lib/fileSystem';
 import { captureDiagnosticException } from '@shared/lib/diagnostics';
@@ -13,13 +13,6 @@ const shouldSkipImportErrorReport = (error: unknown) =>
   (error instanceof DomainError &&
     (error.code === ImportDocumentErrorCode.invalidJson ||
       error.code === ImportDocumentErrorCode.invalidDocumentFormat));
-
-const toSafeImportReportError = () => {
-  return new DomainError('Could not import the document', {
-    cause: createSafeErrorCause('Document JSON import failed'),
-    code: ImportDocumentErrorCode.documentImportFailed,
-  });
-};
 
 /**
  * Runs the document JSON import flow with shared snackbar and diagnostics behavior.
@@ -102,7 +95,14 @@ export const useImportDocumentAction = () => {
       });
 
       if (!shouldSkipImportErrorReport(error)) {
-        captureDiagnosticException(toSafeImportReportError(), {
+        const reportError =
+          error instanceof DomainError
+            ? error
+            : new DomainError('Could not import the document', {
+                cause: error,
+                code: ImportDocumentErrorCode.documentImportFailed,
+              });
+        captureDiagnosticException(reportError, {
           feature: 'documentImport',
           action: 'importDocumentJson',
         });

--- a/src/features/localDirectoryPick/usePickLocalDirectory.test.ts
+++ b/src/features/localDirectoryPick/usePickLocalDirectory.test.ts
@@ -53,7 +53,7 @@ describe('usePickLocalDirectory', () => {
     });
   });
 
-  it('reports a privacy-safe DomainError when the directory picker fails with a raw path message', async () => {
+  it('reports a DomainError preserving the raw picker failure as cause', async () => {
     const rawCause = new DOMException(
       'Could not access /Device files/Private/Taxes 2025',
       'NotAllowedError',
@@ -76,15 +76,10 @@ describe('usePickLocalDirectory', () => {
     expect(reportedError).toBeInstanceOf(DomainError);
     expect(reportedError).toMatchObject({
       message: 'Could not add the folder',
-      cause: expect.objectContaining({
-        message: 'Directory picker operation failed',
-      }),
+      code: 'localDirectoryPick.pickFailed',
     });
-    if (!(reportedError instanceof DomainError)) {
-      throw new Error('Expected DomainError');
-    }
-    expect(reportedError.cause).not.toMatchObject({
-      message: rawCause.message,
-    });
+    expect(reportedError.cause).toBe(rawCause);
+    expect(reportedError.message).not.toContain('/Device files');
+    expect(reportedError.message).not.toContain('Taxes 2025');
   });
 });

--- a/src/features/localDirectoryPick/usePickLocalDirectory.ts
+++ b/src/features/localDirectoryPick/usePickLocalDirectory.ts
@@ -1,11 +1,15 @@
 import { useFileSystem } from '@entity/mountedDirectories';
-import { createSafeErrorCause, DomainError } from '@shared/lib/error';
+import { DomainError } from '@shared/lib/error';
 import { isUserFileSelectionCancel } from '@shared/lib/fileSystem';
 import { isFunction } from 'es-toolkit';
 import { ref, toRef } from 'vue';
 import { captureDiagnosticException } from '@shared/lib/diagnostics';
 import { useDialog } from '@shared/ui/Dialog';
 import { useSnackbar } from '@shared/ui/Snackbar';
+
+enum LocalDirectoryPickErrorCode {
+  pickFailed = 'localDirectoryPick.pickFailed',
+}
 
 /**
  * Creates a directory picker flow for mounting a local folder into the app.
@@ -61,7 +65,8 @@ export const usePickLocalDirectory = () => {
           error instanceof DomainError
             ? error
             : new DomainError('Could not add the folder', {
-                cause: createSafeErrorCause('Directory picker operation failed'),
+                cause: error,
+                code: LocalDirectoryPickErrorCode.pickFailed,
               });
 
         addSnackbar({

--- a/src/features/mioframeSpacePick/mioframeSpacePick.errors.ts
+++ b/src/features/mioframeSpacePick/mioframeSpacePick.errors.ts
@@ -1,20 +1,8 @@
-import { createSafeErrorCause, DomainError } from '@shared/lib/error';
-
-const buildAddFolderError = (message: string, causeMessage: string) =>
-  new DomainError(message, {
-    cause: createSafeErrorCause(causeMessage),
-  });
-
 /**
- * Creates the privacy-safe error surfaced when Mioframe space creation fails.
- * @returns Domain error with a safe technical cause for Mioframe-space creation failures.
+ * Stable error codes for Mioframe space pick failures.
  */
-export const buildCreateSpaceError = () =>
-  buildAddFolderError('Could not create the Mioframe space', 'Creating the Mioframe space failed');
-
-/**
- * Creates the privacy-safe error surfaced when opening an existing Mioframe space fails.
- * @returns Domain error with a safe technical cause for Mioframe-space open failures.
- */
-export const buildOpenSpaceError = () =>
-  buildAddFolderError('Could not open the Mioframe space', 'Opening the Mioframe space failed');
+export enum MioframeSpacePickErrorCode {
+  createFailed = 'mioframeSpacePick.createFailed',
+  openFailed = 'mioframeSpacePick.openFailed',
+  rollbackFailed = 'mioframeSpacePick.rollbackFailed',
+}

--- a/src/features/mioframeSpacePick/useCreateMioframeSpace.ts
+++ b/src/features/mioframeSpacePick/useCreateMioframeSpace.ts
@@ -1,12 +1,12 @@
 import { useFileSystem } from '@entity/mountedDirectories';
 import { useMainServiceClient } from '@shared/service';
-import { createSafeErrorCause, DomainError } from '@shared/lib/error';
+import { DomainError } from '@shared/lib/error';
 import { captureDiagnosticException } from '@shared/lib/diagnostics';
 import { DEVICE_FILES_ROOT_NAME } from '@shared/service/fileSystem';
 import { useSnackbar } from '@shared/ui/Snackbar';
 import { PathUtils } from '@shared/lib/virtualFileSystem';
 import { ref, toValue, type MaybeRefOrGetter } from 'vue';
-import { buildCreateSpaceError, buildOpenSpaceError } from './mioframeSpacePick.errors';
+import { MioframeSpacePickErrorCode } from './mioframeSpacePick.errors';
 import { inspectMioframeSpaceDirectory } from './mioframeSpacePick.helpers';
 
 const EXISTING_ORDINARY_FOLDER_ERROR =
@@ -52,12 +52,18 @@ export const useCreateMioframeSpace = (
   const handleUnexpectedError = (
     error: unknown,
     options?: {
-      fallbackError?: DomainError;
+      message?: string;
+      code?: MioframeSpacePickErrorCode;
       action?: 'createSpace' | 'openExistingSpace';
     },
   ) => {
     const reportedError =
-      error instanceof DomainError ? error : (options?.fallbackError ?? buildCreateSpaceError());
+      error instanceof DomainError
+        ? error
+        : new DomainError(options?.message ?? 'Could not create the Mioframe space', {
+            cause: error,
+            code: options?.code ?? MioframeSpacePickErrorCode.createFailed,
+          });
 
     addSnackbar({
       text: reportedError.message,
@@ -68,10 +74,11 @@ export const useCreateMioframeSpace = (
     });
   };
 
-  const reportRollbackError = () => {
+  const reportRollbackError = (rollbackError: unknown) => {
     captureDiagnosticException(
       new DomainError('Could not roll back failed Mioframe space creation', {
-        cause: createSafeErrorCause('Rolling back failed Mioframe space creation failed'),
+        cause: rollbackError,
+        code: MioframeSpacePickErrorCode.rollbackFailed,
       }),
       {
         feature: 'mioframeSpaceCreate',
@@ -186,8 +193,8 @@ export const useCreateMioframeSpace = (
       if (mountedRecord) {
         try {
           await disconnectDeviceFile(mountedRecord.name);
-        } catch {
-          reportRollbackError();
+        } catch (rollbackError) {
+          reportRollbackError(rollbackError);
         }
       }
 
@@ -217,7 +224,8 @@ export const useCreateMioframeSpace = (
       return true;
     } catch (error) {
       handleUnexpectedError(error, {
-        fallbackError: buildOpenSpaceError(),
+        message: 'Could not open the Mioframe space',
+        code: MioframeSpacePickErrorCode.openFailed,
         action: 'openExistingSpace',
       });
       return false;

--- a/src/features/mioframeSpacePick/useMioframeSpaceFlows.test.ts
+++ b/src/features/mioframeSpacePick/useMioframeSpaceFlows.test.ts
@@ -213,8 +213,9 @@ describe('useMioframeSpaceParentPicker', () => {
     expect(parentPicker.parentHandle.value).toBeUndefined();
   });
 
-  it('reports a privacy-safe error when parent-folder picking fails unexpectedly', async () => {
-    showDirectoryPickerMock.mockRejectedValueOnce(new Error('raw picker detail'));
+  it('reports a DomainError preserving raw picker failure as cause when parent-folder picking fails', async () => {
+    const rawPickerError = new Error('raw picker detail');
+    showDirectoryPickerMock.mockRejectedValueOnce(rawPickerError);
     const parentPicker = useMioframeSpaceParentPicker();
 
     await parentPicker.pickParentDirectory();
@@ -223,18 +224,13 @@ describe('useMioframeSpaceParentPicker', () => {
     expect(addSnackbarMock).toHaveBeenCalledWith({
       text: 'Could not create the Mioframe space',
     });
-    expect(captureDiagnosticExceptionMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: 'Could not create the Mioframe space',
-        cause: expect.objectContaining({
-          message: 'Creating the Mioframe space failed',
-        }),
-      }),
-      {
-        feature: 'mioframeSpaceCreate',
-        action: 'pickParentFolder',
-      },
-    );
+    const [reportedError, options] = captureDiagnosticExceptionMock.mock.calls[0] ?? [];
+    expect(options).toEqual({ feature: 'mioframeSpaceCreate', action: 'pickParentFolder' });
+    expect(reportedError).toMatchObject({
+      message: 'Could not create the Mioframe space',
+      code: 'mioframeSpacePick.createFailed',
+    });
+    expect(reportedError.cause).toBe(rawPickerError);
   });
 });
 
@@ -448,7 +444,7 @@ describe('useCreateMioframeSpace', () => {
     expect(initializeRepositoryMock).not.toHaveBeenCalled();
   });
 
-  it('reports a privacy-safe error when opening an existing conflicted space fails', async () => {
+  it('reports a DomainError preserving raw mount failure as cause when opening an existing conflicted space fails', async () => {
     const existingSpaceHandle = createDirectoryHandle({
       name: 'Work Notes',
       entries: [[markerFileName, createFileHandle(markerFileName)]],
@@ -457,7 +453,8 @@ describe('useCreateMioframeSpace', () => {
       name: 'Documents',
       subdirectoryFactory: () => existingSpaceHandle,
     });
-    addDeviceDirectoryMock.mockRejectedValueOnce(new Error('raw filesystem detail'));
+    const rawMountError = new Error('raw filesystem detail');
+    addDeviceDirectoryMock.mockRejectedValueOnce(rawMountError);
     const createFlow = useCreateMioframeSpace(ref(parentHandle));
 
     await expect(createFlow.checkCreateSpaceNameAvailability('Work Notes')).resolves.toEqual({
@@ -472,18 +469,13 @@ describe('useCreateMioframeSpace', () => {
     expect(addSnackbarMock).toHaveBeenCalledWith({
       text: 'Could not open the Mioframe space',
     });
-    expect(captureDiagnosticExceptionMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: 'Could not open the Mioframe space',
-        cause: expect.objectContaining({
-          message: 'Opening the Mioframe space failed',
-        }),
-      }),
-      {
-        feature: 'mioframeSpaceCreate',
-        action: 'openExistingSpace',
-      },
-    );
+    const [reportedError, options] = captureDiagnosticExceptionMock.mock.calls[0] ?? [];
+    expect(options).toEqual({ feature: 'mioframeSpaceCreate', action: 'openExistingSpace' });
+    expect(reportedError).toMatchObject({
+      message: 'Could not open the Mioframe space',
+      code: 'mioframeSpacePick.openFailed',
+    });
+    expect(reportedError.cause).toBe(rawMountError);
   });
 
   it('rolls back the mounted record when repository initialization fails after mounting', async () => {
@@ -502,7 +494,8 @@ describe('useCreateMioframeSpace', () => {
       name: 'Work Notes',
       handle: createdSpaceHandle,
     });
-    initializeRepositoryMock.mockRejectedValueOnce(new Error('raw filesystem detail'));
+    const rawInitError = new Error('raw filesystem detail');
+    initializeRepositoryMock.mockRejectedValueOnce(rawInitError);
     const createFlow = useCreateMioframeSpace(ref(parentHandle));
 
     await expect(createFlow.createSpace('Work Notes')).resolves.toBe(false);
@@ -510,18 +503,13 @@ describe('useCreateMioframeSpace', () => {
     expect(addSnackbarMock).toHaveBeenCalledWith({
       text: 'Could not create the Mioframe space',
     });
-    expect(captureDiagnosticExceptionMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: 'Could not create the Mioframe space',
-        cause: expect.objectContaining({
-          message: 'Creating the Mioframe space failed',
-        }),
-      }),
-      {
-        feature: 'mioframeSpaceCreate',
-        action: 'createSpace',
-      },
-    );
+    const [reportedError, options] = captureDiagnosticExceptionMock.mock.calls[0] ?? [];
+    expect(options).toEqual({ feature: 'mioframeSpaceCreate', action: 'createSpace' });
+    expect(reportedError).toMatchObject({
+      message: 'Could not create the Mioframe space',
+      code: 'mioframeSpacePick.createFailed',
+    });
+    expect(reportedError.cause).toBe(rawInitError);
     expect(captureDiagnosticExceptionMock).not.toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
@@ -531,7 +519,7 @@ describe('useCreateMioframeSpace', () => {
     );
   });
 
-  it('reports a privacy-safe error when rollback after repository initialization failure fails', async () => {
+  it('preserves raw rollback and init errors as causes when rollback after repository initialization failure also fails', async () => {
     const createdSpaceHandle = createDirectoryHandle({ name: 'Work Notes' });
     const parentHandle = createDirectoryHandle({
       name: 'Documents',
@@ -547,39 +535,36 @@ describe('useCreateMioframeSpace', () => {
       name: 'Work Notes',
       handle: createdSpaceHandle,
     });
-    initializeRepositoryMock.mockRejectedValueOnce(new Error('raw filesystem detail'));
-    disconnectDeviceFileMock.mockRejectedValueOnce(new Error('raw rollback detail'));
+    const rawInitError = new Error('raw filesystem detail');
+    const rawRollbackError = new Error('raw rollback detail');
+    initializeRepositoryMock.mockRejectedValueOnce(rawInitError);
+    disconnectDeviceFileMock.mockRejectedValueOnce(rawRollbackError);
     const createFlow = useCreateMioframeSpace(ref(parentHandle));
 
     await expect(createFlow.createSpace('Work Notes')).resolves.toBe(false);
 
-    expect(captureDiagnosticExceptionMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: 'Could not roll back failed Mioframe space creation',
-        cause: expect.objectContaining({
-          message: 'Rolling back failed Mioframe space creation failed',
-        }),
-      }),
-      {
-        feature: 'mioframeSpaceCreate',
-        action: 'rollbackCreateSpaceMount',
-      },
+    const rollbackCall = captureDiagnosticExceptionMock.mock.calls.find(
+      ([, opts]) => opts?.action === 'rollbackCreateSpaceMount',
     );
-    expect(captureDiagnosticExceptionMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: 'Could not create the Mioframe space',
-        cause: expect.objectContaining({
-          message: 'Creating the Mioframe space failed',
-        }),
-      }),
-      {
-        feature: 'mioframeSpaceCreate',
-        action: 'createSpace',
-      },
+    expect(rollbackCall).toBeDefined();
+    expect(rollbackCall?.[0]).toMatchObject({
+      message: 'Could not roll back failed Mioframe space creation',
+      code: 'mioframeSpacePick.rollbackFailed',
+    });
+    expect(rollbackCall?.[0].cause).toBe(rawRollbackError);
+
+    const createCall = captureDiagnosticExceptionMock.mock.calls.find(
+      ([, opts]) => opts?.action === 'createSpace',
     );
+    expect(createCall).toBeDefined();
+    expect(createCall?.[0]).toMatchObject({
+      message: 'Could not create the Mioframe space',
+      code: 'mioframeSpacePick.createFailed',
+    });
+    expect(createCall?.[0].cause).toBe(rawInitError);
   });
 
-  it('reports a privacy-safe error when create mounting fails', async () => {
+  it('reports a DomainError preserving raw mount error as cause when create mounting fails', async () => {
     const createdSpaceHandle = createDirectoryHandle({ name: 'Work Notes' });
     const parentHandle = createDirectoryHandle({
       name: 'Documents',
@@ -591,7 +576,8 @@ describe('useCreateMioframeSpace', () => {
         throw new DOMException('Missing directory', 'NotFoundError');
       },
     });
-    addDeviceDirectoryMock.mockRejectedValueOnce(new Error('raw filesystem detail'));
+    const rawMountError = new Error('raw filesystem detail');
+    addDeviceDirectoryMock.mockRejectedValueOnce(rawMountError);
     const createFlow = useCreateMioframeSpace(ref(parentHandle));
 
     await expect(createFlow.createSpace('Work Notes')).resolves.toBe(false);
@@ -600,21 +586,16 @@ describe('useCreateMioframeSpace', () => {
     expect(addSnackbarMock).toHaveBeenCalledWith({
       text: 'Could not create the Mioframe space',
     });
-    expect(captureDiagnosticExceptionMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: 'Could not create the Mioframe space',
-        cause: expect.objectContaining({
-          message: 'Creating the Mioframe space failed',
-        }),
-      }),
-      {
-        feature: 'mioframeSpaceCreate',
-        action: 'createSpace',
-      },
-    );
+    const [reportedError, options] = captureDiagnosticExceptionMock.mock.calls[0] ?? [];
+    expect(options).toEqual({ feature: 'mioframeSpaceCreate', action: 'createSpace' });
+    expect(reportedError).toMatchObject({
+      message: 'Could not create the Mioframe space',
+      code: 'mioframeSpacePick.createFailed',
+    });
+    expect(reportedError.cause).toBe(rawMountError);
   });
 
-  it('returns false after reporting a privacy-safe error when availability inspection fails unexpectedly', async () => {
+  it('returns false after reporting a DomainError with raw filesystem error as cause when availability inspection fails unexpectedly', async () => {
     const parentHandle = createDirectoryHandle({
       name: 'Documents',
       subdirectoryFactory: () => {
@@ -627,18 +608,13 @@ describe('useCreateMioframeSpace', () => {
     expect(addSnackbarMock).toHaveBeenCalledWith({
       text: 'Could not create the Mioframe space',
     });
-    expect(captureDiagnosticExceptionMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: 'Could not create the Mioframe space',
-        cause: expect.objectContaining({
-          message: 'Creating the Mioframe space failed',
-        }),
-      }),
-      {
-        feature: 'mioframeSpaceCreate',
-        action: 'createSpace',
-      },
-    );
+    const [reportedError, options] = captureDiagnosticExceptionMock.mock.calls[0] ?? [];
+    expect(options).toEqual({ feature: 'mioframeSpaceCreate', action: 'createSpace' });
+    expect(reportedError).toMatchObject({
+      message: 'Could not create the Mioframe space',
+      code: 'mioframeSpacePick.createFailed',
+    });
+    expect(reportedError.cause).toMatchObject({ message: 'raw filesystem detail' });
   });
 });
 
@@ -705,26 +681,22 @@ describe('useOpenMioframeSpace', () => {
     expect(addDeviceDirectoryMock).not.toHaveBeenCalled();
   });
 
-  it('reports a privacy-safe error when open flow hits an unexpected picker failure', async () => {
-    showDirectoryPickerMock.mockRejectedValueOnce(new Error('raw picker detail'));
+  it('reports a DomainError preserving raw picker error as cause when open flow hits an unexpected picker failure', async () => {
+    const rawPickerError = new Error('raw picker detail');
+    showDirectoryPickerMock.mockRejectedValueOnce(rawPickerError);
 
     await useOpenMioframeSpace().openSpace();
 
     expect(addSnackbarMock).toHaveBeenCalledWith({
       text: 'Could not open the Mioframe space',
     });
-    expect(captureDiagnosticExceptionMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: 'Could not open the Mioframe space',
-        cause: expect.objectContaining({
-          message: 'Opening the Mioframe space failed',
-        }),
-      }),
-      {
-        feature: 'mioframeSpaceOpen',
-        action: 'openSpace',
-      },
-    );
+    const [reportedError, options] = captureDiagnosticExceptionMock.mock.calls[0] ?? [];
+    expect(options).toEqual({ feature: 'mioframeSpaceOpen', action: 'openSpace' });
+    expect(reportedError).toMatchObject({
+      message: 'Could not open the Mioframe space',
+      code: 'mioframeSpacePick.openFailed',
+    });
+    expect(reportedError.cause).toBe(rawPickerError);
   });
 });
 /* eslint-enable @typescript-eslint/consistent-type-assertions, @typescript-eslint/require-await -- Re-enable after DOM File System Access API test mocks. */

--- a/src/features/mioframeSpacePick/useMioframeSpaceParentPicker.ts
+++ b/src/features/mioframeSpacePick/useMioframeSpaceParentPicker.ts
@@ -7,7 +7,7 @@ import {
   pickWritableDirectory,
   showDirectoryPickerUnsupportedMessage,
 } from './directoryPickerSupport';
-import { buildCreateSpaceError } from './mioframeSpacePick.errors';
+import { MioframeSpacePickErrorCode } from './mioframeSpacePick.errors';
 
 /**
  * Owns the parent-directory picker state for creating a Mioframe space.
@@ -20,7 +20,13 @@ export const useMioframeSpaceParentPicker = () => {
   const isSupported = computed(() => isDirectoryPickerSupported());
 
   const reportPickerFailure = (error: unknown) => {
-    const reportedError = error instanceof DomainError ? error : buildCreateSpaceError();
+    const reportedError =
+      error instanceof DomainError
+        ? error
+        : new DomainError('Could not create the Mioframe space', {
+            cause: error,
+            code: MioframeSpacePickErrorCode.createFailed,
+          });
 
     addSnackbar({
       text: reportedError.message,

--- a/src/features/mioframeSpacePick/useOpenMioframeSpace.ts
+++ b/src/features/mioframeSpacePick/useOpenMioframeSpace.ts
@@ -10,7 +10,7 @@ import {
   pickWritableDirectory,
   showDirectoryPickerUnsupportedMessage,
 } from './directoryPickerSupport';
-import { buildOpenSpaceError } from './mioframeSpacePick.errors';
+import { MioframeSpacePickErrorCode } from './mioframeSpacePick.errors';
 
 const OPEN_GUARDRAIL_HEADLINE = 'No Mioframe space found';
 const OPEN_GUARDRAIL_TEXT = 'Choose a folder where a Mioframe space has already been created.';
@@ -28,7 +28,13 @@ export const useOpenMioframeSpace = () => {
   const isSupported = toRef(isDirectoryPickerSupported);
 
   const handleUnexpectedError = (error: unknown) => {
-    const reportedError = error instanceof DomainError ? error : buildOpenSpaceError();
+    const reportedError =
+      error instanceof DomainError
+        ? error
+        : new DomainError('Could not open the Mioframe space', {
+            cause: error,
+            code: MioframeSpacePickErrorCode.openFailed,
+          });
 
     addSnackbar({
       text: reportedError.message,
@@ -60,8 +66,11 @@ export const useOpenMioframeSpace = () => {
 
       try {
         inspection = await inspectMioframeSpaceDirectory(selectedHandle);
-      } catch {
-        throw buildOpenSpaceError();
+      } catch (error) {
+        throw new DomainError('Could not open the Mioframe space', {
+          cause: error,
+          code: MioframeSpacePickErrorCode.openFailed,
+        });
       }
 
       if (inspection.looksLikeExistingSpace) {

--- a/src/pages/DataStoragePrivacyPane/DataStoragePrivacyPane.test.ts
+++ b/src/pages/DataStoragePrivacyPane/DataStoragePrivacyPane.test.ts
@@ -81,8 +81,8 @@ it('renders the local-first and privacy help content in-app', async () => {
     'You can enable or disable error diagnostics at any time in Settings under Error diagnostics.',
   );
   expect(root.textContent).toContain('Mioframe 0.1 does not use Sentry Session Replay.');
-  expect(root.textContent).toContain('https://github.com/Vyachean/Mioframe/discussions');
-  expect(root.textContent).toContain('https://github.com/Vyachean/Mioframe/issues');
+  expect(root.textContent).toContain('https://github.com/Vyachean/mioframe/discussions');
+  expect(root.textContent).toContain('https://github.com/Vyachean/mioframe/issues');
 
   app.unmount();
   root.remove();
@@ -109,10 +109,10 @@ it('renders privacy markdown structure and safe external links', async () => {
 
   const links = Array.from(root.querySelectorAll('a'));
   expect(links).toHaveLength(2);
-  expect(links[0]?.getAttribute('href')).toBe('https://github.com/Vyachean/Mioframe/discussions');
+  expect(links[0]?.getAttribute('href')).toBe('https://github.com/Vyachean/mioframe/discussions');
   expect(links[0]?.getAttribute('target')).toBe('_blank');
   expect(links[0]?.getAttribute('rel')).toBe('noopener noreferrer');
-  expect(links[1]?.getAttribute('href')).toBe('https://github.com/Vyachean/Mioframe/issues');
+  expect(links[1]?.getAttribute('href')).toBe('https://github.com/Vyachean/mioframe/issues');
   expect(links[1]?.getAttribute('target')).toBe('_blank');
   expect(links[1]?.getAttribute('rel')).toBe('noopener noreferrer');
 

--- a/src/pages/DataStoragePrivacyPane/DataStoragePrivacyPane.test.ts
+++ b/src/pages/DataStoragePrivacyPane/DataStoragePrivacyPane.test.ts
@@ -81,8 +81,8 @@ it('renders the local-first and privacy help content in-app', async () => {
     'You can enable or disable error diagnostics at any time in Settings under Error diagnostics.',
   );
   expect(root.textContent).toContain('Mioframe 0.1 does not use Sentry Session Replay.');
-  expect(root.textContent).toContain('https://github.com/Vyachean/beaver/discussions');
-  expect(root.textContent).toContain('https://github.com/Vyachean/beaver/issues');
+  expect(root.textContent).toContain('https://github.com/Vyachean/Mioframe/discussions');
+  expect(root.textContent).toContain('https://github.com/Vyachean/Mioframe/issues');
 
   app.unmount();
   root.remove();
@@ -109,10 +109,10 @@ it('renders privacy markdown structure and safe external links', async () => {
 
   const links = Array.from(root.querySelectorAll('a'));
   expect(links).toHaveLength(2);
-  expect(links[0]?.getAttribute('href')).toBe('https://github.com/Vyachean/beaver/discussions');
+  expect(links[0]?.getAttribute('href')).toBe('https://github.com/Vyachean/Mioframe/discussions');
   expect(links[0]?.getAttribute('target')).toBe('_blank');
   expect(links[0]?.getAttribute('rel')).toBe('noopener noreferrer');
-  expect(links[1]?.getAttribute('href')).toBe('https://github.com/Vyachean/beaver/issues');
+  expect(links[1]?.getAttribute('href')).toBe('https://github.com/Vyachean/Mioframe/issues');
   expect(links[1]?.getAttribute('target')).toBe('_blank');
   expect(links[1]?.getAttribute('rel')).toBe('noopener noreferrer');
 

--- a/src/shared/lib/deviceFileSystemProvider/DeviceFileSystemProvider.test.ts
+++ b/src/shared/lib/deviceFileSystemProvider/DeviceFileSystemProvider.test.ts
@@ -286,6 +286,55 @@ describe('DeviceFileSystemProvider', () => {
     });
   });
 
+  it('VfsError messages from mounted-root operations do not contain raw paths or root names', async () => {
+    const secretName = 'SecretProjectName';
+    mountRecord(secretName);
+
+    const errors: Error[] = [];
+    const collect = (p: Promise<unknown>) =>
+      p.catch((e: unknown) => {
+        if (e instanceof Error) errors.push(e);
+      });
+
+    await collect(provider.stat('/NonExistentRoot'));
+    await collect(provider.readFile('/'));
+    await collect(provider.readFile(`/${secretName}`));
+    await collect(provider.writeFile(`/${secretName}`, 'x', { create: true, overwrite: true }));
+    await collect(provider.createDirectory(`/${secretName}`));
+    await collect(provider.move(`/${secretName}`, '/Other'));
+    await collect(provider.move('/Other', `/${secretName}`));
+    await collect(
+      provider.writeFile('/NonExistentRoot/file.txt', 'x', { create: true, overwrite: true }),
+    );
+
+    expect(errors.length).toBeGreaterThan(0);
+    for (const error of errors) {
+      expect(error.message).not.toContain(secretName);
+      expect(error.message).not.toContain('SecretProject');
+      expect(error.message).not.toContain('/Non');
+    }
+  });
+
+  it('VfsError codes from mounted-root boundary operations remain correct', async () => {
+    mountRecord('Projects');
+
+    await expect(provider.stat('/Missing')).rejects.toMatchObject({
+      code: FileSystemError.FileNotFound,
+    });
+    await expect(provider.readFile('/Projects')).rejects.toMatchObject({
+      code: FileSystemError.FileIsADirectory,
+    });
+    await expect(
+      provider.writeFile('/Projects', 'x', { create: true, overwrite: true }),
+    ).rejects.toMatchObject({ code: FileSystemError.NotSupported });
+    await expect(provider.createDirectory('/Projects')).rejects.toMatchObject({
+      code: FileSystemError.NotSupported,
+    });
+    await expect(provider.move('/Projects', '/Other')).rejects.toMatchObject({
+      code: FileSystemError.NotSupported,
+    });
+  });
+
   it('should rely on VFS delete semantics for mounted roots', async () => {
     const vfs = new VirtualFileSystem();
 

--- a/src/shared/lib/deviceFileSystemProvider/DeviceFileSystemProvider.ts
+++ b/src/shared/lib/deviceFileSystemProvider/DeviceFileSystemProvider.ts
@@ -108,7 +108,7 @@ const resolveRecordForWrite = (path: string, records: Map<string, ActiveDeviceFi
   const record = rootName ? records.get(rootName) : undefined;
 
   if (!record) {
-    throw new VfsError(FileSystemError.FileNotFound, `Directory not found: ${path}`);
+    throw new VfsError(FileSystemError.FileNotFound, 'Directory not found.');
   }
 
   return {
@@ -205,7 +205,7 @@ export const DeviceFileSystemProvider = (
       const record = records.get(rootName);
 
       if (!record) {
-        throw new VfsError(FileSystemError.FileNotFound, `Directory not found: ${path}`);
+        throw new VfsError(FileSystemError.FileNotFound, 'Directory not found.');
       }
 
       const rootStat = await record.provider.stat('/');
@@ -223,10 +223,7 @@ export const DeviceFileSystemProvider = (
     const normalizedPath = PathUtils.normalize(path);
 
     if (isMountedRootPath(normalizedPath)) {
-      throw new VfsError(
-        FileSystemError.FileIsADirectory,
-        `Cannot read directory: ${normalizedPath}`,
-      );
+      throw new VfsError(FileSystemError.FileIsADirectory, 'Cannot read a mounted root as a file.');
     }
 
     return vfs.readFile(normalizedPath);
@@ -240,10 +237,7 @@ export const DeviceFileSystemProvider = (
     const normalizedPath = PathUtils.normalize(path);
 
     if (isMountedRootPath(normalizedPath)) {
-      throw new VfsError(
-        FileSystemError.NotSupported,
-        `Cannot create files at root path: ${normalizedPath}`,
-      );
+      throw new VfsError(FileSystemError.NotSupported, 'Cannot create files at the mounted root.');
     }
 
     const { record, relativePath } = resolveRecordForWrite(normalizedPath, records);
@@ -268,10 +262,7 @@ export const DeviceFileSystemProvider = (
     const normalizedPath = PathUtils.normalize(path);
 
     if (isMountedRootPath(normalizedPath)) {
-      throw new VfsError(
-        FileSystemError.NotSupported,
-        `Cannot create mounted roots at: ${normalizedPath}`,
-      );
+      throw new VfsError(FileSystemError.NotSupported, 'Cannot create mounted roots.');
     }
 
     return vfs.createDirectory(normalizedPath);
@@ -292,10 +283,7 @@ export const DeviceFileSystemProvider = (
     const normalizedNewPath = PathUtils.normalize(newPath);
 
     if (isMountedRootPath(normalizedOldPath) || isMountedRootPath(normalizedNewPath)) {
-      throw new VfsError(
-        FileSystemError.NotSupported,
-        `Cannot move mounted roots: ${oldPath} -> ${newPath}`,
-      );
+      throw new VfsError(FileSystemError.NotSupported, 'Cannot move mounted roots.');
     }
 
     return vfs.move(normalizedOldPath, normalizedNewPath);

--- a/src/shared/lib/diagnostics/sanitizeSentryEvent.test.ts
+++ b/src/shared/lib/diagnostics/sanitizeSentryEvent.test.ts
@@ -1,0 +1,323 @@
+import { describe, expect, it } from 'vitest';
+import type { ErrorEvent as SentryErrorEvent } from '@sentry/vue';
+import {
+  sanitizeExceptionValue,
+  sanitizeExceptionValues,
+  createBeforeSend,
+} from './sanitizeSentryEvent';
+
+// ---------------------------------------------------------------------------
+// sanitizeExceptionValue
+// ---------------------------------------------------------------------------
+
+describe('sanitizeExceptionValue', () => {
+  it('keeps a short safe user-facing message unchanged', () => {
+    const result = sanitizeExceptionValue({
+      value: 'Could not create example',
+      type: 'DomainError',
+    });
+    expect(result.value).toBe('Could not create example');
+  });
+
+  it('keeps a short VFS error code unchanged', () => {
+    const result = sanitizeExceptionValue({ value: 'EACCES', type: 'VfsError' });
+    expect(result.value).toBe('EACCES');
+  });
+
+  it('replaces an absolute path message with [sanitized]', () => {
+    const result = sanitizeExceptionValue({
+      value: 'ENOENT: no such file or directory, mkdir /private/Examples',
+      type: 'Error',
+    });
+    expect(result.value).toBe('[sanitized]');
+  });
+
+  it('replaces a Windows path message with [sanitized]', () => {
+    const result = sanitizeExceptionValue({
+      value: 'C:\\Users\\developer\\projects\\repo',
+      type: 'Error',
+    });
+    expect(result.value).toBe('[sanitized]');
+  });
+
+  it('replaces a URL message with [sanitized]', () => {
+    const result = sanitizeExceptionValue({
+      value: 'https://token@api.internal.company.com/v1/resource',
+      type: 'Error',
+    });
+    expect(result.value).toBe('[sanitized]');
+  });
+
+  it('replaces an email-like message with [sanitized]', () => {
+    const result = sanitizeExceptionValue({
+      value: 'user@example.com access denied',
+      type: 'Error',
+    });
+    expect(result.value).toBe('[sanitized]');
+  });
+
+  it('replaces a storage-key-like message with [sanitized]', () => {
+    const result = sanitizeExceptionValue({
+      value: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ_repo123',
+      type: 'Error',
+    });
+    expect(result.value).toBe('[sanitized]');
+  });
+
+  it('replaces a message exceeding max length with [sanitized]', () => {
+    const longMessage = 'x'.repeat(201);
+    const result = sanitizeExceptionValue({ value: longMessage, type: 'Error' });
+    expect(result.value).toBe('[sanitized]');
+  });
+
+  it('preserves exception type and stacktrace when sanitizing the value', () => {
+    const result = sanitizeExceptionValue({
+      value: '/private/secret/path',
+      type: 'TypeError',
+      stacktrace: { frames: [{ filename: 'app.js' }] },
+    });
+    expect(result.value).toBe('[sanitized]');
+    expect(result.type).toBe('TypeError');
+    expect(result.stacktrace).toEqual({ frames: [{ filename: 'app.js' }] });
+  });
+
+  it('returns entry unchanged when value is undefined', () => {
+    const entry = { type: 'Error' };
+    const result = sanitizeExceptionValue(entry);
+    expect(result).toBe(entry);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sanitizeExceptionValues
+// ---------------------------------------------------------------------------
+
+describe('sanitizeExceptionValues', () => {
+  it('sanitizes all entries in the exception chain', () => {
+    const exception: SentryErrorEvent['exception'] = {
+      values: [
+        { value: 'Could not create example', type: 'DomainError' },
+        { value: 'ENOENT: no such file or directory /private/Examples', type: 'Error' },
+      ],
+    };
+
+    const result = sanitizeExceptionValues(exception);
+
+    expect(result?.values?.[0]?.value).toBe('Could not create example');
+    expect(result?.values?.[1]?.value).toBe('[sanitized]');
+  });
+
+  it('sanitizes a single-entry exception', () => {
+    const exception: SentryErrorEvent['exception'] = {
+      values: [{ value: 'postgres://admin:pass@db.company.com/db', type: 'Error' }],
+    };
+
+    const result = sanitizeExceptionValues(exception);
+    expect(result?.values?.[0]?.value).toBe('[sanitized]');
+  });
+
+  it('returns undefined when exception is undefined', () => {
+    expect(sanitizeExceptionValues(undefined)).toBeUndefined();
+  });
+
+  it('returns the exception unchanged when there are no values', () => {
+    const exception: SentryErrorEvent['exception'] = {};
+    const result = sanitizeExceptionValues(exception);
+    expect(result).toBe(exception);
+  });
+
+  it('preserves exception type while sanitizing the message', () => {
+    const exception: SentryErrorEvent['exception'] = {
+      values: [{ value: '/secret/path/to/file', type: 'WebFileSystemAccessRequiredError' }],
+    };
+
+    const result = sanitizeExceptionValues(exception);
+    expect(result?.values?.[0]?.type).toBe('WebFileSystemAccessRequiredError');
+    expect(result?.values?.[0]?.value).toBe('[sanitized]');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createBeforeSend — exception value sanitization in full pipeline
+// ---------------------------------------------------------------------------
+
+const makeEnabledBeforeSend = () =>
+  createBeforeSend({ isVerbose: false, getState: () => 'enabled' });
+
+describe('createBeforeSend exception value sanitization', () => {
+  it('passes a safe DomainError message through the event pipeline unchanged', () => {
+    const beforeSend = makeEnabledBeforeSend();
+    const event: SentryErrorEvent = {
+      type: undefined,
+      exception: {
+        values: [{ value: 'Could not create example', type: 'DomainError' }],
+      },
+    };
+
+    const result = beforeSend(event);
+
+    expect(result?.exception?.values?.[0]?.value).toBe('Could not create example');
+  });
+
+  it('sanitizes a raw path in the top-level exception message', () => {
+    const beforeSend = makeEnabledBeforeSend();
+    const event: SentryErrorEvent = {
+      type: undefined,
+      exception: {
+        values: [
+          { value: 'ENOENT: no such file, open /Users/dev/project/secret.json', type: 'Error' },
+        ],
+      },
+    };
+
+    const result = beforeSend(event);
+
+    expect(result?.exception?.values?.[0]?.value).toBe('[sanitized]');
+  });
+
+  it('sanitizes a raw cause message in a nested linked exception', () => {
+    const beforeSend = makeEnabledBeforeSend();
+    const event: SentryErrorEvent = {
+      type: undefined,
+      exception: {
+        values: [
+          { value: 'Could not save changes', type: 'DomainError' },
+          {
+            value: 'Connection failed to postgres://admin:pass@db.internal:5432/mioframe',
+            type: 'Error',
+          },
+        ],
+      },
+    };
+
+    const result = beforeSend(event);
+
+    expect(result?.exception?.values?.[0]?.value).toBe('Could not save changes');
+    expect(result?.exception?.values?.[1]?.value).toBe('[sanitized]');
+  });
+
+  it('sanitizes a raw absolute path in the cause exception chain', () => {
+    const beforeSend = makeEnabledBeforeSend();
+    const event: SentryErrorEvent = {
+      type: undefined,
+      exception: {
+        values: [
+          { value: 'Could not create example', type: 'DomainError' },
+          {
+            value: '/home/developer/projects/beaver/src/config/secrets.json: access denied',
+            type: 'Error',
+          },
+        ],
+      },
+    };
+
+    const result = beforeSend(event);
+
+    expect(result?.exception?.values?.[0]?.value).toBe('Could not create example');
+    expect(result?.exception?.values?.[1]?.value).toBe('[sanitized]');
+  });
+
+  it('keeps stack frames intact while sanitizing the exception message', () => {
+    const beforeSend = makeEnabledBeforeSend();
+    const frames = [{ filename: 'useExampleDocumentsCreate.ts', lineno: 42 }];
+    const event: SentryErrorEvent = {
+      type: undefined,
+      exception: {
+        values: [{ value: '/secret/path', type: 'Error', stacktrace: { frames } }],
+      },
+    };
+
+    const result = beforeSend(event);
+
+    expect(result?.exception?.values?.[0]?.value).toBe('[sanitized]');
+    expect(result?.exception?.values?.[0]?.stacktrace?.frames).toEqual(frames);
+  });
+
+  it('preserves exception type when sanitizing the message', () => {
+    const beforeSend = makeEnabledBeforeSend();
+    const event: SentryErrorEvent = {
+      type: undefined,
+      exception: {
+        values: [{ value: '/secret/path', type: 'VfsError' }],
+      },
+    };
+
+    const result = beforeSend(event);
+
+    expect(result?.exception?.values?.[0]?.type).toBe('VfsError');
+    expect(result?.exception?.values?.[0]?.value).toBe('[sanitized]');
+  });
+
+  it('keeps a stable error code in tags while sanitizing the message', () => {
+    const beforeSend = makeEnabledBeforeSend();
+    const event: SentryErrorEvent = {
+      type: undefined,
+      exception: {
+        values: [{ value: '/secret/path', type: 'DomainError' }],
+      },
+      tags: { eventKind: 'handledException', feature: 'exampleDocumentsCreate' },
+    };
+
+    const result = beforeSend(event);
+
+    expect(result?.tags?.['eventKind']).toBe('handledException');
+    expect(result?.tags?.['feature']).toBe('exampleDocumentsCreate');
+    expect(result?.exception?.values?.[0]?.value).toBe('[sanitized]');
+  });
+
+  it('drops a raw path from tags while keeping safe values', () => {
+    const beforeSend = makeEnabledBeforeSend();
+    const event: SentryErrorEvent = {
+      type: undefined,
+      exception: { values: [{ value: 'Could not save', type: 'DomainError' }] },
+      tags: {
+        eventKind: 'handledException',
+        filePath: '/Users/dev/doc.json',
+        feature: 'repositorySync',
+      },
+    };
+
+    const result = beforeSend(event);
+
+    expect(result?.tags?.['filePath']).toBeUndefined();
+    expect(result?.tags?.['feature']).toBe('repositorySync');
+  });
+
+  it('strips user fields except a valid session-scoped id', () => {
+    const beforeSend = makeEnabledBeforeSend();
+    const event: SentryErrorEvent = {
+      type: undefined,
+      exception: { values: [] },
+      user: { id: 'session:550e8400-e29b-41d4-a716-446655440000', email: 'user@example.com' },
+    };
+
+    const result = beforeSend(event);
+
+    expect(result?.user?.id).toMatch(/^session:/);
+    expect(result?.user).not.toHaveProperty('email');
+  });
+
+  it('sanitizes a token-like string in extras', () => {
+    const beforeSend = makeEnabledBeforeSend();
+    const event: SentryErrorEvent = {
+      type: undefined,
+      exception: { values: [] },
+      extra: { operation: 'save', authToken: 'Bearer sk-1234567890abcdef' },
+    };
+
+    const result = beforeSend(event);
+
+    expect(result?.extra?.['operation']).toBe('save');
+    expect(result?.extra?.['authToken']).toBeUndefined();
+  });
+
+  it('drops events when reporting state is not enabled', () => {
+    const beforeSend = createBeforeSend({ isVerbose: false, getState: () => 'disabled' });
+    const event: SentryErrorEvent = {
+      type: undefined,
+      exception: { values: [{ value: 'Something failed', type: 'Error' }] },
+    };
+
+    expect(beforeSend(event)).toBeNull();
+  });
+});

--- a/src/shared/lib/diagnostics/sanitizeSentryEvent.test.ts
+++ b/src/shared/lib/diagnostics/sanitizeSentryEvent.test.ts
@@ -538,11 +538,11 @@ describe('createBeforeSend exception value sanitization', () => {
   it('removes frame vars containing absolute paths, repo IDs, and auth tokens', () => {
     const beforeSend = makeEnabledBeforeSend();
     const DANGEROUS_VALUES = {
-      localPath: '/home/matdr/Projects/beaver/src/config/secrets.json',
+      localPath: '/home/usr/Projects/beaver/src/config/secrets.json',
       repoId: 'repo_ABCDE12345_xyz789',
       authHeader: 'Authorization: Bearer ghp_secret1234567890abcdef',
       docName: 'My confidential budget 2025',
-      urlWithQuery: 'https://api.example.com/v1/resource?token=abc&user=matdr',
+      urlWithQuery: 'https://api.example.com/v1/resource?token=abc&user=usr',
     };
 
     const event: SentryErrorEvent = {

--- a/src/shared/lib/diagnostics/sanitizeSentryEvent.test.ts
+++ b/src/shared/lib/diagnostics/sanitizeSentryEvent.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import type { ErrorEvent as SentryErrorEvent } from '@sentry/vue';
+import type { ErrorEvent as SentryErrorEvent, Exception as SentryException } from '@sentry/vue';
 import {
   sanitizeExceptionValue,
   sanitizeExceptionValues,
+  sanitizeMechanism,
+  sanitizeStacktrace,
   createBeforeSend,
 } from './sanitizeSentryEvent';
 
@@ -81,10 +83,154 @@ describe('sanitizeExceptionValue', () => {
     expect(result.stacktrace).toEqual({ frames: [{ filename: 'app.js' }] });
   });
 
-  it('returns entry unchanged when value is undefined', () => {
-    const entry = { type: 'Error' };
+  it('preserves type and omits value when value is undefined', () => {
+    const result = sanitizeExceptionValue({ type: 'Error' });
+    expect(result.type).toBe('Error');
+    expect(result).not.toHaveProperty('value');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sanitizeMechanism
+// ---------------------------------------------------------------------------
+
+describe('sanitizeMechanism', () => {
+  it('keeps type and handled while dropping data', () => {
+    const result = sanitizeMechanism({
+      type: 'generic',
+      handled: true,
+      data: { handler: 'onClick', target: '/home/user/Projects/app/src/handler.ts' },
+    });
+    expect(result.type).toBe('generic');
+    expect(result.handled).toBe(true);
+    expect(result).not.toHaveProperty('data');
+  });
+
+  it('removes mechanism.data with raw token-like values', () => {
+    const result = sanitizeMechanism({
+      type: 'instrument',
+      data: { authToken: 'Bearer sk-1234567890abcdef1234567890' },
+    });
+    expect(result).not.toHaveProperty('data');
+  });
+
+  it('removes mechanism.meta', () => {
+    const result = sanitizeMechanism({
+      type: 'onerror',
+      // @ts-expect-error testing runtime sanitization of unknown meta field
+      meta: { signal: 'unhandledrejection', extra: 'raw-payload' },
+    });
+    expect(result).not.toHaveProperty('meta');
+  });
+
+  it('preserves source, synthetic, exception_id, parent_id, is_exception_group', () => {
+    const result = sanitizeMechanism({
+      type: 'chained',
+      synthetic: false,
+      source: 'cause',
+      exception_id: 1,
+      parent_id: 0,
+      is_exception_group: false,
+    });
+    expect(result.source).toBe('cause');
+    expect(result.synthetic).toBe(false);
+    expect(result.exception_id).toBe(1);
+    expect(result.parent_id).toBe(0);
+    expect(result.is_exception_group).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sanitizeStacktrace
+// ---------------------------------------------------------------------------
+
+describe('sanitizeStacktrace', () => {
+  it('removes vars from all frames', () => {
+    const result = sanitizeStacktrace({
+      frames: [
+        {
+          filename: 'useExampleDocumentsCreate.ts',
+          lineno: 42,
+          vars: {
+            path: '/home/developer/projects/beaver/src/config/secrets.json',
+            authToken: 'sk-secret-token',
+          },
+        },
+        { filename: 'main.ts', lineno: 1 },
+      ],
+    });
+    expect(result.frames?.[0]).not.toHaveProperty('vars');
+    expect(result.frames?.[1]).not.toHaveProperty('vars');
+  });
+
+  it('preserves filename, function, lineno, colno, in_app', () => {
+    const result = sanitizeStacktrace({
+      frames: [
+        { filename: 'app.ts', function: 'createExample', lineno: 10, colno: 5, in_app: true },
+      ],
+    });
+    expect(result.frames?.[0]).toEqual(
+      expect.objectContaining({ filename: 'app.ts', function: 'createExample', lineno: 10 }),
+    );
+  });
+
+  it('returns stacktrace unchanged when no frames', () => {
+    const st = {};
+    expect(sanitizeStacktrace(st)).toBe(st);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sanitizeExceptionValue — full entry sanitization
+// ---------------------------------------------------------------------------
+
+describe('sanitizeExceptionValue — full entry sanitization', () => {
+  it('drops custom enumerable fields not in the standard exception interface', () => {
+    const entry: SentryException = { value: 'Something failed', type: 'DomainError' };
+    Object.assign(entry, {
+      rawFilePath: '/home/user/projects/secret.json',
+      providerPayload: 'Bearer abc123',
+    });
     const result = sanitizeExceptionValue(entry);
-    expect(result).toBe(entry);
+    expect(result).not.toHaveProperty('rawFilePath');
+    expect(result).not.toHaveProperty('providerPayload');
+    expect(result.type).toBe('DomainError');
+    expect(result.value).toBe('Something failed');
+  });
+
+  it('sanitizes mechanism.data containing raw path values while keeping mechanism type and handled', () => {
+    const result = sanitizeExceptionValue({
+      value: 'Could not create example',
+      type: 'DomainError',
+      mechanism: {
+        type: 'generic',
+        handled: true,
+        data: { errorPath: '/home/developer/projects/beaver/private/doc.json' },
+      },
+    });
+    expect(result.value).toBe('Could not create example');
+    expect(result.mechanism?.type).toBe('generic');
+    expect(result.mechanism?.handled).toBe(true);
+    expect(result.mechanism).not.toHaveProperty('data');
+  });
+
+  it('removes vars from stacktrace frames while keeping frame metadata', () => {
+    const result = sanitizeExceptionValue({
+      value: 'Path not found.',
+      type: 'VfsError',
+      stacktrace: {
+        frames: [
+          {
+            filename: 'MemoryFileSystem.ts',
+            lineno: 70,
+            vars: { path: '/Users/developer/Documents/repos/beaver/secret.json' },
+          },
+        ],
+      },
+    });
+    expect(result.stacktrace?.frames?.[0]).not.toHaveProperty('vars');
+    expect(result.stacktrace?.frames?.[0]?.filename).toBe('MemoryFileSystem.ts');
+    expect(result.stacktrace?.frames?.[0]?.lineno).toBe(70);
   });
 });
 
@@ -309,6 +455,77 @@ describe('createBeforeSend exception value sanitization', () => {
 
     expect(result?.extra?.['operation']).toBe('save');
     expect(result?.extra?.['authToken']).toBeUndefined();
+  });
+
+  it('removes mechanism.data with a raw document path from the exception entry', () => {
+    const beforeSend = makeEnabledBeforeSend();
+    const event: SentryErrorEvent = {
+      type: undefined,
+      exception: {
+        values: [
+          {
+            value: 'Could not create example',
+            type: 'DomainError',
+            mechanism: {
+              type: 'generic',
+              handled: true,
+              data: {
+                documentPath:
+                  '/home/matdr/Documents/repos/beaver/src/private/doc_ABCDEFGHIJ_12345.json',
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    const result = beforeSend(event);
+
+    expect(result?.exception?.values?.[0]?.value).toBe('Could not create example');
+    expect(result?.exception?.values?.[0]?.mechanism?.type).toBe('generic');
+    expect(result?.exception?.values?.[0]?.mechanism?.handled).toBe(true);
+    expect(result?.exception?.values?.[0]?.mechanism).not.toHaveProperty('data');
+  });
+
+  it('removes frame vars containing absolute paths, repo IDs, and auth tokens', () => {
+    const beforeSend = makeEnabledBeforeSend();
+    const DANGEROUS_VALUES = {
+      localPath: '/home/matdr/Projects/beaver/src/config/secrets.json',
+      repoId: 'repo_ABCDE12345_xyz789',
+      authHeader: 'Authorization: Bearer ghp_secret1234567890abcdef',
+      docName: 'My confidential budget 2025',
+      urlWithQuery: 'https://api.example.com/v1/resource?token=abc&user=matdr',
+    };
+
+    const event: SentryErrorEvent = {
+      type: undefined,
+      exception: {
+        values: [
+          {
+            value: 'Directory not found.',
+            type: 'VfsError',
+            stacktrace: {
+              frames: [
+                {
+                  filename: 'VirtualFileSystem.ts',
+                  function: 'resolve',
+                  lineno: 42,
+                  vars: DANGEROUS_VALUES,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+
+    const result = beforeSend(event);
+
+    const frame = result?.exception?.values?.[0]?.stacktrace?.frames?.[0];
+    expect(frame).not.toHaveProperty('vars');
+    expect(frame?.filename).toBe('VirtualFileSystem.ts');
+    expect(frame?.function).toBe('resolve');
+    expect(frame?.lineno).toBe(42);
   });
 
   it('drops events when reporting state is not enabled', () => {

--- a/src/shared/lib/diagnostics/sanitizeSentryEvent.test.ts
+++ b/src/shared/lib/diagnostics/sanitizeSentryEvent.test.ts
@@ -88,6 +88,54 @@ describe('sanitizeExceptionValue', () => {
     expect(result.type).toBe('Error');
     expect(result).not.toHaveProperty('value');
   });
+
+  it('preserves safe well-known error type names unchanged', () => {
+    expect(sanitizeExceptionValue({ type: 'VfsError' }).type).toBe('VfsError');
+    expect(sanitizeExceptionValue({ type: 'DomainError' }).type).toBe('DomainError');
+    expect(sanitizeExceptionValue({ type: 'WebFileSystemAccessRequiredError' }).type).toBe(
+      'WebFileSystemAccessRequiredError',
+    );
+    expect(sanitizeExceptionValue({ type: 'TypeError' }).type).toBe('TypeError');
+  });
+
+  it('replaces an unsafe path-like exception type with Error', () => {
+    const result = sanitizeExceptionValue({ type: '/home/user/inject/CustomError', value: 'oops' });
+    expect(result.type).toBe('Error');
+  });
+
+  it('replaces an unsafe URL-like exception type with Error', () => {
+    const result = sanitizeExceptionValue({ type: 'http://evil.com/Error', value: 'oops' });
+    expect(result.type).toBe('Error');
+  });
+
+  it('keeps a safe short exception module', () => {
+    const result = sanitizeExceptionValue({ type: 'Error', module: 'diagnostics' });
+    expect(result.module).toBe('diagnostics');
+  });
+
+  it('drops an unsafe URL-like exception module', () => {
+    const result = sanitizeExceptionValue({
+      type: 'Error',
+      module: 'app://localhost/src/shared/lib/diagnostics',
+    });
+    expect(result).not.toHaveProperty('module');
+  });
+
+  it('drops an unsafe path-like exception module', () => {
+    const result = sanitizeExceptionValue({ type: 'Error', module: '/home/user/projects/app' });
+    expect(result).not.toHaveProperty('module');
+  });
+
+  it('preserves stack frames when sanitizing unsafe type and module', () => {
+    const result = sanitizeExceptionValue({
+      type: '/injected/path/Error',
+      module: 'app://localhost/bundle.js',
+      stacktrace: { frames: [{ filename: 'app.ts', lineno: 1 }] },
+    });
+    expect(result.type).toBe('Error');
+    expect(result).not.toHaveProperty('module');
+    expect(result.stacktrace?.frames?.[0]?.filename).toBe('app.ts');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/shared/lib/diagnostics/sanitizeSentryEvent.ts
+++ b/src/shared/lib/diagnostics/sanitizeSentryEvent.ts
@@ -186,8 +186,13 @@ export const sanitizeExceptionValue = (excValue: SentryException): SentryExcepti
   const { value, type, mechanism, module, thread_id, stacktrace } = excValue;
 
   const safe: SentryException = {};
-  if (type !== undefined) safe.type = type;
-  if (module !== undefined) safe.module = module;
+  if (type !== undefined) {
+    safe.type = sanitizePrimitiveString(type, DEFAULT_MAX_STRING) ?? 'Error';
+  }
+  if (module !== undefined) {
+    const safeModule = sanitizePrimitiveString(module, DEFAULT_MAX_STRING);
+    if (safeModule !== undefined) safe.module = safeModule;
+  }
   if (thread_id !== undefined) safe.thread_id = thread_id;
 
   if (value !== undefined) {

--- a/src/shared/lib/diagnostics/sanitizeSentryEvent.ts
+++ b/src/shared/lib/diagnostics/sanitizeSentryEvent.ts
@@ -2,6 +2,7 @@ import type {
   ErrorEvent as SentryErrorEvent,
   Contexts as SentryContexts,
   User as SentryUser,
+  Exception as SentryException,
 } from '@sentry/vue';
 import { isSessionSentryUserId } from './sentrySession';
 import type { SentryReportingState } from './sentryRuntimeState';
@@ -11,6 +12,7 @@ import {
   isSensitiveValue,
   DEFAULT_MAX_STRING,
   sanitizeFlatRecord,
+  sanitizePrimitiveString,
 } from './privacySanitizer';
 
 // ---------------------------------------------------------------------------
@@ -128,6 +130,46 @@ export const sanitizeUser = (user: SentryUser | undefined): { id: string } | und
 };
 
 // ---------------------------------------------------------------------------
+// Exception value sanitization — scrubs sensitive messages from exception chain
+// ---------------------------------------------------------------------------
+
+const SANITIZED_PLACEHOLDER = '[sanitized]';
+
+/**
+ * Sanitizes a single exception entry's `value` (the error message).
+ * Replaces values that look like paths, URLs, emails, or storage keys with a placeholder.
+ * Keeps short safe strings such as user-facing `DomainError.message`.
+ * Preserves all other exception fields (type, stacktrace, mechanism).
+ * @param excValue - Sentry exception entry.
+ * @returns Exception entry with sanitized `value`.
+ */
+export const sanitizeExceptionValue = (excValue: SentryException): SentryException => {
+  if (excValue.value === undefined) return excValue;
+  const safe = sanitizePrimitiveString(excValue.value, DEFAULT_MAX_STRING);
+  if (safe === undefined) {
+    return { ...excValue, value: SANITIZED_PLACEHOLDER };
+  }
+  return { ...excValue, value: safe };
+};
+
+/**
+ * Sanitizes all exception values in the exception chain.
+ * Sentry serializes `error.cause` chains as additional linked exception entries.
+ * This ensures sensitive messages in nested causes are also scrubbed.
+ * @param exception - Sentry event exception container.
+ * @returns Exception container with sanitized values, or `undefined` when absent.
+ */
+export const sanitizeExceptionValues = (
+  exception: SentryErrorEvent['exception'],
+): SentryErrorEvent['exception'] => {
+  if (!exception?.values) return exception;
+  return {
+    ...exception,
+    values: exception.values.map(sanitizeExceptionValue),
+  };
+};
+
+// ---------------------------------------------------------------------------
 // Main sanitizer — used as Sentry beforeSend callback
 // ---------------------------------------------------------------------------
 
@@ -162,6 +204,7 @@ export { createBeforeBreadcrumb };
  * - Drops events when reporting is not enabled.
  * - Drops unhandled `WebFileSystemAccessRequiredError` events (surfaced separately as recovery UI).
  * - Strips `request` entirely.
+ * - Sanitizes exception value messages (the error message in Sentry's exception chain).
  * - Sanitizes breadcrumbs, contexts, user, tags, and extras using denylist-based filtering.
  * - Keeps a session-scoped `user.id`; strips all other user fields.
  * @param root0 - Factory parameters (`isVerbose` and `getState`).
@@ -176,6 +219,11 @@ export const createBeforeSend: BeforeSendFactory =
     const sanitized: SentryErrorEvent = { ...event };
 
     delete sanitized.request;
+
+    const safeException = sanitizeExceptionValues(event.exception);
+    if (safeException !== undefined) {
+      sanitized.exception = safeException;
+    }
 
     const safeBreadcrumbs = sanitizeTechnicalBreadcrumbs(event.breadcrumbs, isVerbose);
     if (safeBreadcrumbs !== undefined) {

--- a/src/shared/lib/diagnostics/sanitizeSentryEvent.ts
+++ b/src/shared/lib/diagnostics/sanitizeSentryEvent.ts
@@ -4,6 +4,9 @@ import type {
   User as SentryUser,
   Exception as SentryException,
 } from '@sentry/vue';
+
+type SentryMechanism = NonNullable<SentryException['mechanism']>;
+type SentryStacktrace = NonNullable<SentryException['stacktrace']>;
 import { isSessionSentryUserId } from './sentrySession';
 import type { SentryReportingState } from './sentryRuntimeState';
 import { createBeforeBreadcrumb, sanitizeTechnicalBreadcrumbs } from './technicalBreadcrumbs';
@@ -130,26 +133,77 @@ export const sanitizeUser = (user: SentryUser | undefined): { id: string } | und
 };
 
 // ---------------------------------------------------------------------------
-// Exception value sanitization — scrubs sensitive messages from exception chain
+// Exception entry sanitization — scrubs sensitive data from full exception entries
 // ---------------------------------------------------------------------------
 
 const SANITIZED_PLACEHOLDER = '[sanitized]';
 
 /**
- * Sanitizes a single exception entry's `value` (the error message).
- * Replaces values that look like paths, URLs, emails, or storage keys with a placeholder.
- * Keeps short safe strings such as user-facing `DomainError.message`.
- * Preserves all other exception fields (type, stacktrace, mechanism).
+ * Sanitizes mechanism fields, keeping structural metadata and dropping variable data.
+ * Preserves: type, handled, synthetic, source, exception_id, parent_id, is_exception_group.
+ * Drops: data and meta (may contain raw event targets, handler names, or provider details).
+ * @param mechanism - Sentry mechanism object.
+ * @returns Sanitized mechanism.
+ */
+export const sanitizeMechanism = (mechanism: SentryMechanism): SentryMechanism => {
+  const { type, handled, synthetic, source, exception_id, parent_id, is_exception_group } =
+    mechanism;
+  const safe: SentryMechanism = { type };
+  if (handled !== undefined) safe.handled = handled;
+  if (synthetic !== undefined) safe.synthetic = synthetic;
+  if (source !== undefined) safe.source = source;
+  if (exception_id !== undefined) safe.exception_id = exception_id;
+  if (parent_id !== undefined) safe.parent_id = parent_id;
+  if (is_exception_group !== undefined) safe.is_exception_group = is_exception_group;
+  return safe;
+};
+
+/**
+ * Sanitizes stacktrace by stripping per-frame variable bindings (`vars`), which may contain
+ * local variable values captured at throw time. Keeps all other frame fields intact.
+ * @param stacktrace - Sentry stacktrace object.
+ * @returns Sanitized stacktrace with `vars` removed from every frame.
+ */
+export const sanitizeStacktrace = (stacktrace: SentryStacktrace): SentryStacktrace => {
+  if (!stacktrace.frames) return stacktrace;
+  return {
+    ...stacktrace,
+    frames: stacktrace.frames.map(({ vars: _vars, ...rest }) => rest),
+  };
+};
+
+/**
+ * Sanitizes a single exception entry.
+ * - Replaces `value` (error message) when it looks like a path, URL, email, or storage key.
+ * - Strips `mechanism.data` and `mechanism.meta` (may carry raw event targets or provider text).
+ * - Strips `stacktrace.frames[].vars` (per-frame local variable bindings).
+ * - Drops custom enumerable exception fields not part of the standard interface.
+ * - Preserves: type, stacktrace frames (filename/function/lineno/colno), mechanism type/handled.
  * @param excValue - Sentry exception entry.
- * @returns Exception entry with sanitized `value`.
+ * @returns Sanitized exception entry.
  */
 export const sanitizeExceptionValue = (excValue: SentryException): SentryException => {
-  if (excValue.value === undefined) return excValue;
-  const safe = sanitizePrimitiveString(excValue.value, DEFAULT_MAX_STRING);
-  if (safe === undefined) {
-    return { ...excValue, value: SANITIZED_PLACEHOLDER };
+  const { value, type, mechanism, module, thread_id, stacktrace } = excValue;
+
+  const safe: SentryException = {};
+  if (type !== undefined) safe.type = type;
+  if (module !== undefined) safe.module = module;
+  if (thread_id !== undefined) safe.thread_id = thread_id;
+
+  if (value !== undefined) {
+    const safeValue = sanitizePrimitiveString(value, DEFAULT_MAX_STRING);
+    safe.value = safeValue !== undefined ? safeValue : SANITIZED_PLACEHOLDER;
   }
-  return { ...excValue, value: safe };
+
+  if (mechanism !== undefined) {
+    safe.mechanism = sanitizeMechanism(mechanism);
+  }
+
+  if (stacktrace !== undefined) {
+    safe.stacktrace = sanitizeStacktrace(stacktrace);
+  }
+
+  return safe;
 };
 
 /**

--- a/src/shared/lib/error/index.ts
+++ b/src/shared/lib/error/index.ts
@@ -8,7 +8,12 @@ export type SerializedDomainError<TCode extends PropertyKey = string> = {
   name: string;
   /** User-facing error message. */
   message: string;
-  /** Stable machine-readable error code. */
+  /**
+   * Stable machine-readable error code.
+   * New reportable `DomainError` instances must use a string enum value defined close to the
+   * boundary that detects the failure. Do not use ad hoc string literals.
+   * Legacy numeric codes (e.g. `HttpStatusCode`) are still accepted for backwards compatibility.
+   */
   code?: TCode | undefined;
   /** Original stack trace when available. */
   stack?: string | undefined;
@@ -22,16 +27,38 @@ export type SerializedDomainError<TCode extends PropertyKey = string> = {
 export type DomainErrorOptions<TCode extends PropertyKey = string> = {
   /** Underlying cause preserved for debugging. */
   cause?: unknown;
-  /** Stable machine-readable error code. */
+  /**
+   * Stable machine-readable error code.
+   * Prefer a string enum value defined close to the boundary that detects the failure.
+   * Do not use ad hoc string literals or a global error-code registry.
+   * Legacy numeric codes are still accepted for backwards compatibility.
+   */
   code?: TCode;
 };
 
 /**
  * Error type for user-facing domain failures with optional stable codes.
+ *
+ * **Message**: must be a safe user-facing string — no raw paths, names, ids, URLs,
+ * or external text. The Sentry sanitizer scrubs outgoing event data, but the message
+ * must be safe before it reaches any user-facing surface.
+ *
+ * **Code**: when present, should be a stable string enum value defined close to the
+ * detecting boundary (e.g. `RepositoryErrorCode.SaveFailed`). Do not use ad hoc
+ * string literals or a global error-code registry. Legacy numeric codes are still
+ * accepted by the type for backwards compatibility.
+ *
+ * **Cause**: may hold the raw runtime cause. Raw `cause` is allowed inside the app
+ * and across trusted proxy boundaries; it is scrubbed by the Sentry `beforeSend`
+ * sanitizer at the outgoing event boundary.
  */
 export class DomainError<TCode extends PropertyKey = string> extends Error {
   override name = 'DomainError';
   __isDomainError = true;
+  /**
+   * Stable code for this failure.
+   * Prefer a string enum value; numeric codes are legacy.
+   */
   code?: TCode | undefined;
 
   /**

--- a/src/shared/lib/virtualFileSystem/MemoryFileSystem.test.ts
+++ b/src/shared/lib/virtualFileSystem/MemoryFileSystem.test.ts
@@ -174,7 +174,38 @@ describe('MemoryFileSystem', () => {
     await expect(memoryFS.stat('/docs')).rejects.toMatchObject({
       code: FileSystemError.FileNotFound,
     });
+    await expect(memoryFS.stat('/docs/nested')).rejects.toMatchObject({
+      code: FileSystemError.FileNotFound,
+    });
+    await expect(memoryFS.stat('/docs/nested/file.txt')).rejects.toMatchObject({
+      code: FileSystemError.FileNotFound,
+    });
     await expect(memoryFS.readFile('/keep.txt').then((file) => file.text())).resolves.toBe('safe');
+  });
+
+  it('recursive delete removes all deeply nested files and directories', async () => {
+    await memoryFS.createDirectory('/root');
+    await memoryFS.createDirectory('/root/a');
+    await memoryFS.createDirectory('/root/a/b');
+    await memoryFS.writeFile('/root/a/b/deep.txt', 'deep', { create: true, overwrite: true });
+    await memoryFS.writeFile('/root/a/shallow.txt', 'shallow', { create: true, overwrite: true });
+    await memoryFS.writeFile('/root/top.txt', 'top', { create: true, overwrite: true });
+
+    await memoryFS.delete('/root', true);
+
+    for (const path of [
+      '/root',
+      '/root/a',
+      '/root/a/b',
+      '/root/a/b/deep.txt',
+      '/root/a/shallow.txt',
+      '/root/top.txt',
+    ]) {
+      // eslint-disable-next-line no-await-in-loop -- sequential to get distinct error per case
+      await expect(memoryFS.stat(path)).rejects.toMatchObject({
+        code: FileSystemError.FileNotFound,
+      });
+    }
   });
 
   it('rejects deletion of non-empty directories without recursive mode', async () => {

--- a/src/shared/lib/virtualFileSystem/MemoryFileSystem.test.ts
+++ b/src/shared/lib/virtualFileSystem/MemoryFileSystem.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { FSNodeType } from './IFileSystemProvider';
 import { MemoryFileSystem } from './MemoryFileSystem';
-import { FileSystemError } from './VfsError';
+import { FileSystemError, VfsError } from './VfsError';
 
 describe('MemoryFileSystem', () => {
   let memoryFS: MemoryFileSystem;
@@ -184,7 +184,9 @@ describe('MemoryFileSystem', () => {
       overwrite: true,
     });
 
-    await expect(memoryFS.delete('/docs', false)).rejects.toThrow('Directory not empty');
+    await expect(memoryFS.delete('/docs', false)).rejects.toMatchObject({
+      code: FileSystemError.DirectoryNotEmpty,
+    });
   });
 
   it('rejects deletion of the root directory', async () => {
@@ -234,6 +236,87 @@ describe('MemoryFileSystem', () => {
     await expect(memoryFS.move('/folder', '/folder/nested')).rejects.toMatchObject({
       code: FileSystemError.NotSupported,
     });
+  });
+
+  it('rejects deletion of non-empty directories with a typed VfsError and DirectoryNotEmpty code', async () => {
+    await memoryFS.createDirectory('/projects');
+    await memoryFS.writeFile('/projects/readme.md', 'hello', { create: true, overwrite: true });
+
+    await expect(memoryFS.delete('/projects', false)).rejects.toMatchObject({
+      code: FileSystemError.DirectoryNotEmpty,
+      name: 'VfsError',
+    });
+  });
+
+  it('VfsError messages do not contain raw path or name values', async () => {
+    const rawPath = '/secret/path/to/document';
+    const rawName = 'confidential-document-name';
+
+    await memoryFS.createDirectory('/data');
+    await memoryFS.writeFile('/data/file.txt', 'content', { create: true, overwrite: true });
+
+    const errors: VfsError[] = [];
+
+    // stat on missing entry
+    await memoryFS.stat(rawPath).catch((e: unknown) => {
+      if (e instanceof VfsError) errors.push(e);
+    });
+
+    // readDirectory on a file
+    await memoryFS.readDirectory('/data/file.txt').catch((e: unknown) => {
+      if (e instanceof VfsError) errors.push(e);
+    });
+
+    // createDirectory with missing parent
+    await memoryFS.createDirectory(`/missing/${rawName}`).catch((e: unknown) => {
+      if (e instanceof VfsError) errors.push(e);
+    });
+
+    // delete non-empty
+    await memoryFS.createDirectory('/nonempty');
+    await memoryFS.writeFile(`/nonempty/${rawName}`, 'x', { create: true, overwrite: true });
+    await memoryFS.delete('/nonempty', false).catch((e: unknown) => {
+      if (e instanceof VfsError) errors.push(e);
+    });
+
+    // move to missing parent
+    await memoryFS.move('/data', `/missing/${rawPath}/dest`).catch((e: unknown) => {
+      if (e instanceof VfsError) errors.push(e);
+    });
+
+    expect(errors.length).toBeGreaterThan(0);
+
+    for (const error of errors) {
+      expect(error.message).not.toContain(rawPath);
+      expect(error.message).not.toContain(rawName);
+      expect(error.message).not.toContain('/secret');
+      expect(error.message).not.toContain('confidential');
+    }
+  });
+
+  it('VfsError instances have stable FileSystemError codes', async () => {
+    await memoryFS.createDirectory('/dir');
+    await memoryFS.writeFile('/dir/file.txt', 'x', { create: true, overwrite: true });
+
+    const cases: Array<[Promise<unknown>, FileSystemError]> = [
+      [memoryFS.stat('/missing'), FileSystemError.FileNotFound],
+      [memoryFS.readDirectory('/dir/file.txt'), FileSystemError.FileNotADirectory],
+      [
+        memoryFS.writeFile('/dir/file.txt', 'y', { create: false, overwrite: false }),
+        FileSystemError.FileExists,
+      ],
+      [
+        memoryFS.writeFile('/missing/file.txt', 'y', { create: false, overwrite: true }),
+        FileSystemError.FileNotFound,
+      ],
+      [memoryFS.delete('/dir', false), FileSystemError.DirectoryNotEmpty],
+      [memoryFS.delete('/', true), FileSystemError.NoPermissions],
+    ];
+
+    for (const [promise, expectedCode] of cases) {
+      // eslint-disable-next-line no-await-in-loop -- sequential to get distinct error per case
+      await expect(promise).rejects.toMatchObject({ code: expectedCode });
+    }
   });
 
   it('treats a move to the same normalized path as a no-op', async () => {

--- a/src/shared/lib/virtualFileSystem/MemoryFileSystem.ts
+++ b/src/shared/lib/virtualFileSystem/MemoryFileSystem.ts
@@ -296,7 +296,7 @@ export class MemoryFileSystem implements IFileSystemProvider {
               );
             }
 
-            toDelete.add(path);
+            toDelete.add(storedPath);
           }
         }
         toDelete.forEach((key) => this.store.delete(key));

--- a/src/shared/lib/virtualFileSystem/MemoryFileSystem.ts
+++ b/src/shared/lib/virtualFileSystem/MemoryFileSystem.ts
@@ -280,7 +280,9 @@ export class MemoryFileSystem implements IFileSystemProvider {
       }
 
       if (hasChildren && !recursive) {
-        return Promise.reject(new Error('Directory not empty'));
+        return Promise.reject(
+          new VfsError(FileSystemError.DirectoryNotEmpty, 'Directory is not empty.'),
+        );
       }
 
       if (hasChildren && recursive) {

--- a/src/shared/lib/virtualFileSystem/VirtualFileSystem.test.ts
+++ b/src/shared/lib/virtualFileSystem/VirtualFileSystem.test.ts
@@ -558,7 +558,9 @@ describe('VirtualFileSystem', () => {
       vfs.mount('/mnt/test', memoryFS);
 
       // This should fail
-      await expect(vfs.delete('/mnt/test/testdir', false)).rejects.toThrow(/Directory not empty/);
+      await expect(vfs.delete('/mnt/test/testdir', false)).rejects.toMatchObject({
+        code: FileSystemError.DirectoryNotEmpty,
+      });
     });
 
     it('should handle delete with invalid paths gracefully', async () => {

--- a/src/shared/lib/webFileSystemProvider/WebFileSystemProvider.test.ts
+++ b/src/shared/lib/webFileSystemProvider/WebFileSystemProvider.test.ts
@@ -926,7 +926,7 @@ describe('WebFileSystemProvider', () => {
 
     await expect(provider.move('/missing.txt', '/Archive/missing.txt')).rejects.toMatchObject({
       code: 'ENOENT',
-      message: 'Source not found: /missing.txt',
+      message: 'Source not found.',
       name: 'VfsError',
     });
   });

--- a/src/shared/lib/webFileSystemProvider/WebFileSystemProvider.ts
+++ b/src/shared/lib/webFileSystemProvider/WebFileSystemProvider.ts
@@ -266,10 +266,7 @@ export const WebFileSystemProvider = (
         });
       } catch (error) {
         if (error instanceof DOMException && error.name === 'NotFoundError') {
-          throw new VfsError(
-            FileSystemError.FileNotFound,
-            `Directory not found: ${part} in ${path}`,
-          );
+          throw new VfsError(FileSystemError.FileNotFound, 'Directory not found.');
         }
         throw error;
       }
@@ -284,12 +281,12 @@ export const WebFileSystemProvider = (
     } catch (error) {
       if (error instanceof DOMException) {
         if (error.name === 'NotFoundError') {
-          throw new VfsError(FileSystemError.FileNotFound, `Entry not found: ${name}`, error);
+          throw new VfsError(FileSystemError.FileNotFound, 'Entry not found.', error);
         }
         if (error.name === 'TypeMismatchError') {
           throw new VfsError(
             type === 'file' ? FileSystemError.FileIsADirectory : FileSystemError.FileNotADirectory,
-            `Type mismatch for: ${name}`,
+            'Type mismatch.',
             error,
           );
         }
@@ -366,7 +363,7 @@ export const WebFileSystemProvider = (
         };
       } catch (directoryError) {
         if (isLookupMiss(directoryError, FileSystemError.FileNotADirectory)) {
-          throw new VfsError(FileSystemError.FileNotFound, `Path not found: ${path}`);
+          throw new VfsError(FileSystemError.FileNotFound, 'Path not found.');
         }
         throw directoryError;
       }
@@ -488,7 +485,7 @@ export const WebFileSystemProvider = (
     await ensureAccess('readwrite');
     try {
       await getHandle(path, false, 'directory');
-      throw new VfsError(FileSystemError.FileExists, `Directory already exists: ${path}`);
+      throw new VfsError(FileSystemError.FileExists, 'Directory already exists.');
     } catch (error) {
       if (!(error instanceof VfsError && error.code === FileSystemError.FileNotFound)) {
         throw error;
@@ -505,10 +502,7 @@ export const WebFileSystemProvider = (
     const { stat: nodeStat } = await lookupPath(normalized);
 
     if (nodeStat.capabilities?.canDelete === false) {
-      throw new VfsError(
-        FileSystemError.NoPermissions,
-        `Deletion is not allowed for path: ${path}`,
-      );
+      throw new VfsError(FileSystemError.NoPermissions, 'Deletion is not allowed.');
     }
 
     const parts = normalized.split('/').filter((part) => part.length > 0);
@@ -526,7 +520,7 @@ export const WebFileSystemProvider = (
     } catch (error) {
       if (error instanceof DOMException) {
         if (error.name === 'NotFoundError') {
-          throw new VfsError(FileSystemError.FileNotFound, `Entry not found: ${path}`);
+          throw new VfsError(FileSystemError.FileNotFound, 'Entry not found.');
         }
         if (error.name === 'InvalidModificationError') {
           throw new VfsError(
@@ -554,16 +548,13 @@ export const WebFileSystemProvider = (
       ({ handle: sourceHandle, stat: sourceStat } = await lookupPath(normalizedOld));
     } catch (error) {
       if (error instanceof VfsError && error.code === FileSystemError.FileNotFound) {
-        throw new VfsError(FileSystemError.FileNotFound, `Source not found: ${oldPath}`);
+        throw new VfsError(FileSystemError.FileNotFound, 'Source not found.');
       }
       throw error;
     }
 
     if (sourceStat.capabilities?.canChangePath === false) {
-      throw new VfsError(
-        FileSystemError.NoPermissions,
-        `Path change is not allowed for path: ${oldPath}`,
-      );
+      throw new VfsError(FileSystemError.NoPermissions, 'Path change is not allowed.');
     }
 
     const newName = PathUtils.basename(normalizedNew);
@@ -571,17 +562,11 @@ export const WebFileSystemProvider = (
     const { handle: destinationHandle, stat: destinationStat } = await lookupPath(newDirName);
 
     if (destinationHandle.kind !== 'directory') {
-      throw new VfsError(
-        FileSystemError.FileNotADirectory,
-        `Type mismatch for: ${PathUtils.basename(newDirName)}`,
-      );
+      throw new VfsError(FileSystemError.FileNotADirectory, 'Type mismatch.');
     }
 
     if (destinationStat.capabilities?.canEditChildren === false) {
-      throw new VfsError(
-        FileSystemError.NoPermissions,
-        `Path change is not allowed inside directory: ${newDirName}`,
-      );
+      throw new VfsError(FileSystemError.NoPermissions, 'Path change is not allowed.');
     }
 
     const destinationDirHandle = destinationHandle;

--- a/src/shared/lib/wrapWorker/workerTransformerMap.test.ts
+++ b/src/shared/lib/wrapWorker/workerTransformerMap.test.ts
@@ -6,7 +6,9 @@ import {
   WebFileSystemAccessRequiredError,
 } from '@shared/lib/webFileSystemProvider';
 import { getFileSystemAccessRecovery } from '@shared/lib/fileSystem';
+import { FileSystemError, VfsError } from '@shared/lib/virtualFileSystem';
 import type { VfsActivityState } from '@shared/lib/virtualFileSystem';
+import { DomainError } from '@shared/lib/error';
 import { transformers } from './workerTransformerMap';
 
 class MockProvider {
@@ -62,6 +64,10 @@ const createChannel = (clientId: string, serviceId: string) => {
   return { clientProvider, serviceProvider };
 };
 
+enum TestErrorCode {
+  TestFailure = 'test.failure',
+}
+
 describe('workerTransformerMap', () => {
   it('reconstructs WebFileSystemAccessRequiredError across the service boundary', async () => {
     const serviceId = uid();
@@ -93,6 +99,71 @@ describe('workerTransformerMap', () => {
       expect(getFileSystemAccessRecovery(error, { operation: 'write' })).toEqual({
         operation: 'write',
         spaceName: 'Work',
+      });
+      return true;
+    });
+  });
+
+  it('reconstructs DomainError across the service boundary with message, code, cause, and name intact', async () => {
+    const serviceId = uid();
+    const clientId = uid();
+    const { clientProvider, serviceProvider } = createChannel(clientId, serviceId);
+
+    const originalCause = new Error('ENOENT: no such file or directory, mkdir /private/Examples');
+
+    createService(serviceProvider, serviceId, transformers, () => ({
+      fail: () => {
+        throw new DomainError('Could not create example', {
+          code: TestErrorCode.TestFailure,
+          cause: originalCause,
+        });
+      },
+    }));
+
+    const client = createClient<{ fail: () => Promise<void> }>(
+      clientProvider,
+      clientId,
+      transformers,
+    );
+
+    await expect(client.fail()).rejects.toSatisfy((error: unknown) => {
+      expect(error).toBeInstanceOf(DomainError);
+      expect(error).toMatchObject({
+        name: 'DomainError',
+        message: 'Could not create example',
+        code: TestErrorCode.TestFailure,
+      });
+      if (!(error instanceof DomainError)) return true;
+      expect(error.cause).toMatchObject({ message: originalCause.message });
+      return true;
+    });
+  });
+
+  it('reconstructs VfsError with code, message, and cause across the service boundary', async () => {
+    const serviceId = uid();
+    const clientId = uid();
+    const { clientProvider, serviceProvider } = createChannel(clientId, serviceId);
+
+    const rawCause = new DOMException('NotFoundError');
+
+    createService(serviceProvider, serviceId, transformers, () => ({
+      fail: () => {
+        throw new VfsError(FileSystemError.FileNotFound, 'Entry not found.', rawCause);
+      },
+    }));
+
+    const client = createClient<{ fail: () => Promise<void> }>(
+      clientProvider,
+      clientId,
+      transformers,
+    );
+
+    await expect(client.fail()).rejects.toSatisfy((error: unknown) => {
+      expect(error).toBeInstanceOf(VfsError);
+      expect(error).toMatchObject({
+        name: 'VfsError',
+        message: 'Entry not found.',
+        code: FileSystemError.FileNotFound,
       });
       return true;
     });


### PR DESCRIPTION
… safe messages

- ensure that all errors during example document creation are reported as DomainErrors
- preserve raw causes for debugging while sanitizing sensitive information for diagnostics
- implement stable error codes for different failure scenarios
- enhance tests to verify error handling and reporting behavior