### PR TITLE
fix(vfs): remove DOMException code from error details in diagnostics

### DIFF
--- a/src/features/vfsActivityStatus/saveStatusText.test.ts
+++ b/src/features/vfsActivityStatus/saveStatusText.test.ts
@@ -68,13 +68,18 @@ describe('saveStatusText', () => {
   });
 
   it('formats a generic DomainError chain with DOMException details when present', () => {
+    const domException = new DOMException('The handle became invalid', 'InvalidStateError');
+    Object.defineProperty(domException, 'code', {
+      configurable: true,
+      value: 11,
+    });
     const copied = formatSaveStatusErrorDetails({
       operationType: 'writeFile',
       path: '/private/project/secret.txt',
       message: 'safe message only',
       cause: new DomainError('Could not start writing to this storage location.', {
         code: 'web-file-system-write-start-failed',
-        cause: new DOMException('The handle became invalid', 'InvalidStateError'),
+        cause: domException,
       }),
       occurredAt: 1_700_000_000_003,
       acknowledged: false,
@@ -86,6 +91,7 @@ describe('saveStatusText', () => {
     expect(copied).toContain('Cause class: DOMException');
     expect(copied).toContain('Browser error name: InvalidStateError');
     expect(copied).toContain('Browser error message: The handle became invalid');
+    expect(copied).not.toContain('Browser error code:');
     expect(copied).not.toContain('/private/project/secret.txt');
   });
 

--- a/src/features/vfsActivityStatus/saveStatusText.ts
+++ b/src/features/vfsActivityStatus/saveStatusText.ts
@@ -49,12 +49,6 @@ const formatDomExceptionCauseDetails = (error: unknown): string[] => {
   }
 
   const lines = [`Browser error name: ${error.name}`];
-  const rawCode = Reflect.get(error, 'code');
-
-  if (typeof rawCode === 'number' && Number.isFinite(rawCode)) {
-    lines.push(`Browser error code: ${rawCode}`);
-  }
-
   const safeMessage = sanitizePrimitiveString(error.message);
   if (safeMessage !== undefined) {
     lines.push(`Browser error message: ${safeMessage}`);

--- a/src/shared/service/fileSystem/webFileSystemWriteDiagnostics.test.ts
+++ b/src/shared/service/fileSystem/webFileSystemWriteDiagnostics.test.ts
@@ -96,7 +96,6 @@ describe('webFileSystemWriteDiagnostics', () => {
         classification: 'web-file-system-write-start-failed',
         errorClass: 'DOMException',
         domException: 'InvalidStateError',
-        domExceptionCode: 11,
         errorDetail: 'The handle became invalid',
       },
       level: 'warning',
@@ -141,7 +140,6 @@ describe('webFileSystemWriteDiagnostics', () => {
       'classification',
       'errorClass',
       'domException',
-      'domExceptionCode',
       'errorDetail',
     ]);
     for (const key of Object.keys(data)) {
@@ -186,8 +184,24 @@ describe('webFileSystemWriteDiagnostics', () => {
     const data = call?.[0]?.data ?? {};
     expect(data).not.toHaveProperty('errorClass');
     expect(data).not.toHaveProperty('domException');
-    expect(data).not.toHaveProperty('domExceptionCode');
     expect(data).not.toHaveProperty('errorDetail');
+  });
+
+  it('ignores legacy DOMException code even when the browser exposes it', () => {
+    const error = new DOMException('The handle became invalid', 'InvalidStateError');
+    Object.defineProperty(error, 'code', {
+      configurable: true,
+      value: 11,
+    });
+
+    addWebFileSystemDiagnosticStepBreadcrumb({
+      step: 'writableOpen',
+      result: 'failed',
+      error,
+    });
+
+    const call = vi.mocked(addTechnicalBreadcrumb).mock.calls[0];
+    expect(call?.[0]?.data).not.toHaveProperty('domExceptionCode');
   });
 
   it('drops sensitive writableOpen error details while keeping safe classification fields', () => {

--- a/src/shared/service/fileSystem/webFileSystemWriteDiagnostics.ts
+++ b/src/shared/service/fileSystem/webFileSystemWriteDiagnostics.ts
@@ -12,15 +12,6 @@ const getSafeErrorClass = (error: unknown): string => {
 const getSafeDomException = (error: unknown): string | undefined =>
   error instanceof DOMException ? error.name : undefined;
 
-const getSafeDomExceptionCode = (error: unknown): number | undefined => {
-  if (!(error instanceof DOMException)) {
-    return undefined;
-  }
-
-  const rawCode = Reflect.get(error, 'code');
-  return typeof rawCode === 'number' && Number.isFinite(rawCode) ? rawCode : undefined;
-};
-
 const getSafeErrorDetail = (error: unknown): string | undefined => {
   if (!(error instanceof DOMException || error instanceof Error)) {
     return undefined;
@@ -78,8 +69,6 @@ export const addWebFileSystemDiagnosticStepBreadcrumb = (
 
   const errorClass = event.error !== undefined ? getSafeErrorClass(event.error) : undefined;
   const domException = event.error !== undefined ? getSafeDomException(event.error) : undefined;
-  const domExceptionCode =
-    event.error !== undefined ? getSafeDomExceptionCode(event.error) : undefined;
   const classification =
     event.step === 'writableOpen' && event.result === 'failed'
       ? WEB_FILE_SYSTEM_WRITE_START_FAILED_CODE
@@ -99,7 +88,6 @@ export const addWebFileSystemDiagnosticStepBreadcrumb = (
       ...(classification !== undefined ? { classification } : {}),
       ...(errorClass !== undefined ? { errorClass } : {}),
       ...(domException !== undefined ? { domException } : {}),
-      ...(domExceptionCode !== undefined ? { domExceptionCode } : {}),
       ...(errorDetail !== undefined ? { errorDetail } : {}),
     },
     level: event.result === 'failed' ? 'warning' : 'info',


### PR DESCRIPTION
- prevent exposure of sensitive DOMException code in error messages
- ensure error handling remains consistent with privacy standards
- update tests to verify that legacy DOMException code is ignored

<!-- Keep sections concise. Use N/A when a section is not applicable. -->

## Architecture Decision

## Ownership Matrix

- feature:
- entity:
- widget:
- page/pane:
- shared:
- service/worker:

## Source of Truth

## State Shape / API Contract

## User Scenarios Preserved

## Shared UI / Blast Radius

## Verification

- Focused:
- Full:

## Known Risks

## Reviewer Notes
