### PR TITLE
fix(e2e): correct checkbox interaction and visibility in settings tests

### DIFF
--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -502,6 +502,11 @@ function getVitestScope(changedFiles) {
   const scope = [];
 
   for (const filePath of changedFiles) {
+    if (filePath.startsWith('tests/e2e/')) {
+      // vitest.config.ts excludes tests/e2e/** entirely; Playwright specs there are not vitest scope.
+      continue;
+    }
+
     if (
       (filePath.endsWith('.test.ts') ||
         filePath.endsWith('.spec.ts') ||

--- a/tests/e2e/appSmoke.spec.ts
+++ b/tests/e2e/appSmoke.spec.ts
@@ -37,8 +37,8 @@ test('toggles Error diagnostics in Settings with Space and Enter when available'
   const diagnosticsCheckbox = page.getByRole('checkbox', { name: /error diagnostics/i });
   await expect(diagnosticsCheckbox).toBeVisible();
 
-  const disabled = await diagnosticsCheckbox.getAttribute('aria-disabled');
-  if (disabled === 'true') {
+  const disabled = await diagnosticsCheckbox.isDisabled();
+  if (disabled) {
     await expect(diagnosticsCheckbox).toHaveAttribute('aria-checked', 'false');
     return;
   }

--- a/tests/e2e/browserStoragePersistenceSmoke.spec.ts
+++ b/tests/e2e/browserStoragePersistenceSmoke.spec.ts
@@ -143,7 +143,7 @@ test('settings contains a storage section with a checkbox-style item', async ({ 
   await expect(page.getByText(/more reliable browser storage/i).first()).toBeVisible();
 });
 
-test('settings persistent state is not interactive (no button role)', async ({ page }) => {
+test('settings persistent state is not interactive (disabled)', async ({ page }) => {
   await page.addInitScript(() => {
     StorageManager.prototype.persisted = function persisted(
       this: StorageManager,
@@ -157,7 +157,7 @@ test('settings persistent state is not interactive (no button role)', async ({ p
 
   await expect(page.getByText(/more reliable browser storage/i).first()).toBeVisible();
 
-  // The row must not be a button when persistent.
+  // The row must be non-interactive (disabled) once persistence is already granted.
   const storageRow = page.getByRole('checkbox', { name: /more reliable browser storage/i });
-  await expect(storageRow).not.toHaveAttribute('type', 'button');
+  await expect(storageRow).toBeDisabled();
 });

--- a/tests/e2e/databaseViewsAndQueryFlows.spec.ts
+++ b/tests/e2e/databaseViewsAndQueryFlows.spec.ts
@@ -63,9 +63,10 @@ test('creates, renames, selects, and removes views through the view settings she
   await renameView(page, secondViewName, renamedViewName);
   await selectView(page, renamedViewName);
   const selectedViewSheet = await openViewsSheet(page);
-  await expect(
-    selectedViewSheet.getByRole('button', { name: new RegExp(renamedViewName, 'i') }),
-  ).toHaveAttribute('aria-current', 'true');
+  await expect(selectedViewSheet.getByRole('button', { name: renamedViewName })).toHaveAttribute(
+    'aria-current',
+    'true',
+  );
 
   const selectedViewRow = findListRow(selectedViewSheet, renamedViewName);
   await selectedViewRow.getByRole('button', { name: /settings view/i }).click();

--- a/tests/e2e/databaseViewsAndQueryFlows.spec.ts
+++ b/tests/e2e/databaseViewsAndQueryFlows.spec.ts
@@ -17,6 +17,7 @@ import {
   dismissStorageOnboarding,
   expectDatabaseValuesInOrder,
   findDatabaseRow,
+  findListRow,
   launchApp,
   openDirectory,
   openDocumentFromExplorer,
@@ -51,9 +52,10 @@ test('creates, renames, selects, and removes views through the view settings she
   await addDatabaseItem(page, propertyName, betaValue);
 
   const initialViewSheet = await openViewsSheet(page);
-  await expect(
-    initialViewSheet.getByRole('button', { name: /default view/i }).getByRole('checkbox'),
-  ).toBeChecked();
+  await expect(initialViewSheet.getByRole('button', { name: /default view/i })).toHaveAttribute(
+    'aria-current',
+    'true',
+  );
   await closeBottomSheet(page, /database views sheet/i);
 
   const secondViewName = await addView(page, createUniqueName('secondary view'));
@@ -62,14 +64,10 @@ test('creates, renames, selects, and removes views through the view settings she
   await selectView(page, renamedViewName);
   const selectedViewSheet = await openViewsSheet(page);
   await expect(
-    selectedViewSheet
-      .getByRole('button', { name: new RegExp(renamedViewName, 'i') })
-      .getByRole('checkbox'),
-  ).toBeChecked();
+    selectedViewSheet.getByRole('button', { name: new RegExp(renamedViewName, 'i') }),
+  ).toHaveAttribute('aria-current', 'true');
 
-  const selectedViewRow = selectedViewSheet
-    .getByRole('button', { name: new RegExp(renamedViewName, 'i') })
-    .first();
+  const selectedViewRow = findListRow(selectedViewSheet, renamedViewName);
   await selectedViewRow.getByRole('button', { name: /settings view/i }).click();
   await page.getByRole('menuitem', { name: /^remove$/i }).click();
 
@@ -78,17 +76,19 @@ test('creates, renames, selects, and removes views through the view settings she
   await removeDialog.getByRole('button', { name: /^remove$/i }).click();
   await expect(removeDialog).toHaveCount(0);
 
-  await expect(
-    selectedViewSheet.getByRole('button', { name: /default view/i }).getByRole('checkbox'),
-  ).toBeChecked();
+  await expect(selectedViewSheet.getByRole('button', { name: /default view/i })).toHaveAttribute(
+    'aria-current',
+    'true',
+  );
   await closeBottomSheet(page, /database views sheet/i);
 
   await closeDocumentPane(page);
   await openDocumentFromExplorer(page, documentName);
   const reopenedViewSheet = await openViewsSheet(page);
-  await expect(
-    reopenedViewSheet.getByRole('button', { name: /default view/i }).getByRole('checkbox'),
-  ).toBeChecked();
+  await expect(reopenedViewSheet.getByRole('button', { name: /default view/i })).toHaveAttribute(
+    'aria-current',
+    'true',
+  );
   await closeBottomSheet(page, /database views sheet/i);
 });
 

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -402,7 +402,7 @@ export const addDatabaseItemValues = async (
 export const findDatabaseRow = (root: Page | Locator, value: string): Locator =>
   root.locator('tbody[role="list"] > tr').filter({ hasText: value }).first();
 
-const findListRow = (root: Page | Locator, value: string | RegExp): Locator =>
+export const findListRow = (root: Page | Locator, value: string | RegExp): Locator =>
   root.getByRole('list').locator(':scope > *').filter({ hasText: value }).first();
 
 export const editDatabaseItem = async (
@@ -486,7 +486,11 @@ export const selectView = async (page: Page, name: string | RegExp) => {
   const sheet = await openViewsSheet(page);
   const row = findListRow(sheet, name);
   await row.click();
-  await expect(row.getByRole('checkbox')).toBeChecked();
+  const nameRegExp = typeof name === 'string' ? new RegExp(name, 'i') : name;
+  await expect(sheet.getByRole('button', { name: nameRegExp })).toHaveAttribute(
+    'aria-current',
+    'true',
+  );
   await closeBottomSheet(page, /database views sheet/i);
 };
 

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -486,11 +486,7 @@ export const selectView = async (page: Page, name: string | RegExp) => {
   const sheet = await openViewsSheet(page);
   const row = findListRow(sheet, name);
   await row.click();
-  const nameRegExp = typeof name === 'string' ? new RegExp(name, 'i') : name;
-  await expect(sheet.getByRole('button', { name: nameRegExp })).toHaveAttribute(
-    'aria-current',
-    'true',
-  );
+  await expect(sheet.getByRole('button', { name })).toHaveAttribute('aria-current', 'true');
   await closeBottomSheet(page, /database views sheet/i);
 };
 


### PR DESCRIPTION
## Summary

Fixes the current app e2e baseline failures that were exposed when full app e2e started running for risk-based verification changes.

Changes:
- update the Error diagnostics checkbox e2e check to use Playwright disabled-state semantics;
- assert persistent browser storage as disabled/non-interactive instead of checking a brittle `type` attribute;
- update database view selection checks to assert the current row contract via `aria-current="true"`;
- reuse the existing list-row e2e helper for database view rows;
- exclude `tests/e2e/**` from Vitest scope because Playwright specs are not Vitest tests.

## Architecture Decision

Treat this as an e2e baseline correction, not a change to product architecture or to the risk-based e2e policy.

The selected database view contract in these tests is the row/button `aria-current="true"` state, not a nested checkbox state.

## Ownership Matrix

- feature: unchanged; existing Settings and Database View behavior is preserved.
- entity: unchanged.
- widget: unchanged.
- page/pane: unchanged.
- shared: unchanged.
- service/worker: unchanged.
- tests/tooling: app e2e assertions and Vitest scope selection are updated.

## Source of Truth

- Existing app UI accessibility contract.
- Existing Playwright e2e scenarios under `tests/e2e/**`.
- `vitest.config.ts` exclusion of `tests/e2e/**` from Vitest scope.

## User Scenarios Preserved

- Settings exposes Error diagnostics with correct disabled-state handling.
- Browser storage persistence state is shown as non-interactive when persistence is already granted.
- Database views can be created, renamed, selected, removed, and restored after reopen.

## Shared UI / Blast Radius

No shared UI or product component changes.

## Verification

Focused:
- `pnpm verify --only e2e --files tests/e2e/appSmoke.spec.ts`
- `pnpm verify --only e2e --files tests/e2e/browserStoragePersistenceSmoke.spec.ts`
- `pnpm verify --only e2e --files tests/e2e/databaseViewsAndQueryFlows.spec.ts`
- `pnpm verify --only type-check --files tests/e2e/helpers.ts tests/e2e/databaseViewsAndQueryFlows.spec.ts scripts/verify.mjs`

Full:
- GitHub `verify` workflow.

## Known Risks

- Full CI must pass before merge.
- This PR intentionally does not change `scripts/lib/e2eRisk.mjs` or PR #103 behavior.