### PR TITLE
fix(export): clarify JSON export behavior and error messages

### DIFF
--- a/docs/user/data/01-data-storage.md
+++ b/docs/user/data/01-data-storage.md
@@ -33,11 +33,21 @@ Local folders can become unavailable if:
 
 If that happens, Mioframe may no longer be able to open the affected files until access is granted again or the files are restored outside the app.
 
-## Google Drive
+## How Mioframe stores documents: `.mf` files
 
-Google Drive may be available only when the integration is enabled.
+Inside a local folder or Browser Storage, Mioframe keeps each document's data in Automerge storage chunks with the `.mf` file extension. A single document is typically represented by more than one `.mf` chunk, not one file per document.
 
-When you use Google Drive, the data remains subject to your Google Account and Google Drive settings, permissions, and availability.
+`.mf` files are internal storage for the whole Mioframe space in that folder, not a standalone exported document. Treat them as part of the folder's storage, not as something to move, copy, or share individually:
+
+- Move or back up `.mf` files only as part of moving or backing up the entire Mioframe space folder.
+- Do not pick out a single `.mf` file expecting it to represent one document — open or move the whole folder instead.
+- To get a single, self-contained file for one document, use **Export JSON** instead of copying a `.mf` file.
+
+## Google Drive and other synced or shared folders
+
+Google Drive may be available only when the integration is enabled, and the same applies to any folder that is itself synced or shared by another tool (a synced cloud folder, a shared local folder, and so on).
+
+Access to that data is controlled by the storage provider or folder permissions (your Google Account, Drive sharing settings, or your operating system's folder permissions), not by Mioframe. Mioframe does not provide its own Share, Invite, participant management, or permissions management, and it has no separate collaboration mode. If a folder is shared with someone through the storage provider, that person gets the access the provider grants them — Mioframe is not aware of, and does not manage, who else can reach that folder.
 
 ## Backup expectations
 

--- a/docs/user/data/02-backup-and-restore.md
+++ b/docs/user/data/02-backup-and-restore.md
@@ -1,13 +1,13 @@
 # Backup and restore
 
-This page explains how to back up or restore one document at a time in Mioframe.
+This page explains how to back up one document at a time in Mioframe, and what happens when you import that backup.
 
 ## What Export JSON and Import JSON do
 
-- **Export JSON** saves one document to a JSON file.
-- **Import JSON** restores or adds one document from a JSON file.
+- **Export JSON** saves the current content of one document as a JSON file. This is a document snapshot, not a copy of Mioframe's internal storage.
+- **Import JSON** creates a new Mioframe document from a JSON file. It does not restore the original document's storage identity or history — importing always adds a separate document.
 
-These actions are document-level only. They are not a full workspace backup or full workspace restore.
+These actions are document-level only. They are not a full workspace backup or full workspace restore. For how a document is stored on disk, see [Data storage](./01-data-storage.md).
 
 ## When to export a JSON backup
 
@@ -36,18 +36,19 @@ Keep exported backups somewhere you control and can find again, such as:
 
 If a document is important, keep more than one copy in places you manage.
 
-## How to restore or import one document
+## How to import a JSON document
 
 1. Open the target folder in the app.
 2. Open the folder options menu.
 3. Choose **Import JSON**.
 4. Choose the JSON file.
 
-If the file is valid and the target location is available, Mioframe imports that one document.
+If the file is valid and the target location is available, Mioframe creates a new document in that folder from the JSON file.
 
 ## Important limits
 
 - Export JSON and Import JSON work on one document at a time.
+- Importing always creates a new document; it does not restore the original document's storage identity, `.mf` chunks, or edit history.
 - They do not restore an entire workspace, folder structure, or browser storage state.
 - Mioframe cannot recreate data that was never exported or otherwise preserved.
 

--- a/src/features/documentManage/DocumentManageMenuButton.vue
+++ b/src/features/documentManage/DocumentManageMenuButton.vue
@@ -61,11 +61,11 @@ const onClickMenuAction = async ({ key }: { key: DocumentContextEvent }) => {
         const exported = await saveJsonFile(directoryPath.value, documentId.value);
 
         if (exported) {
-          addSnackbar({ text: 'Document exported' });
+          addSnackbar({ text: 'JSON exported. It can be imported as a new document.' });
         }
       } catch (error) {
         addSnackbar({
-          text: error instanceof DomainError ? error.message : 'Could not export the document',
+          text: error instanceof DomainError ? error.message : 'Could not export JSON',
         });
         if (!isUserFileSelectionCancel(error)) {
           captureDiagnosticException(error, {

--- a/src/features/exportDocument/useExportDocument.test.ts
+++ b/src/features/exportDocument/useExportDocument.test.ts
@@ -66,7 +66,7 @@ describe('useExportDocument', () => {
 
     expect(error).toBeInstanceOf(DomainError);
     expect(error).toMatchObject({
-      message: 'Could not export the document',
+      message: 'Could not export JSON',
       code: 'exportDocument.documentExportFailed',
     });
     if (!(error instanceof DomainError)) throw new Error('expected DomainError');
@@ -143,7 +143,7 @@ describe('useExportDocument', () => {
 
     expect(error).toBeInstanceOf(DomainError);
     expect(error).toMatchObject({
-      message: 'Could not export the document',
+      message: 'Could not export JSON',
       code: 'exportDocument.documentExportFailed',
     });
     if (!(error instanceof DomainError)) throw new Error('expected DomainError');
@@ -152,7 +152,7 @@ describe('useExportDocument', () => {
   });
 
   it('preserves an existing DomainError when saving fails', async () => {
-    const cause = new DomainError('Could not export the document');
+    const cause = new DomainError('Could not export JSON');
     fileSaveMock.mockRejectedValueOnce(cause);
 
     const { saveJsonFile } = useExportDocument();

--- a/src/features/exportDocument/useExportDocument.ts
+++ b/src/features/exportDocument/useExportDocument.ts
@@ -34,7 +34,7 @@ export const useExportDocument = () => {
         throw error;
       }
 
-      throw new DomainError('Could not export the document', {
+      throw new DomainError('Could not export JSON', {
         cause: error,
         code: ExportDocumentErrorCode.documentExportFailed,
       });
@@ -69,7 +69,7 @@ export const useExportDocument = () => {
         throw error;
       }
 
-      throw new DomainError('Could not export the document', {
+      throw new DomainError('Could not export JSON', {
         cause: error,
         code: ExportDocumentErrorCode.documentExportFailed,
       });

--- a/src/features/importDocument/useImportDocumentAction.test.ts
+++ b/src/features/importDocument/useImportDocumentAction.test.ts
@@ -186,7 +186,7 @@ describe('useImportDocumentAction', () => {
     await expect(importDocument('/documents')).resolves.toBe('document-id');
     expect(importDocumentFromJsonFileMock).toHaveBeenCalledWith('/documents', file);
     expect(addSnackbarMock).toHaveBeenCalledWith({
-      text: 'Document imported into this Mioframe folder',
+      text: 'JSON imported as a new Mioframe document.',
     });
     expect(captureDiagnosticExceptionMock).not.toHaveBeenCalled();
   });
@@ -372,7 +372,7 @@ describe('useImportDocumentAction', () => {
     expect(importDocumentFromJsonFileMock).toHaveBeenNthCalledWith(2, '/documents', file);
     expect(pickJsonFileMock).toHaveBeenCalledTimes(1);
     expect(addSnackbarMock).toHaveBeenCalledWith({
-      text: 'Document imported into this Mioframe folder',
+      text: 'JSON imported as a new Mioframe document.',
     });
   });
 
@@ -408,7 +408,7 @@ describe('useImportDocumentAction', () => {
       );
       expect(importDocumentFromJsonPathMock).toHaveBeenCalledWith('/documents', '/folder/doc.json');
       expect(addSnackbarMock).toHaveBeenCalledWith({
-        text: 'Document imported into this Mioframe folder',
+        text: 'JSON imported as a new Mioframe document.',
       });
       expect(captureDiagnosticExceptionMock).not.toHaveBeenCalled();
     });
@@ -469,7 +469,7 @@ describe('useImportDocumentAction', () => {
       ).resolves.toBe('dup-id');
       expect(importDocumentFromJsonPathMock).toHaveBeenCalledTimes(1);
       expect(addSnackbarMock).toHaveBeenCalledWith({
-        text: 'Document imported into this Mioframe folder',
+        text: 'JSON imported as a new Mioframe document.',
       });
     });
 
@@ -493,7 +493,7 @@ describe('useImportDocumentAction', () => {
       );
       expect(importDocumentFromJsonPathMock).toHaveBeenCalledTimes(2);
       expect(addSnackbarMock).toHaveBeenCalledWith({
-        text: 'Document imported into this Mioframe folder',
+        text: 'JSON imported as a new Mioframe document.',
       });
       expect(captureDiagnosticExceptionMock).not.toHaveBeenCalled();
     });

--- a/src/features/importDocument/useImportDocumentAction.ts
+++ b/src/features/importDocument/useImportDocumentAction.ts
@@ -140,7 +140,7 @@ export const useImportDocumentAction = () => {
         return undefined;
       }
 
-      addSnackbar({ text: 'Document imported into this Mioframe folder' });
+      addSnackbar({ text: 'JSON imported as a new Mioframe document.' });
 
       return documentId;
     } catch (error) {
@@ -186,7 +186,7 @@ export const useImportDocumentAction = () => {
         return undefined;
       }
 
-      addSnackbar({ text: 'Document imported into this Mioframe folder' });
+      addSnackbar({ text: 'JSON imported as a new Mioframe document.' });
 
       return documentId;
     } catch (error) {


### PR DESCRIPTION
## Architecture Decision

Clarify existing JSON export/import UX copy and user help documentation without changing Mioframe data architecture.

`Export JSON` remains a document-level snapshot export for one document. Importing JSON creates a new Mioframe document in the selected folder. `.mf` files remain Mioframe Automerge storage chunks for a space and are not presented as standalone exported documents. Folder/shared access remains controlled by the selected storage provider, not by Mioframe.

No sharing flow, participant UI, collaboration mode, storage format change, JSON schema change, or worker/service behavior change is introduced.

## Ownership Matrix

- feature: export/import user-facing copy for existing document-level actions.
- entity: N/A.
- widget: N/A.
- page/pane: in-app Help continues to consume existing `docs/user` markdown catalog.
- shared: N/A; no shared UI changes.
- service/worker: N/A; no storage, worker, provider, or import/export model changes.

## Source of Truth

- Notion task: explain the distinction between `Export JSON`, `.mf` files, and folder/provider access.
- Existing implementation: `Export JSON` and `Import JSON` remain the supported document-level transfer flow.
- Existing storage architecture: `.mf` files remain Automerge storage chunks for Mioframe spaces.

## State Shape / API Contract

No state shape or API contract changes.

The PR only changes user-facing copy, export/import success wording, export error wording, and user documentation.

## User Scenarios Preserved

- Export one document through `Document menu -> Export JSON -> choose save location -> done`.
- Import a JSON file as a new Mioframe document.
- Move/back up storage-level `.mf` files only as part of the whole Mioframe space/folder.
- Use Google Drive or shared/synced folders with access controlled by the provider/folder.

## Shared UI / Blast Radius

No shared UI components are changed.

The blast radius is limited to export/import feature copy and `docs/user` help content.

## Verification

- Focused: export document and import document unit tests updated for the revised copy.
- Full: pending CI `verify` on the PR head.

## Known Risks

- The PR should not be merged until CI `verify` is green.

## Reviewer Notes

Review should focus on whether the copy accurately preserves the product boundary:

- JSON export is a document snapshot.
- JSON import creates a new document.
- `.mf` files are storage chunks, not exported documents.
- folder/shared access is provider-controlled and not Mioframe sharing.