### PR TITLE
fix(vfs): improve file loading logic for v2 and legacy formats

### DIFF
--- a/src/shared/lib/automergeAdapter/createVFSAdapter.test.ts
+++ b/src/shared/lib/automergeAdapter/createVFSAdapter.test.ts
@@ -95,6 +95,80 @@ describe('createVFSAdapter – load reads legacy files', () => {
 
     expect(result).toBeUndefined();
   });
+
+  it('reads a v2 full-key file directly without scanning the directory', async () => {
+    const { vfs, path } = await setupVfs();
+    const docId = getDocumentId();
+    const v2Name = requireV2Name(docId, 'snapshot', HASH_A);
+    await vfs.writeFile(`${path}/${v2Name}`, DATA_A);
+    const readDirectorySpy = vi.spyOn(vfs, 'readDirectory');
+
+    const adapter = createVFSAdapter(vfs, path);
+    const result = await adapter.load([docId, 'snapshot', HASH_A]);
+
+    expect(result).toEqual(DATA_A);
+    expect(readDirectorySpy).not.toHaveBeenCalled();
+  });
+
+  it('reads a legacy full-key file directly without scanning when v2 is missing', async () => {
+    const { vfs, path } = await setupVfs();
+    const docId = getDocumentId();
+    const legacyName = `${docId}_snapshot_${HASH_A}.automerge`;
+    await vfs.writeFile(`${path}/${legacyName}`, DATA_A);
+    const readDirectorySpy = vi.spyOn(vfs, 'readDirectory');
+
+    const adapter = createVFSAdapter(vfs, path);
+    const result = await adapter.load([docId, 'snapshot', HASH_A]);
+
+    expect(result).toEqual(DATA_A);
+    expect(readDirectorySpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the directory scan when direct v2 and legacy reads miss', async () => {
+    const { vfs, path } = await setupVfs();
+    const docId = getDocumentId();
+    const scanOnlyLegacyName = `${docId}_snapshot_${HASH_A}`;
+    const readDirectorySpy = vi.spyOn(vfs, 'readDirectory');
+    const readFileSpy = vi.spyOn(vfs, 'readFile');
+    await vfs.writeFile(`${path}/${scanOnlyLegacyName}`, DATA_A);
+
+    const adapter = createVFSAdapter(vfs, path);
+    const result = await adapter.load([docId, 'snapshot', HASH_A]);
+
+    expect(result).toEqual(DATA_A);
+    expect(readDirectorySpy).toHaveBeenCalledTimes(1);
+    expect(readFileSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it('prefers v2 data over legacy when both direct paths exist for the same full key', async () => {
+    const { vfs, path } = await setupVfs();
+    const docId = getDocumentId();
+    const v2Name = requireV2Name(docId, 'snapshot', HASH_A);
+    const legacyName = `${docId}_snapshot_${HASH_A}.automerge`;
+    const v2Data = new Uint8Array([40, 50, 60]);
+    const legacyData = new Uint8Array([10, 20, 30]);
+    await vfs.writeFile(`${path}/${legacyName}`, legacyData);
+    await vfs.writeFile(`${path}/${v2Name}`, v2Data);
+    const readDirectorySpy = vi.spyOn(vfs, 'readDirectory');
+
+    const adapter = createVFSAdapter(vfs, path);
+    const result = await adapter.load([docId, 'snapshot', HASH_A]);
+
+    expect(result).toEqual(v2Data);
+    expect(readDirectorySpy).not.toHaveBeenCalled();
+  });
+
+  it('still discovers externally created files through the fallback scan path', async () => {
+    const { vfs, path } = await setupVfs();
+    const docId = getDocumentId();
+    const scanOnlyLegacyName = `${docId}_snapshot_${HASH_A}`;
+    await vfs.writeFile(`${path}/${scanOnlyLegacyName}`, DATA_A);
+
+    const adapter = createVFSAdapter(vfs, path);
+    const result = await adapter.load([docId, 'snapshot', HASH_A]);
+
+    expect(result).toEqual(DATA_A);
+  });
 });
 
 describe('createVFSAdapter – loadRange handles both legacy and v2 files', () => {

--- a/src/shared/lib/automergeAdapter/createVFSAdapter.test.ts
+++ b/src/shared/lib/automergeAdapter/createVFSAdapter.test.ts
@@ -110,21 +110,23 @@ describe('createVFSAdapter – load reads legacy files', () => {
     expect(readDirectorySpy).not.toHaveBeenCalled();
   });
 
-  it('reads a legacy full-key file directly without scanning when v2 is missing', async () => {
+  it('falls back to the directory scan when direct v2 read misses and only a legacy file exists', async () => {
     const { vfs, path } = await setupVfs();
     const docId = getDocumentId();
     const legacyName = `${docId}_snapshot_${HASH_A}.automerge`;
     await vfs.writeFile(`${path}/${legacyName}`, DATA_A);
     const readDirectorySpy = vi.spyOn(vfs, 'readDirectory');
+    const readFileSpy = vi.spyOn(vfs, 'readFile');
 
     const adapter = createVFSAdapter(vfs, path);
     const result = await adapter.load([docId, 'snapshot', HASH_A]);
 
     expect(result).toEqual(DATA_A);
-    expect(readDirectorySpy).not.toHaveBeenCalled();
+    expect(readDirectorySpy).toHaveBeenCalledTimes(1);
+    expect(readFileSpy).toHaveBeenCalledTimes(2);
   });
 
-  it('falls back to the directory scan when direct v2 and legacy reads miss', async () => {
+  it('falls back to the directory scan when direct v2 read misses', async () => {
     const { vfs, path } = await setupVfs();
     const docId = getDocumentId();
     const scanOnlyLegacyName = `${docId}_snapshot_${HASH_A}`;
@@ -137,7 +139,7 @@ describe('createVFSAdapter – load reads legacy files', () => {
 
     expect(result).toEqual(DATA_A);
     expect(readDirectorySpy).toHaveBeenCalledTimes(1);
-    expect(readFileSpy).toHaveBeenCalledTimes(3);
+    expect(readFileSpy).toHaveBeenCalledTimes(2);
   });
 
   it('prefers v2 data over legacy when both direct paths exist for the same full key', async () => {
@@ -168,6 +170,22 @@ describe('createVFSAdapter – load reads legacy files', () => {
     const result = await adapter.load([docId, 'snapshot', HASH_A]);
 
     expect(result).toEqual(DATA_A);
+  });
+
+  it('keeps legacy duplicate tie-break behavior on the scan path when v2 is missing', async () => {
+    const { vfs, path } = await setupVfs();
+    const docId = getDocumentId();
+    const legacyNameWithExtension = `${docId}_snapshot_${HASH_A}.automerge`;
+    const legacyNameWithoutExtension = `${docId}_snapshot_${HASH_A}`;
+    await vfs.writeFile(`${path}/${legacyNameWithExtension}`, DATA_A);
+    await vfs.writeFile(`${path}/${legacyNameWithoutExtension}`, DATA_B);
+    const readDirectorySpy = vi.spyOn(vfs, 'readDirectory');
+
+    const adapter = createVFSAdapter(vfs, path);
+    const result = await adapter.load([docId, 'snapshot', HASH_A]);
+
+    expect(result).toEqual(DATA_A);
+    expect(readDirectorySpy).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/shared/lib/automergeAdapter/createVFSAdapter.ts
+++ b/src/shared/lib/automergeAdapter/createVFSAdapter.ts
@@ -3,6 +3,7 @@ import type { AMChunk } from '@shared/lib/automerge';
 import { isStandardBufferView } from '@shared/lib/isStandardBufferView';
 import { FileSystemError, PathUtils, type VirtualFileSystem, VfsError } from '../virtualFileSystem';
 import type { PartialStorageKey, StorageKey } from './types';
+import { encodeStorageKeyToV2FileName } from './filenameCodecV2';
 import {
   listStorageFileEntries,
   selectReadableStorageEntries,
@@ -10,7 +11,6 @@ import {
   storageKeyToId,
   toWritableStorageFileName,
 } from './storageKeyHelpers';
-import { partialKeyToFileName } from './partialKeyToFileName';
 
 /**
  * Creates an Automerge storage adapter backed by a VirtualFileSystem path.
@@ -44,23 +44,14 @@ export const createVFSAdapter = (vfs: VirtualFileSystem, path: string): StorageA
 
   const load = async (key: PartialStorageKey): Promise<Uint8Array | undefined> => {
     if (key.length === 3) {
-      const v2Name = toWritableStorageFileName(key);
+      const [documentId, kind, hash] = key;
+      const v2Name = encodeStorageKeyToV2FileName(documentId, kind, hash);
 
       if (v2Name) {
         const v2Data = await tryReadDirectFile(v2Name);
 
         if (v2Data) {
           return v2Data;
-        }
-      }
-
-      const legacyName = partialKeyToFileName(key);
-
-      if (legacyName && legacyName !== v2Name) {
-        const legacyData = await tryReadDirectFile(legacyName);
-
-        if (legacyData) {
-          return legacyData;
         }
       }
     }

--- a/src/shared/lib/automergeAdapter/createVFSAdapter.ts
+++ b/src/shared/lib/automergeAdapter/createVFSAdapter.ts
@@ -10,6 +10,7 @@ import {
   storageKeyToId,
   toWritableStorageFileName,
 } from './storageKeyHelpers';
+import { partialKeyToFileName } from './partialKeyToFileName';
 
 /**
  * Creates an Automerge storage adapter backed by a VirtualFileSystem path.
@@ -27,7 +28,43 @@ export const createVFSAdapter = (vfs: VirtualFileSystem, path: string): StorageA
     return selectReadableStorageEntries(directoryContent.map(([name]) => name));
   };
 
+  const tryReadDirectFile = async (name: string): Promise<Uint8Array | undefined> => {
+    try {
+      const file = await vfs.readFile(PathUtils.join(path, name));
+
+      return new Uint8Array(await file.arrayBuffer());
+    } catch (error) {
+      if (error instanceof VfsError && error.code === FileSystemError.FileNotFound) {
+        return undefined;
+      }
+
+      throw error;
+    }
+  };
+
   const load = async (key: PartialStorageKey): Promise<Uint8Array | undefined> => {
+    if (key.length === 3) {
+      const v2Name = toWritableStorageFileName(key);
+
+      if (v2Name) {
+        const v2Data = await tryReadDirectFile(v2Name);
+
+        if (v2Data) {
+          return v2Data;
+        }
+      }
+
+      const legacyName = partialKeyToFileName(key);
+
+      if (legacyName && legacyName !== v2Name) {
+        const legacyData = await tryReadDirectFile(legacyName);
+
+        if (legacyData) {
+          return legacyData;
+        }
+      }
+    }
+
     const allEntries = await listDeduplicatedEntries();
     const keyId = storageKeyToId(key);
     const matched = allEntries.get(keyId);
@@ -36,9 +73,7 @@ export const createVFSAdapter = (vfs: VirtualFileSystem, path: string): StorageA
       return undefined;
     }
 
-    const file = await vfs.readFile(PathUtils.join(path, matched.name));
-
-    return new Uint8Array(await file.arrayBuffer());
+    return tryReadDirectFile(matched.name);
   };
 
   const loadRange = async (keyPrefix: PartialStorageKey): Promise<AMChunk[]> => {


### PR DESCRIPTION
- add direct v2 read path for full Automerge storage keys
- fall back to existing directory scan/dedupe when v2 is missing
- preserve legacy duplicate resolution semantics