### PR TITLE
docs(agents): add architecture handoff guidance and PR template

### DIFF
--- a/.agents/skills/architect-handoff/SKILL.md
+++ b/.agents/skills/architect-handoff/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: architect-handoff
+description: 'Use this skill for non-trivial work to define the architecture handoff contract that links architecture discussion, agent tasks, implementation preflight, implementation, PR description, and final review.'
+---
+
+# Architecture handoff
+
+Use this skill before non-trivial implementation, workflow, shared UI, storage, diagnostics, Material, or cross-layer changes. The handoff is the implementation contract and must not be silently replaced by a different architecture during coding or review.
+
+## When to use
+
+Use this skill when the task changes or clarifies any of these:
+
+- product or feature behavior with multiple user scenarios;
+- cross-layer ownership or FSD boundaries;
+- shared UI primitives or consumer-visible blast radius;
+- storage, service, worker, diagnostics, or workflow contracts;
+- Material patterns or UI composition with architecture consequences;
+- task scope that spans more than one owner or requires pass order.
+
+## When it may be skipped
+
+You may skip this skill only for clearly bounded trivial work such as:
+
+- typo, comment, or formatting-only edits;
+- mechanical renames with no ownership or behavior change;
+- docs-only edits that do not define or alter workflow contracts;
+- narrow fixes where ownership, source of truth, final state, and verification are already explicit and unchanged.
+
+If you skip it, be able to state why no architecture contract is needed.
+
+## Required handoff structure
+
+Record the handoff with these fields:
+
+- Goal
+- Non-goals
+- Affected user scenarios
+- Boundaries: what changes and what must not be touched
+- Ownership matrix:
+  - feature
+  - entity
+  - widget
+  - page/pane
+  - shared
+  - service/worker
+- Source of truth
+- State shape
+- Public API / entry points
+- Rejected approaches
+- Shared UI blast radius
+- Acceptance matrix
+- Risk matrix
+- Required verification
+- Forbidden
+
+Keep the handoff concrete. Prefer specific owners, explicit preserved scenarios, and named entry points over generic architecture language.
+
+## Stop conditions before implementation
+
+Stop before production edits when any of these are true:
+
+- ownership is unclear;
+- source of truth is unclear;
+- expected final state is unclear;
+- more than two architecture questions are unresolved;
+- shared UI would be changed only to patch one feature without blast-radius review;
+- the task combines unrelated domains without an explicit pass order.
+
+When blocked, resolve the handoff first. Do not patch forward and hope review will reconcile the architecture later.
+
+## Implementation contract
+
+- Treat the handoff as upstream input for agent tasking, implementation preflight, coding, PR description, and final review.
+- Restate only the implementation-relevant decisions in downstream steps; do not rewrite the architecture into a different plan.
+- If new facts invalidate the handoff, stop and update the handoff explicitly before continuing.
+- Do not silently replace rejected approaches, move ownership, or expand touched boundaries during implementation.
+
+## Review contract after implementation
+
+Review the full implemented feature against the architecture handoff.
+
+- Do not review only the latest fix or latest changed files.
+- Check goal, non-goals, affected scenarios, ownership, dependency direction, state shape, API shape, public contracts, shared UI blast radius, verification coverage, simplicity, and future safety.
+- Preserve all unresolved findings in one consolidated list instead of dropping earlier blockers when new issues appear.
+- If repeated review rounds show ownership drift or mixed responsibilities, stop patching and redo the architecture handoff.
+
+## Output discipline
+
+Keep the handoff concise but complete. The handoff should create concrete agent behavior, not broad generic process language.

--- a/.agents/skills/architect-handoff/SKILL.md
+++ b/.agents/skills/architect-handoff/SKILL.md
@@ -29,6 +29,16 @@ You may skip this skill only for clearly bounded trivial work such as:
 
 If you skip it, be able to state why no architecture contract is needed.
 
+## Token budget
+
+Keep the handoff compact.
+
+- Prefer short bullet points over prose.
+- For small but non-trivial tasks, the handoff should usually fit in 20-40 lines.
+- Do not expand stable repository rules, FSD explanations, or Material rules unless they are directly relevant to the decision.
+- Use `N/A` for genuinely not applicable sections.
+- Do not create an architecture handoff for trivial single-file mechanical changes when ownership, source of truth, and final state are obvious.
+
 ## Required handoff structure
 
 Record the handoff with these fields:

--- a/.agents/skills/implementation-preflight/SKILL.md
+++ b/.agents/skills/implementation-preflight/SKILL.md
@@ -17,6 +17,7 @@ Do not use this skill for trivial typo fixes, formatting-only changes, comments-
 
 Answer these before the first production edit:
 
+0. **Upstream handoff check**: if the task includes an architecture handoff, restate only the implementation-relevant decisions, verify the planned edits match that handoff, and do not replace it with a different architecture. If a non-trivial task has no handoff and ownership, source of truth, or expected final state is unclear, stop before production edits.
 1. **Owner map**: identify source of truth, runtime owner, user-action owner, UI composition owner, error owner, retry/navigation owner, and verification owner when they apply.
 2. **Public entry points**: which FSD layer owns the behavior, and which public APIs should be used instead of deep imports?
 3. **Reuse**: what existing helpers, components, configs, schemas, services, tests, or dependencies already cover nearby behavior?
@@ -137,3 +138,5 @@ The first implementation should cover the applicable matrix, not only the happy 
 Keep the preflight concise. A useful preflight is usually 5-10 lines plus a short verification note.
 
 Do not repeat generic repository rules. Name only the rules and risks that apply to the current task.
+
+Before final handoff, report whether the resulting diff still matches the architecture handoff when one exists. If it does not, fix the implementation or explicitly report the architectural divergence.

--- a/.agents/skills/implementation-preflight/SKILL.md
+++ b/.agents/skills/implementation-preflight/SKILL.md
@@ -17,7 +17,7 @@ Do not use this skill for trivial typo fixes, formatting-only changes, comments-
 
 Answer these before the first production edit:
 
-0. **Upstream handoff check**: if the task includes an architecture handoff, restate only the implementation-relevant decisions, verify the planned edits match that handoff, and do not replace it with a different architecture. If a non-trivial task has no handoff and ownership, source of truth, or expected final state is unclear, stop before production edits.
+0. **Upstream handoff check**: if the task includes an architecture handoff, do not repeat the full handoff. Restate only the decisions that affect the planned edits, verify the planned edits match that handoff, and do not replace it with a different architecture. If a non-trivial task has no handoff and ownership, source of truth, or expected final state is unclear, stop before production edits.
 1. **Owner map**: identify source of truth, runtime owner, user-action owner, UI composition owner, error owner, retry/navigation owner, and verification owner when they apply.
 2. **Public entry points**: which FSD layer owns the behavior, and which public APIs should be used instead of deep imports?
 3. **Reuse**: what existing helpers, components, configs, schemas, services, tests, or dependencies already cover nearby behavior?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Architecture Decision
+
+## Ownership Matrix
+
+- feature:
+- entity:
+- widget:
+- page/pane:
+- shared:
+- service/worker:
+
+## User Scenarios Preserved
+
+## Shared UI / Blast Radius
+
+## Verification
+
+- Focused:
+- Full:
+
+## Known Risks
+
+## Reviewer Notes

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+<!-- Keep sections concise. Use N/A when a section is not applicable. -->
+
 ## Architecture Decision
 
 ## Ownership Matrix

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,10 @@
 - shared:
 - service/worker:
 
+## Source of Truth
+
+## State Shape / API Contract
+
 ## User Scenarios Preserved
 
 ## Shared UI / Blast Radius

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,9 @@ reason:
 
 - Prefer plan-first implementation over broad discovery.
 - Before broad repository exploration, use ByteRover local search to recall prior project decisions; use synthesized queries only when search results are insufficient.
+- For non-trivial product, feature, cross-layer, shared UI, storage, diagnostics, Material, workflow, or architecture changes, start from an explicit architecture handoff before implementation and use the `architect-handoff` skill.
+- The architecture handoff must cover goal, non-goals, affected scenarios, ownership matrix, source of truth, state/API shape, rejected approaches, acceptance matrix, risk matrix, required verification, and forbidden paths.
+- Treat the architecture handoff as the contract for agent tasks, implementation preflight, implementation, and PR review. If implementation details contradict the handoff, stop and resolve the mismatch instead of silently choosing a different architecture.
 - Use the `implementation-preflight` skill before non-trivial implementation work to identify owner boundaries, reuse opportunities, acceptance matrix, risk matrix, and focused verification before the first production edit.
 - Before editing, identify the smallest affected FSD owner layer and read only task-relevant files plus direct imports unless the task proves wider impact.
 - For cross-layer changes, write a compact owner map before production edits: source of truth, runtime owner, user-action owner, UI composition owner, error owner, retry/navigation owner, and verification owner. If any owner is unclear, stop and resolve the architecture before editing.
@@ -129,6 +132,9 @@ reason:
 ## Implementation quality gates
 
 - Treat implementation preflight as a contract, not a planning note. Before final verification, compare the resulting diff against the preflight owner-layer plan, acceptance matrix, and risk matrix. If the diff violates the plan, either refactor it or explicitly report the remaining risk instead of claiming completion.
+- Review the complete implemented feature against the architecture handoff, not only the latest requested fix or the files changed in the last iteration.
+- Preserve known unresolved findings in one consolidated list. Do not drop earlier blockers when new issues are found.
+- A PR is not ready if it only satisfies the latest coding task but still violates the feature-level goal, ownership matrix, user scenarios, public contracts, or shared UI blast-radius constraints from the architecture handoff.
 - For cross-layer changes, final handoff must include a short architecture check: owner map respected, dependency direction respected, no page-owned domain flow, no capability leak in UI records, errors defined at the detecting boundary, and no duplicate data reads for the same state.
 - Preserve existing user scenarios unless the task explicitly removes them. When replacing a menu, navigation control, status indicator, or shared surface, list the old user actions it provided and ensure they are still reachable or intentionally removed by the task.
 - Do not treat a green `pnpm verify` as architectural approval. Verification proves that automated checks passed; it does not prove FSD ownership, Material correctness, browser behavior, accessibility, or UX acceptance unless those checks were actually covered.


### PR DESCRIPTION
- introduce the `architect-handoff` skill for non-trivial changes
- outline required handoff structure and stop conditions before implementation
- create a pull request template to ensure architecture decisions are documented