### PR TITLE
feat(release): add release quality gate (#116)

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,35 @@
+name: release-tag
+
+# Lightweight validation for vX.Y.Z tag pushes: confirms the tag matches
+# package.json's version. main was already validated by the `release` workflow
+# before the tag was created, so this does not rerun the full release gate
+# (pnpm verify:release) — no e2e, visual, mutation, artifact, or deploy steps.
+# See docs/release.md.
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-tag:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Validate tag matches package.json version
+        run: node scripts/release/validateVersion.mjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,133 @@
+name: release
+
+# Release gate for the stable public branch: full-project verification
+# (pnpm verify:release) for every PR into main and every push to main. Stable
+# deploy only ever runs after a green release gate on a push to main.
+# vX.Y.Z tag pushes do not rerun this full gate — see the separate, lightweight
+# `release-tag` workflow (.github/workflows/release-tag.yml). See docs/release.md.
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release-gate:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.head.ref || github.ref }}
+
+      - name: Fetch pull request base branch
+        if: github.event_name == 'pull_request'
+        run: git fetch --no-tags origin "refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+        env:
+          BASE_REF: ${{ github.base_ref }}
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - run: pnpm install --frozen-lockfile
+
+      # VITE_GOOGLE_CLIENT_ID, VITE_SENTRY_DSN, and SENTRY_AUTH_TOKEN are
+      # deliberately not set here: they are optional integrations, not
+      # required by pnpm verify:release, and passing them as secrets would
+      # expand to empty strings when unconfigured (see docs/release.md#release-config-validation).
+      # They are still passed to the deploy-stable build step below, which
+      # does use them when configured.
+      - name: Full release verification
+        run: pnpm verify:release --verbose
+
+      - name: Upload release verification logs
+        if: ${{ failure() || cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-logs
+          path: .verify/logs/
+          if-no-files-found: ignore
+          retention-days: 14
+
+  deploy-stable:
+    needs: [release-gate]
+    if: >-
+      !cancelled() &&
+      needs.release-gate.result == 'success' &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    concurrency:
+      group: pages-publish
+      cancel-in-progress: false
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build release artifact
+        env:
+          BASE_URL: /${{ github.event.repository.name }}/
+          VITE_GOOGLE_CLIENT_ID: ${{ secrets.VITE_GOOGLE_CLIENT_ID }}
+          VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: pnpm release:build-artifact
+
+      - name: Publish stable build to staging
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: >-
+          node scripts/pages/publishStable.mjs
+          --dist dist
+          --output-dir pages-staging
+
+      - name: Write root SPA fallback
+        run: >-
+          node scripts/pages/writeSpaFallback.mjs
+          --base /${{ github.event.repository.name }}/
+          --output-dir pages-staging
+
+      - uses: actions/configure-pages@v4
+        with:
+          enablement: true
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./pages-staging/
+
+      - uses: actions/deploy-pages@v4
+        id: deploy

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,10 +1,17 @@
 name: verify
 
+# Development verification for develop-bound work: focused pnpm verify plus a
+# PR-into-develop version-bump check, and PR preview deploys. PRs/pushes to
+# main use the separate `release` workflow (.github/workflows/release.yml)
+# instead — see docs/release.md. The trigger below excludes PRs into main so
+# this workflow and the release gate never both run for the same PR path.
+
 on:
   pull_request:
+    branches-ignore:
+      - main
   push:
     branches:
-      - main
       - develop
 
 concurrency:
@@ -13,7 +20,9 @@ concurrency:
 
 jobs:
   autofix:
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
@@ -98,7 +107,9 @@ jobs:
   verify:
     needs:
       - autofix
-    if: ${{ !cancelled() && (needs.autofix.result == 'success' || needs.autofix.result == 'skipped') }}
+    if: >-
+      !cancelled() &&
+      (needs.autofix.result == 'success' || needs.autofix.result == 'skipped')
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
@@ -125,6 +136,12 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
 
       - run: pnpm install --frozen-lockfile
+
+      # Every PR into develop must bump package.json version above develop's
+      # current version (docs/release.md#pr-level-version-bump-policy).
+      - name: Validate version bump
+        if: github.event_name == 'pull_request'
+        run: node scripts/release/validateVersion.mjs
 
       - name: Verify format
         run: pnpm verify --verbose --only format
@@ -242,73 +259,3 @@ jobs:
           node scripts/pages/upsertPreviewComment.mjs
           --pr ${{ github.event.number }}
           --url "https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-${{ github.event.number }}/"
-
-  deploy-stable:
-    needs: [verify]
-    if: >-
-      !cancelled() &&
-      needs.verify.result == 'success' &&
-      github.event_name == 'push' &&
-      github.ref == 'refs/heads/develop'
-    runs-on: ubuntu-24.04
-    timeout-minutes: 15
-    permissions:
-      contents: write
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}
-    concurrency:
-      group: pages-publish
-      cancel-in-progress: false
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: lts/*
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - run: pnpm install --frozen-lockfile
-
-      - name: Build
-        env:
-          BASE_URL: /${{ github.event.repository.name }}/
-          VITE_GOOGLE_CLIENT_ID: ${{ secrets.VITE_GOOGLE_CLIENT_ID }}
-          VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-        run: pnpm run build
-
-      - name: Fix 404 for SPA
-        run: cp ./dist/index.html ./dist/404.html
-
-      - name: Publish stable build to staging
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-        run: >-
-          node scripts/pages/publishStable.mjs
-          --dist dist
-          --output-dir pages-staging
-
-      - name: Write root SPA fallback
-        run: >-
-          node scripts/pages/writeSpaFallback.mjs
-          --base /${{ github.event.repository.name }}/
-          --output-dir pages-staging
-
-      - uses: actions/configure-pages@v4
-        with:
-          enablement: true
-
-      - uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./pages-staging/
-
-      - uses: actions/deploy-pages@v4
-        id: deploy

--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,9 @@ coverage/
 storybook-static/
 reports/mutation/
 playwright-report/
+playwright-report-release/
 test-results/
+pages-staging/
 .sisyphus/
 .opencode/
 # Ignore local Claude state but allow project-level compatibility files.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,16 @@ status: passed | failed | not run | blocked by active local verification
 reason if not run:
 ```
 
+## Release
+
+`develop` is the active development branch; `main` is the stable public
+branch; stable publish only happens from `main`. Every PR into `develop` or
+`main` must bump `package.json` version. `pnpm verify` stays the focused
+development gate; `pnpm verify:release` (`node scripts/verify.mjs --full`)
+is the full-project release gate required for `main`. See `docs/release.md`
+for the full policy and `docs/release-checklist.md` for the promotion and
+hotfix checklist.
+
 ## Contains
 
 - `src/app`: bootstrap, routing, global shells, and global styles.

--- a/config/tooling.json
+++ b/config/tooling.json
@@ -5,6 +5,12 @@
   "appPreview": {
     "port": 4173
   },
+  "release": {
+    "basePath": "/mioframe/",
+    "artifactServer": {
+      "port": 4174
+    }
+  },
   "storybook": {
     "devServer": {
       "port": 6006

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,71 @@
+# Release checklist
+
+Use this checklist for every promotion of `develop` into `main`, and for
+every hotfix directly into `main`. See `docs/release.md` for the full policy
+this checklist enforces.
+
+## Before opening the PR into `main`
+
+- [ ] `develop` (or the hotfix branch) is green on its own `verify` workflow.
+- [ ] `package.json` `version` is bumped above the version currently on
+      `main`, following SemVer (`docs/release.md#choosing-patch--minor--major`).
+- [ ] `docs/releases/<version>.md` exists and describes what changed in this
+      release, in product-facing language.
+- [ ] No storage format, data model, routing model, or product UX behavior
+      changed unintentionally as a side effect of release infrastructure
+      work.
+
+## Opening the PR into `main`
+
+- [ ] PR target branch is `main`.
+- [ ] PR description fills in the pull request template's ownership matrix
+      and verification sections.
+- [ ] The `release` workflow run is green:
+  - [ ] `pnpm verify:release` full-project gate passed (format, lint,
+        type-check, unit tests, full app e2e, full visual regression).
+  - [ ] production build and artifact validation passed.
+  - [ ] release smoke coverage (first-user and returning-user flows)
+        passed.
+  - [ ] release/version metadata validation passed (version format, PR
+        version greater than `main`'s current version).
+  - [ ] release config validation passed (base path consistency, PWA not
+        disabled, no preview-only settings, env/config presence — see
+        `docs/release.md#release-config-validation`). Absent optional
+        Google/Sentry integrations do not block this — only real
+        release-mode misconfiguration (wrong base path, PWA disabled, a
+        PR-preview base path, or an explicitly empty optional value outside
+        GitHub Actions) does.
+
+## After merging into `main`
+
+- [ ] The `release` workflow's push-to-`main` run is green (this re-runs the
+      full release gate before `deploy-stable`).
+- [ ] `deploy-stable` succeeded and the stable GitHub Pages deployment shows
+      the new version.
+- [ ] Create and push the `vX.Y.Z` tag matching `package.json` version.
+      The tag push runs the lightweight `release-tag` workflow, which only
+      confirms the tag matches `package.json` — it does not rerun the full
+      release gate.
+- [ ] Merge (or cherry-pick) the same change back into `develop` so the
+      branches do not diverge. For a normal promotion (`develop` -> `main`
+      with no `main`-only commits), this is a fast-forward or a trivial
+      merge back.
+
+## If the release gate fails
+
+- [ ] Read the failing step's log in the Actions run, or download the
+      `release-logs` artifact.
+- [ ] Do not bypass the gate. Fix the failure (or, for a flaky
+      infrastructure issue, re-run the workflow) — do not disable checks or
+      force-merge around a failing release gate.
+- [ ] If the gate reveals a defect only visible at full-project scope
+      (e.g. a lint or type-check failure outside the PR's changed files),
+      treat it as a release blocker and fix it before promoting.
+
+## Hotfix-specific steps
+
+- [ ] Branch from `main` as `fix/<name>` or `hotfix/<name>`.
+- [ ] Bump the version (PATCH unless the fix requires more).
+- [ ] Follow the same PR-into-`main` and after-merge steps above.
+- [ ] After the hotfix ships, merge it back into `develop` in the same PR
+      cycle so `develop` does not silently regress.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,259 @@
+# Release model
+
+Mioframe ships from two long-lived branches with different guarantees. This
+document is the source of truth for how code moves from a feature branch to a
+stable public release. `AGENTS.md` links here; keep the detailed policy in
+this file, not in `AGENTS.md`.
+
+## Branches
+
+- **`develop`** is the active development branch. Every feature and fix lands
+  here first. It is verified on every PR but is never published as the stable
+  build.
+- **`main`** is the stable public branch. Only `main` is published to the
+  stable GitHub Pages deployment. Every push to `main` and every PR into
+  `main` runs the full release gate (see below).
+
+## Flows
+
+```
+feature/* -> develop -> main
+fix/*, hotfix/* -> main -> develop
+```
+
+- **Feature flow**: branch from `develop` as `feature/<name>`, open a PR into
+  `develop`. When `develop` is ready to ship, open a promotion PR from
+  `develop` into `main`.
+- **Hotfix flow**: for a defect that must be fixed directly on the stable
+  branch, branch from `main` as `fix/<name>` or `hotfix/<name>`, open a PR
+  into `main`. After the hotfix ships, merge (or cherry-pick) the same change
+  back into `develop` so the two branches do not diverge.
+- Stable publish only ever happens from `main`. `develop` never deploys the
+  stable build; it may still build/deploy PR previews for review.
+
+## Versioning
+
+- `package.json` `version` is the single source of truth for the app version.
+  Vite injects it into the runtime as `__APP_VERSION__` (see
+  `vite.config.ts`).
+- Versions are SemVer-compatible `X.Y.Z` (no pre-release/build suffix).
+- Git tags for stable releases use the format `vX.Y.Z` and must match
+  `package.json` exactly at the point the tag is created.
+- The first public release is `0.1.0`.
+
+### PR-level version bump policy
+
+- **Every PR into `develop` must bump `package.json` version** strictly above
+  the version currently on `develop`. This is enforced by CI (see
+  `scripts/release/validateVersion.mjs`, run as the `release-version` /
+  version-bump check).
+- **Every PR into `main`** (promotion or hotfix) must also carry a version
+  strictly above the version currently on `main`.
+- CI verifies that a bump exists and is monotonically increasing. CI does
+  **not** decide whether the bump should be PATCH, MINOR, or MAJOR — that is
+  a product/review decision made by the PR author and reviewer.
+
+### Choosing PATCH / MINOR / MAJOR
+
+This is a manual decision, not automated by CI:
+
+- **PATCH** (`0.1.0` -> `0.1.1`): bug fixes, internal refactors, verification
+  or tooling changes with no user-facing behavior change.
+- **MINOR** (`0.1.0` -> `0.2.0`): new user-facing functionality that does not
+  break existing data, storage formats, or workflows.
+- **MAJOR** (`0.x.y` -> `1.0.0`, or `x.y.z` -> `(x+1).0.0`): breaking changes
+  to storage format, public APIs, or user workflows that require migration or
+  explicit user action.
+
+## What CI verifies automatically
+
+CI is split into three workflows so no PR/push path ever runs both the
+focused and the full gate, and tag pushes never rerun the full gate:
+
+- **`verify` workflow** (`.github/workflows/verify.yml`): PRs into any
+  branch except `main`, and pushes to `develop`. Runs normal focused
+  development verification (`pnpm verify`, changed-file scope) plus, on PRs,
+  a version-bump check — the PR version must be strictly greater than
+  `develop`'s current version. Its `pull_request` trigger uses
+  `branches-ignore: [main]`, so it never fires for a PR into `main`.
+- **`release` workflow** (`.github/workflows/release.yml`): PRs into `main`
+  and pushes to `main` only. Runs the full release gate
+  (`pnpm verify:release`, full-project scope, see below), which includes
+  version/build metadata and release-config validation. Stable deploy
+  (`deploy-stable`) runs only after this gate passes on a push to `main`.
+- **`release-tag` workflow** (`.github/workflows/release-tag.yml`): `vX.Y.Z`
+  tag pushes only. Runs a single lightweight check
+  (`node scripts/release/validateVersion.mjs`) confirming the tag matches
+  `package.json` version — it does not rerun e2e, visual, artifact, or
+  deploy steps, since `main` was already validated by the `release`
+  workflow before the tag was created.
+
+## What remains a manual product/release decision
+
+- Whether a change is PATCH, MINOR, or MAJOR.
+- Whether a given `develop` state is ready to promote to `main`.
+- Writing the release notes for a version (`docs/releases/<version>.md`).
+- Creating and pushing the `vX.Y.Z` tag after `main` is updated.
+
+## Full release verification
+
+`pnpm verify` remains the normal development command: it scopes checks to
+changed files and is meant for fast PR feedback on `develop`.
+
+`pnpm verify:release` (= `node scripts/verify.mjs --full`) is the release
+gate. It ignores changed-file scope and always runs, for the whole project:
+
+- format check (`oxfmt`) across the full supported file set;
+- `oxlint` across the full project;
+- `eslint` across the full project;
+- full TypeScript type-check;
+- the full `vitest run` unit/component suite;
+- full app Playwright E2E smoke coverage;
+- full approved visual regression coverage;
+- production build and artifact validation (`docs/release.md#production-artifact-validation`);
+- release smoke coverage (`docs/release.md#release-smoke-coverage`);
+- release/version metadata validation (`scripts/release/validateVersion.mjs`);
+- release config validation (`scripts/release/validateReleaseConfig.mjs`, see
+  `docs/release.md#release-config-validation`).
+
+Full mode never reports a check as skipped because there were no changed
+files. Use `pnpm verify --full --only <label>` to focus on a single release
+check while keeping the release-scope framing.
+
+Mutation testing (`pnpm test:mutate`, or scoped mutation inside ordinary
+`pnpm verify`) remains available for test design and PR-quality work, but it
+is not part of the release gate: it is slow, and it validates test
+robustness rather than the published artifact. `pnpm verify --full` and
+`pnpm verify:release` do not run it, and `pnpm verify --full --only
+mutation` is not a valid release check.
+
+## Production artifact validation
+
+Owned by `scripts/release/buildArtifact.mjs`, `scripts/release/artifactServer.mjs`,
+and `tests/e2e/release/productionArtifactSmoke.spec.ts`. It validates the
+_published_ artifact, not internal build tooling:
+
+- the production build (`vite build`) completes;
+- the built `dist/` opens through a local static server the same way GitHub
+  Pages would serve it, at the configured base path (`/mioframe/`);
+- an unmatched deep route falls back to the site's `404.html` redirect and
+  the app restores the original path after boot (the same mechanism
+  `scripts/pages/writeSpaFallback.mjs` writes for the real deployment);
+- critical assets referenced by `index.html` load without errors under the
+  base path;
+- the PWA manifest is linked and fetchable, and the app does not throw a
+  page error during first launch when a service worker is registered.
+
+This does not assert on Workbox route internals — only the user-visible
+artifact behavior.
+
+### Avoiding duplicate artifact builds
+
+The `build` check (`scripts/release/buildArtifact.mjs`) always builds a
+fresh production artifact and fails fast before the more expensive `artifact`
+and `release-smoke` Playwright checks run. Those checks each spin up their
+own Playwright webServer, which normally builds its own artifact too — so
+without deduplication, one `pnpm verify:release` run would build the same
+production artifact three times.
+
+`scripts/verify.mjs` avoids this: once `build` has passed in the same run,
+it sets `RELEASE_ARTIFACT_SKIP_BUILD=1` for the `artifact` and
+`release-smoke` checks (forwarded through `scripts/e2eReleaseContainer.mjs`
+into the Podman container), and `buildArtifact.mjs` reuses the existing
+`dist/` instead of rebuilding. Standalone invocations
+(`pnpm e2e:release`, `pnpm verify --full --only artifact`) never set this
+flag, so they remain self-sufficient and always build their own artifact.
+
+## Release config validation
+
+Owned by `scripts/release/validateReleaseConfig.mjs`, run as the
+`release-config` check. It validates release-mode config assumptions that
+are not covered by `release-version`:
+
+- `config/tooling.json` `release.basePath` matches `/${package.json name}/`,
+  the same base path the release artifact build and `deploy-stable` use;
+- `VITE_DISABLE_PWA` is not `1` (that is a PR-preview-only setting; see
+  `deploy-preview` in `.github/workflows/verify.yml`);
+- `BASE_URL`, if set, is not a PR-preview path and matches the release base
+  path;
+- `VITE_GOOGLE_CLIENT_ID`, `VITE_SENTRY_DSN`, and `SENTRY_AUTH_TOKEN` are
+  optional integrations, not required for a valid public release. Each is
+  reported as set/optional-and-unset. Outside GitHub Actions, an explicitly
+  empty value fails clearly (a silent misconfiguration, distinct from
+  intentionally unset). Inside GitHub Actions (`GITHUB_ACTIONS=true`), an
+  empty value is logged as a notice, not an error: GitHub Actions expands
+  `${{ secrets.X }}` to an empty string when a secret is not configured, and
+  there is no way inside the job to distinguish that from an explicit empty
+  value, so treating it as fatal there would make an absent optional secret
+  block the release gate;
+- partial Sentry configuration (DSN without auth token, or vice versa) is
+  reported explicitly so the resulting behavior is not a silent surprise.
+
+It deliberately does not read or assert on secret values themselves — only
+presence/absence and mode consistency.
+
+The `Full release verification` step in `.github/workflows/release.yml`
+(`release-gate` job) does not pass `VITE_GOOGLE_CLIENT_ID`, `VITE_SENTRY_DSN`,
+or `SENTRY_AUTH_TOKEN` at all, since `pnpm verify:release` does not require
+them — so in practice these keys are simply absent from that step's
+environment, not empty. The GitHub Actions empty-value notice above exists
+as a safety net for any other invocation (e.g. `deploy-stable`'s build step,
+which does pass these secrets since the build uses them) so an unconfigured
+optional secret never fails release-config validation there either.
+
+## Release smoke coverage
+
+Owned by `tests/e2e/release/*.spec.ts`, using existing Playwright helpers
+(`tests/e2e/helpers.ts`) and user-facing locators, run against the built
+production artifact (see above), not the dev server.
+
+- **First-user flow**: open the artifact, land on Home, open Browser
+  Storage, create a first document, add minimal data, confirm no save
+  error, reload, confirm the data survived.
+- **Returning-user flow**: with data already created (from the same test's
+  own setup), reopen the app, confirm the previous data is visible, and
+  confirm reopening does not create duplicate data or overlay an empty
+  state on top of existing data.
+
+## Required checks and branch protection
+
+Configure these as required status checks in GitHub branch protection
+settings (this repository does not control branch protection directly —
+apply these manually in the GitHub UI):
+
+- `main`: require the `release` workflow (`release-gate` and its
+  sub-jobs) to pass before merge, and require branches to be up to date.
+  Disallow direct pushes; only merges through a reviewed PR. The `verify`
+  workflow does not run for PRs into `main`, so it is not a required check
+  there.
+- `develop`: require the `verify` workflow (`verify` job and the
+  version-bump check) to pass before merge.
+- Tag pushes: the `release-tag` workflow is informational (it validates the
+  tag after the fact); it is not a branch-protection required check since
+  tags are not a protected branch.
+
+## What blocks a release
+
+- Any failing check inside `pnpm verify:release` (format, lint, type-check,
+  unit, e2e, visual, build, artifact, release smoke, version metadata,
+  release config).
+- A missing or non-monotonic version bump.
+- A tag that does not match `package.json` version.
+- Missing release notes for the target version
+  (`docs/releases/<version>.md`) or a missing `docs/release-checklist.md`.
+
+CI failing any of the above must block the `deploy-stable` job; it never
+runs as a fallback or manual override. `deploy-stable` builds with
+`pnpm release:build-artifact` (`scripts/release/buildArtifact.mjs`) — the
+same build script and base-path contract the release gate validates.
+
+## Where to inspect release verification logs
+
+- Locally: `.verify/logs/<label>.log`, one file per check
+  (see `pnpm verify:status`).
+- In GitHub Actions: the failing step's inline log, plus the `verify-logs`
+  / `release-logs` artifact uploaded on failure or cancellation for the run
+  (Actions run page -> Summary -> Artifacts).
+
+See `docs/release-checklist.md` for the step-by-step promotion/hotfix
+checklist.

--- a/docs/releases/0.1.0.md
+++ b/docs/releases/0.1.0.md
@@ -1,0 +1,15 @@
+# 0.1.0
+
+First public release of Mioframe.
+
+## Highlights
+
+- Repository-side release model: `develop` for active development, `main`
+  as the stable public branch, stable publish only from `main`.
+- Full-project release verification gate (`pnpm verify:release`), separate
+  from the focused development `pnpm verify`.
+- Automated release/version metadata validation, production artifact
+  validation, and first-user/returning-user release smoke coverage.
+
+See `docs/release.md` for the release model and `docs/release-checklist.md`
+for the promotion checklist.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mioframe",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "author": {
@@ -18,6 +18,7 @@
     "prepare": "node .husky/install.mjs",
     "setup:git-hooks": "node .husky/install.mjs",
     "verify": "node scripts/verify.mjs",
+    "verify:release": "node scripts/verify.mjs --full",
     "verify:status": "node scripts/verifyStatus.mjs",
     "verify:resume": "node scripts/verifyResume.mjs",
     "ci:autofix": "node scripts/verify.mjs --fix-only",
@@ -33,12 +34,16 @@
     "e2e:headed": "node scripts/e2eHost.mjs --headed",
     "e2e:host:install": "playwright install --with-deps chromium",
     "e2e:ui": "node scripts/e2eHost.mjs --ui",
+    "e2e:release": "node scripts/e2eReleaseContainer.mjs",
     "test:visual": "node scripts/visual.mjs test",
     "test:visual:update": "node scripts/visual.mjs update",
     "test": "vitest",
     "test:run": "node scripts/vitestRun.mjs",
     "test:coverage": "node scripts/vitestRun.mjs --coverage",
-    "test:mutate": "node scripts/mutate.mjs"
+    "test:mutate": "node scripts/mutate.mjs",
+    "release:build-artifact": "node scripts/release/buildArtifact.mjs",
+    "release:validate-version": "node scripts/release/validateVersion.mjs",
+    "release:validate-config": "node scripts/release/validateReleaseConfig.mjs"
   },
   "dependencies": {
     "@automerge/automerge": "^3.2.5",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,7 +12,7 @@ const previewURLPattern = new RegExp(
 
 export default defineConfig({
   testDir: './tests/e2e',
-  testIgnore: ['visual/**'],
+  testIgnore: ['visual/**', 'release/**'],
   // Tests share origin-bound OPFS state, so file-level parallelism is intentionally disabled.
   fullyParallel: false,
   forbidOnly: !!process.env.CI,

--- a/playwright.release.config.ts
+++ b/playwright.release.config.ts
@@ -1,0 +1,56 @@
+import { defineConfig, devices } from '@playwright/test';
+import toolingConfig from './config/tooling.json' with { type: 'json' };
+
+const host = toolingConfig.localServer.host;
+const port = toolingConfig.release.artifactServer.port;
+const basePath = toolingConfig.release.basePath;
+const releaseBaseURL = `http://${host}:${port}${basePath}`;
+
+// Reused by tests/e2e/helpers.ts's launchApp(), which reads this env var
+// before falling back to the dev-server default. Setting it here (rather
+// than duplicating helpers) lets release specs reuse the same user-facing
+// helpers as tests/e2e/*.spec.ts, pointed at the production artifact server
+// this config starts below.
+process.env.PLAYWRIGHT_EXTERNAL_BASE_URL = releaseBaseURL;
+
+export default defineConfig({
+  testDir: './tests/e2e/release',
+  // Release specs build a fresh production artifact and share its origin-bound
+  // storage, so file-level parallelism is intentionally disabled (see playwright.config.ts).
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI
+    ? [['line'], ['html', { open: 'never', outputFolder: 'playwright-report-release' }]]
+    : 'list',
+  use: {
+    baseURL: releaseBaseURL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  webServer: {
+    command: [
+      `node scripts/release/buildArtifact.mjs --base ${basePath}`,
+      `node scripts/release/artifactServer.mjs --base ${basePath} --host ${host} --port ${port}`,
+    ].join(' && '),
+    url: releaseBaseURL,
+    env: {
+      ...process.env,
+      FORCE_COLOR: '0',
+      NO_COLOR: '1',
+    },
+    stdout: 'pipe',
+    timeout: toolingConfig.playwright.webServerTimeoutMs,
+  },
+  workers: process.env.CI ? 1 : undefined,
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        channel: 'chromium',
+      },
+    },
+  ],
+});

--- a/scripts/e2eReleaseContainer.mjs
+++ b/scripts/e2eReleaseContainer.mjs
@@ -1,0 +1,36 @@
+import { runPlaywrightInContainer } from './playwrightContainer.mjs';
+
+const argv = process.argv.slice(2);
+const labelFlagIndex = argv.indexOf('--label');
+const label = labelFlagIndex !== -1 ? argv[labelFlagIndex + 1] : 'release';
+const extraArgs =
+  labelFlagIndex === -1
+    ? argv
+    : [...argv.slice(0, labelFlagIndex), ...argv.slice(labelFlagIndex + 2)];
+// Forwarded into the container so the release Playwright webServer's
+// buildArtifact call can reuse a `dist/` already built by an earlier
+// `pnpm verify:release` `build` check instead of rebuilding (see
+// scripts/verify.mjs and scripts/release/buildArtifact.mjs). The container
+// only receives env vars explicitly listed here, not the full host env.
+const extraEnv =
+  process.env.RELEASE_ARTIFACT_SKIP_BUILD === '1' ? { RELEASE_ARTIFACT_SKIP_BUILD: '1' } : {};
+
+try {
+  await runPlaywrightInContainer({
+    label,
+    config: 'playwright.release.config.ts',
+    extraArgs,
+    extraEnv,
+    missingPodmanMessage:
+      'Podman is required for release artifact/smoke tests.\nInstall Podman and rerun `pnpm e2e:release`.',
+    missingMetadataMessage:
+      'Installed Playwright metadata is missing or invalid at `node_modules/@playwright/test/package.json`.\nRun `pnpm install` before release artifact/smoke tests.',
+    missingBinaryMessage:
+      'Local Playwright binary is missing at `node_modules/.bin/playwright`.\nRun `pnpm install` before release artifact/smoke tests.',
+    podmanFailureMessage:
+      'Podman is required for release artifact/smoke tests, but `podman --version` failed.',
+  });
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/scripts/lib/commandWeight.mjs
+++ b/scripts/lib/commandWeight.mjs
@@ -27,7 +27,14 @@ export function classifyCommandWeight({ label, fileCount = 0, isFullRepo = false
     case 'visual-update':
     case 'mutation':
     case 'playwright-container':
+    case 'artifact':
+    case 'release-smoke':
       return 'expensive';
+    case 'release-version':
+    case 'release-config':
+      return 'light';
+    case 'build':
+      return 'medium';
     default:
       return 'medium';
   }

--- a/scripts/lib/commandWeight.test.mjs
+++ b/scripts/lib/commandWeight.test.mjs
@@ -16,6 +16,17 @@ describe('classifyCommandWeight', () => {
     expect(classifyCommandWeight({ label: 'visual' })).toBe('expensive');
     expect(classifyCommandWeight({ label: 'mutation' })).toBe('expensive');
   });
+
+  it('treats release artifact and smoke checks as expensive', () => {
+    expect(classifyCommandWeight({ label: 'artifact' })).toBe('expensive');
+    expect(classifyCommandWeight({ label: 'release-smoke' })).toBe('expensive');
+  });
+
+  it('keeps release-version and release-config light, and build medium', () => {
+    expect(classifyCommandWeight({ label: 'release-version' })).toBe('light');
+    expect(classifyCommandWeight({ label: 'release-config' })).toBe('light');
+    expect(classifyCommandWeight({ label: 'build' })).toBe('medium');
+  });
 });
 
 describe('resolveEslintConcurrency', () => {

--- a/scripts/lib/e2eRisk.mjs
+++ b/scripts/lib/e2eRisk.mjs
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const VISUAL_SPEC_PREFIX = 'tests/e2e/visual/';
+const RELEASE_SPEC_PREFIX = 'tests/e2e/release/';
 const E2E_DIR_PREFIX = 'tests/e2e/';
 const APP_E2E_SPEC_DIR = 'tests/e2e';
 const STORIES_PATTERN = /\.stories\.(ts|tsx|js|jsx|mjs|vue)$/;
@@ -176,8 +177,20 @@ export function isVisualE2ESpecPath(filePath) {
 }
 
 /**
- * Check whether a changed file is a non-visual app e2e spec under
- * `tests/e2e/`.
+ * Check whether a changed file is a release-only e2e spec under
+ * `tests/e2e/release/`. Release specs run against the production artifact
+ * via `playwright.release.config.ts` / `pnpm verify --full`, not the
+ * focused dev app e2e resolved here.
+ * @param filePath Repository-relative changed file path.
+ * @returns True when the path is a release e2e spec.
+ */
+export function isReleaseE2ESpecPath(filePath) {
+  return filePath.startsWith(RELEASE_SPEC_PREFIX);
+}
+
+/**
+ * Check whether a changed file is a non-visual, non-release app e2e spec
+ * under `tests/e2e/`.
  * @param filePath Repository-relative changed file path.
  * @returns True when the path is an app e2e spec file.
  */
@@ -185,14 +198,16 @@ export function isAppE2ESpecPath(filePath) {
   return (
     filePath.startsWith(E2E_DIR_PREFIX) &&
     !isVisualE2ESpecPath(filePath) &&
+    !isReleaseE2ESpecPath(filePath) &&
     filePath.endsWith('.spec.ts')
   );
 }
 
 /**
  * Check whether a changed file is a non-spec e2e helper/fixture/page-object
- * under `tests/e2e/` (excluding visual). These are reverse-resolved
- * conservatively to a full app e2e run by {@link resolveAppE2EPlan}.
+ * under `tests/e2e/` (excluding visual and release). These are
+ * reverse-resolved conservatively to a full app e2e run by
+ * {@link resolveAppE2EPlan}.
  * @param filePath Repository-relative changed file path.
  * @returns True when the path is an app e2e support file.
  */
@@ -200,6 +215,7 @@ export function isAppE2ESupportPath(filePath) {
   return (
     filePath.startsWith(E2E_DIR_PREFIX) &&
     !isVisualE2ESpecPath(filePath) &&
+    !isReleaseE2ESpecPath(filePath) &&
     !isAppE2ESpecPath(filePath) &&
     filePath.endsWith('.ts')
   );

--- a/scripts/lib/e2eRisk.test.mjs
+++ b/scripts/lib/e2eRisk.test.mjs
@@ -3,11 +3,34 @@ import { describe, expect, it } from 'vitest';
 import {
   APP_E2E_STANDALONE_SPECS,
   E2E_SCENARIO_SCOPES,
+  isAppE2ESpecPath,
+  isAppE2ESupportPath,
   isLowLevelE2EPath,
+  isReleaseE2ESpecPath,
   isUnmappedSourcePath,
   resolveAppE2EPlan,
   validateE2EScenarioRegistry,
 } from './e2eRisk.mjs';
+
+describe('isReleaseE2ESpecPath', () => {
+  it('flags specs under tests/e2e/release/', () => {
+    expect(isReleaseE2ESpecPath('tests/e2e/release/productionArtifactSmoke.spec.ts')).toBe(true);
+  });
+
+  it('does not flag regular app e2e specs', () => {
+    expect(isReleaseE2ESpecPath('tests/e2e/appSmoke.spec.ts')).toBe(false);
+  });
+});
+
+describe('isAppE2ESpecPath and isAppE2ESupportPath exclude release specs', () => {
+  it('does not classify a release spec as an app e2e spec', () => {
+    expect(isAppE2ESpecPath('tests/e2e/release/productionArtifactSmoke.spec.ts')).toBe(false);
+  });
+
+  it('does not classify a release spec as app e2e support', () => {
+    expect(isAppE2ESupportPath('tests/e2e/release/productionArtifactSmoke.spec.ts')).toBe(false);
+  });
+});
 
 describe('isLowLevelE2EPath', () => {
   it('flags playwright config and verify tooling', () => {
@@ -191,6 +214,12 @@ describe('resolveAppE2EPlan', () => {
 
   it('does not trigger app e2e for visual-only spec changes', () => {
     const plan = resolveAppE2EPlan(['tests/e2e/visual/shared-ui.spec.ts']);
+
+    expect(plan.mode).toBe('skip');
+  });
+
+  it('does not trigger focused app e2e for release-only spec changes', () => {
+    const plan = resolveAppE2EPlan(['tests/e2e/release/productionArtifactSmoke.spec.ts']);
 
     expect(plan.mode).toBe('skip');
   });

--- a/scripts/release/artifactServer.mjs
+++ b/scripts/release/artifactServer.mjs
@@ -1,0 +1,160 @@
+import { createServer } from 'node:http';
+import { readFile, stat } from 'node:fs/promises';
+import { extname, join, normalize, resolve, sep } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import toolingConfig from '../../config/tooling.json' with { type: 'json' };
+import { buildSpaFallbackHtml } from '../pages/writeSpaFallback.mjs';
+
+const MIME_TYPES = {
+  '.css': 'text/css; charset=utf-8',
+  '.gif': 'image/gif',
+  '.html': 'text/html; charset=utf-8',
+  '.ico': 'image/x-icon',
+  '.jpeg': 'image/jpeg',
+  '.jpg': 'image/jpeg',
+  '.js': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.txt': 'text/plain; charset=utf-8',
+  '.wasm': 'application/wasm',
+  '.webmanifest': 'application/manifest+json',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+};
+
+function getContentType(filePath) {
+  return MIME_TYPES[extname(filePath).toLowerCase()] ?? 'application/octet-stream';
+}
+
+/**
+ * Resolve a decoded request pathname to a dist file path under a deployment
+ * base path, guarding against path traversal outside `distDir`.
+ * @param distDir Absolute production build output directory.
+ * @param basePath Deployment base path, e.g. `/mioframe/`.
+ * @param pathname Decoded request pathname, e.g. `/mioframe/assets/app.js`.
+ * @returns Absolute candidate file path, or `null` when the pathname is
+ * outside `basePath` or would escape `distDir`.
+ */
+export function resolveArtifactFilePath(distDir, basePath, pathname) {
+  if (!pathname.startsWith(basePath)) {
+    return null;
+  }
+
+  const relative = pathname.slice(basePath.length) || 'index.html';
+  const absoluteDistDir = resolve(distDir);
+  const candidate = normalize(join(absoluteDistDir, relative));
+
+  if (candidate !== absoluteDistDir && !candidate.startsWith(absoluteDistDir + sep)) {
+    return null;
+  }
+
+  return candidate;
+}
+
+async function readExistingFile(filePath) {
+  const stats = await stat(filePath);
+
+  if (stats.isDirectory()) {
+    throw new Error(`${filePath} is a directory`);
+  }
+
+  return readFile(filePath);
+}
+
+/**
+ * Start a static server that reproduces GitHub Pages project-page hosting
+ * for a built `dist/` artifact: files are served under `basePath`, and any
+ * unmatched path returns the site-wide SPA fallback redirect
+ * (`docs/release.md#production-artifact-validation`) with a 404 status —
+ * the same behavior GitHub Pages has for the repository's single root
+ * `404.html` across the whole Pages site.
+ * @param options Server configuration.
+ * @param options.distDir Absolute or relative production build output directory.
+ * @param options.basePath Deployment base path, e.g. `/mioframe/`.
+ * @param [options.host] Host to bind to.
+ * @param [options.port] Port to bind to; `0` picks a free port.
+ * @returns Running server handle with its base URL and a `close` function.
+ */
+export function createArtifactServer({ distDir, basePath, host = '127.0.0.1', port = 0 }) {
+  const fallbackHtml = buildSpaFallbackHtml(basePath);
+
+  const server = createServer((req, res) => {
+    void handleRequest(req, res, { distDir, basePath, fallbackHtml });
+  });
+
+  return new Promise((resolvePromise, reject) => {
+    server.once('error', reject);
+    server.listen(port, host, () => {
+      const address = server.address();
+      const actualPort = typeof address === 'object' && address ? address.port : port;
+
+      resolvePromise({
+        server,
+        url: `http://${host}:${actualPort}${basePath}`,
+        close: () => new Promise((closeResolve) => server.close(() => closeResolve())),
+      });
+    });
+  });
+}
+
+async function handleRequest(req, res, { distDir, basePath, fallbackHtml }) {
+  const requestUrl = new URL(req.url ?? '/', 'http://artifact-server.invalid');
+  const pathname = decodeURIComponent(requestUrl.pathname);
+  const filePath = resolveArtifactFilePath(distDir, basePath, pathname);
+
+  if (filePath) {
+    try {
+      const body = await readExistingFile(filePath);
+      res.writeHead(200, { 'Content-Type': getContentType(filePath) });
+      res.end(body);
+      return;
+    } catch {
+      // Falls through to the site-wide 404 fallback below, matching
+      // GitHub Pages behavior for any path with no matching file.
+    }
+  }
+
+  res.writeHead(404, { 'Content-Type': 'text/html; charset=utf-8' });
+  res.end(fallbackHtml);
+}
+
+function parseArgs(argv) {
+  const getValue = (flag) => {
+    const index = argv.indexOf(flag);
+    return index !== -1 ? argv[index + 1] : undefined;
+  };
+
+  return {
+    distDir: getValue('--dist') ?? 'dist',
+    basePath: getValue('--base') ?? toolingConfig.release.basePath,
+    host: getValue('--host') ?? toolingConfig.localServer.host,
+    port: Number(getValue('--port') ?? toolingConfig.release.artifactServer.port),
+  };
+}
+
+async function main() {
+  const { distDir, basePath, host, port } = parseArgs(process.argv.slice(2));
+  const { url, close } = await createArtifactServer({ distDir, basePath, host, port });
+
+  console.log(`Release artifact server listening at ${url}`);
+
+  const shutdown = async () => {
+    await close();
+    process.exit(0);
+  };
+
+  process.once('SIGINT', shutdown);
+  process.once('SIGTERM', shutdown);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/release/artifactServer.test.mjs
+++ b/scripts/release/artifactServer.test.mjs
@@ -1,0 +1,87 @@
+// @vitest-environment node
+// This test exercises a real Node HTTP server; the default happy-dom
+// environment's fetch() enforces same-origin/CORS semantics that do not
+// apply to plain Node-to-Node requests.
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, sep } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createArtifactServer, resolveArtifactFilePath } from './artifactServer.mjs';
+
+describe('resolveArtifactFilePath', () => {
+  it('maps the base root to index.html', () => {
+    expect(resolveArtifactFilePath('dist', '/mioframe/', '/mioframe/')).toBe(
+      resolve('dist', 'index.html'),
+    );
+  });
+
+  it('maps a nested asset path under the base', () => {
+    expect(resolveArtifactFilePath('dist', '/mioframe/', '/mioframe/assets/app.js')).toBe(
+      resolve('dist', 'assets', 'app.js'),
+    );
+  });
+
+  it('returns null for a path outside the base', () => {
+    expect(resolveArtifactFilePath('dist', '/mioframe/', '/other/app.js')).toBeNull();
+  });
+
+  it('returns null when a path traversal would escape distDir', () => {
+    expect(resolveArtifactFilePath('dist', '/mioframe/', '/mioframe/../../etc/passwd')).toBeNull();
+  });
+
+  it('keeps a distDir-relative path that stays within distDir', () => {
+    const filePath = resolveArtifactFilePath('dist', '/mioframe/', '/mioframe/sub/dir/file.txt');
+    expect(filePath).toBe(resolve('dist', 'sub', 'dir', 'file.txt'));
+    expect(filePath.startsWith(resolve('dist') + sep)).toBe(true);
+  });
+});
+
+describe('createArtifactServer', () => {
+  let distDir = '';
+  let server;
+
+  beforeEach(() => {
+    distDir = mkdtempSync(join(tmpdir(), 'artifact-server-'));
+    writeFileSync(join(distDir, 'index.html'), '<!doctype html><title>app</title>');
+    writeFileSync(join(distDir, 'manifest.webmanifest'), '{"name":"app"}');
+  });
+
+  afterEach(async () => {
+    await server?.close();
+    rmSync(distDir, { recursive: true, force: true });
+  });
+
+  it('serves an existing file under the base path with a 200 status', async () => {
+    server = await createArtifactServer({ distDir, basePath: '/mioframe/' });
+
+    const response = await fetch(`${server.url}manifest.webmanifest`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ name: 'app' });
+  });
+
+  it('serves index.html at the base root', async () => {
+    server = await createArtifactServer({ distDir, basePath: '/mioframe/' });
+
+    const response = await fetch(server.url);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('<title>app</title>');
+  });
+
+  it('returns the site-wide SPA fallback with a 404 status for an unmatched deep route', async () => {
+    server = await createArtifactServer({ distDir, basePath: '/mioframe/' });
+
+    const response = await fetch(`${server.url}some/deep/route`);
+    expect(response.status).toBe(404);
+    const body = await response.text();
+    expect(body).toContain('"/mioframe/"');
+    expect(body).toContain("sessionStorage.setItem('ghPagesSpaFallback'");
+  });
+
+  it('returns the same fallback for a path outside the base', async () => {
+    server = await createArtifactServer({ distDir, basePath: '/mioframe/' });
+
+    const response = await fetch(`${server.url.replace(/\/mioframe\/$/, '/')}other-app/`);
+    expect(response.status).toBe(404);
+  });
+});

--- a/scripts/release/buildArtifact.mjs
+++ b/scripts/release/buildArtifact.mjs
@@ -1,0 +1,138 @@
+import { copyFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import toolingConfig from '../../config/tooling.json' with { type: 'json' };
+import { runGuardedExpensiveLocalCommand } from '../lib/localCommandGuard.mjs';
+import { applyProcessResult } from '../lib/processResult.mjs';
+import { runLocalCommand } from '../lib/runLocalCommand.mjs';
+
+const defaultDeps = {
+  applyProcessResult,
+  runGuardedExpensiveLocalCommand,
+  runLocalCommand,
+};
+
+/**
+ * Resolve the GitHub Pages base path for a release artifact build.
+ * @param [argv] Raw CLI arguments.
+ * @param [env] Process environment.
+ * @returns Resolved base path, e.g. `/mioframe/`.
+ */
+export function resolveArtifactBasePath(argv = process.argv.slice(2), env = process.env) {
+  const baseIndex = argv.indexOf('--base');
+
+  if (baseIndex !== -1 && argv[baseIndex + 1]) {
+    return argv[baseIndex + 1];
+  }
+
+  if (env.BASE_URL) {
+    return env.BASE_URL;
+  }
+
+  return toolingConfig.release.basePath;
+}
+
+/**
+ * Resolve the `vite build` output directory for a release artifact build.
+ * @param [argv] Raw CLI arguments.
+ * @returns Resolved dist directory, defaults to `dist`.
+ */
+export function resolveArtifactDistDir(argv = process.argv.slice(2)) {
+  const distIndex = argv.indexOf('--dist');
+
+  if (distIndex !== -1 && argv[distIndex + 1]) {
+    return argv[distIndex + 1];
+  }
+
+  return 'dist';
+}
+
+/**
+ * Build the production artifact used by release artifact/smoke verification:
+ * a real `vite build` under the GitHub Pages base path, followed by the same
+ * `dist/index.html` -> `dist/404.html` copy the stable deploy job performs.
+ *
+ * When `RELEASE_ARTIFACT_SKIP_BUILD=1` is set, this reuses an existing
+ * `dist/index.html` instead of rebuilding. `scripts/verify.mjs` sets this for
+ * the `artifact`/`release-smoke` release-only checks only when the earlier
+ * `build` check already produced a fresh artifact in the same run, so a
+ * single `pnpm verify:release` run does not build the production artifact
+ * three times (once per check that needs it). Standalone invocations (e.g.
+ * `pnpm e2e:release`, `pnpm verify --full --only artifact`) never set this
+ * flag and always build their own artifact.
+ * @param [argv] Raw CLI arguments.
+ * @param [deps] Test seams for guarded execution and result handling.
+ * @param [env] Process environment, for the reuse-if-prebuilt test seam.
+ */
+export async function runBuildArtifact(
+  argv = process.argv.slice(2),
+  deps = defaultDeps,
+  env = process.env,
+) {
+  const basePath = resolveArtifactBasePath(argv, env);
+  const distDir = resolveArtifactDistDir(argv);
+  const indexPath = join(distDir, 'index.html');
+
+  if (env.RELEASE_ARTIFACT_SKIP_BUILD === '1') {
+    if (!existsSync(indexPath)) {
+      console.error(
+        `RELEASE_ARTIFACT_SKIP_BUILD=1 was set, but no existing production build was found at ${indexPath}. ` +
+          'Rerun without RELEASE_ARTIFACT_SKIP_BUILD so this step builds the artifact itself.',
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    copyFileSync(indexPath, join(distDir, '404.html'));
+    console.log(`Reusing existing production artifact at ${distDir} (base ${basePath}).`);
+    return;
+  }
+
+  // Invoke the local vite binary directly (not `pnpm exec`): this also runs
+  // inside the Playwright container's webServer command (see
+  // playwright.release.config.ts), where `pnpm` is not installed.
+  const viteBin = './node_modules/.bin/vite';
+  const args = ['build'];
+
+  const result = await deps.runGuardedExpensiveLocalCommand(
+    {
+      label: 'release-build',
+      command: `${viteBin} ${args.join(' ')}`,
+      executable: viteBin,
+      args,
+      env: { ...process.env, BASE_URL: basePath },
+      run: (lockEnv) =>
+        deps.runLocalCommand({
+          command: viteBin,
+          args,
+          env: { ...process.env, ...lockEnv, BASE_URL: basePath },
+        }),
+    },
+    deps,
+  );
+
+  if (result.status !== 0 || result.signal) {
+    deps.applyProcessResult(result);
+    return;
+  }
+
+  if (!existsSync(indexPath)) {
+    console.error(`Production build did not produce ${indexPath}.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  copyFileSync(indexPath, join(distDir, '404.html'));
+  console.log(`Production artifact built at ${distDir} (base ${basePath}).`);
+  deps.applyProcessResult(result);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    await runBuildArtifact();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/release/buildArtifact.test.mjs
+++ b/scripts/release/buildArtifact.test.mjs
@@ -1,0 +1,103 @@
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  resolveArtifactBasePath,
+  resolveArtifactDistDir,
+  runBuildArtifact,
+} from './buildArtifact.mjs';
+
+describe('resolveArtifactBasePath', () => {
+  it('uses the tooling.json release base path by default', () => {
+    expect(resolveArtifactBasePath([], {})).toBe('/mioframe/');
+  });
+
+  it('prefers an explicit --base flag', () => {
+    expect(resolveArtifactBasePath(['--base', '/custom/'], { BASE_URL: '/env/' })).toBe('/custom/');
+  });
+
+  it('falls back to the BASE_URL environment variable', () => {
+    expect(resolveArtifactBasePath([], { BASE_URL: '/env/' })).toBe('/env/');
+  });
+});
+
+describe('resolveArtifactDistDir', () => {
+  it('defaults to dist', () => {
+    expect(resolveArtifactDistDir([])).toBe('dist');
+  });
+
+  it('uses an explicit --dist flag', () => {
+    expect(resolveArtifactDistDir(['--dist', 'custom-dist'])).toBe('custom-dist');
+  });
+});
+
+describe('runBuildArtifact with RELEASE_ARTIFACT_SKIP_BUILD', () => {
+  let distDir;
+
+  beforeEach(() => {
+    process.exitCode = 0;
+  });
+
+  afterEach(() => {
+    if (distDir) {
+      rmSync(distDir, { recursive: true, force: true });
+      distDir = undefined;
+    }
+  });
+
+  it('reuses an existing dist/index.html instead of rebuilding', async () => {
+    distDir = mkdtempSync(join(tmpdir(), 'release-artifact-'));
+    writeFileSync(join(distDir, 'index.html'), '<html></html>');
+    const deps = {
+      applyProcessResult: vi.fn(),
+      runGuardedExpensiveLocalCommand: vi.fn(),
+      runLocalCommand: vi.fn(),
+    };
+
+    await runBuildArtifact(['--dist', distDir], deps, { RELEASE_ARTIFACT_SKIP_BUILD: '1' });
+
+    expect(deps.runGuardedExpensiveLocalCommand).not.toHaveBeenCalled();
+    expect(existsSync(join(distDir, '404.html'))).toBe(true);
+    expect(process.exitCode).not.toBe(1);
+  });
+
+  it('fails clearly when asked to reuse a build that does not exist', async () => {
+    distDir = mkdtempSync(join(tmpdir(), 'release-artifact-'));
+    const deps = {
+      applyProcessResult: vi.fn(),
+      runGuardedExpensiveLocalCommand: vi.fn(),
+      runLocalCommand: vi.fn(),
+    };
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await runBuildArtifact(['--dist', distDir], deps, { RELEASE_ARTIFACT_SKIP_BUILD: '1' });
+
+    expect(deps.runGuardedExpensiveLocalCommand).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('no existing production build'),
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('builds normally when the skip flag is not set', async () => {
+    distDir = mkdtempSync(join(tmpdir(), 'release-artifact-'));
+    const deps = {
+      applyProcessResult: vi.fn(),
+      runGuardedExpensiveLocalCommand: vi.fn(async () => {
+        writeFileSync(join(distDir, 'index.html'), '<html></html>');
+        return { status: 0, signal: null };
+      }),
+      runLocalCommand: vi.fn(),
+    };
+
+    await runBuildArtifact(['--dist', distDir], deps, {});
+
+    expect(deps.runGuardedExpensiveLocalCommand).toHaveBeenCalledTimes(1);
+    expect(existsSync(join(distDir, '404.html'))).toBe(true);
+    expect(deps.applyProcessResult).toHaveBeenCalledWith({ status: 0, signal: null });
+  });
+});

--- a/scripts/release/validateReleaseConfig.mjs
+++ b/scripts/release/validateReleaseConfig.mjs
@@ -1,0 +1,189 @@
+import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+const OPTIONAL_ENV_KEYS = ['VITE_GOOGLE_CLIENT_ID', 'VITE_SENTRY_DSN', 'SENTRY_AUTH_TOKEN'];
+const PR_PREVIEW_PATH_PATTERN = /\/pr-\d+\/?/;
+
+/**
+ * Read and parse a JSON file, for release config validation.
+ * @param filePath Path to the JSON file.
+ * @param readFile Injectable file reader, for tests.
+ * @returns Parsed JSON contents.
+ */
+function readJson(filePath, readFile) {
+  return JSON.parse(readFile(filePath, 'utf8'));
+}
+
+/**
+ * Validate release-only config assumptions that are not covered by
+ * `validateVersion.mjs`: base path consistency, PWA/preview-mode assumptions,
+ * and env/config presence semantics for the release artifact build and
+ * stable deploy. See `docs/release.md#release-config-validation`.
+ *
+ * Deliberately does not read or validate secret values themselves — only
+ * their presence/absence and consistency with release-mode assumptions
+ * (docs/release.md).
+ * @param [options] Validation inputs.
+ * @param [options.env] Process environment.
+ * @param [options.deps] Test seams for file/process access and logging.
+ * @returns `true` when validation passed, `false` otherwise. Also sets
+ * `process.exitCode` on failure.
+ */
+export function validateReleaseConfig({ env = process.env, deps = {} } = {}) {
+  const { readFile = readFileSync, log = console.log, logError = console.error } = deps;
+
+  const errors = [];
+  const notices = [];
+
+  let packageJson;
+  let toolingConfig;
+
+  try {
+    packageJson = readJson('package.json', readFile);
+  } catch (readError) {
+    return finish({
+      errors: [
+        `Unable to read/parse package.json: ${readError instanceof Error ? readError.message : String(readError)}`,
+      ],
+      notices,
+      log,
+      logError,
+    });
+  }
+
+  try {
+    toolingConfig = readJson('config/tooling.json', readFile);
+  } catch (readError) {
+    return finish({
+      errors: [
+        `Unable to read/parse config/tooling.json: ${readError instanceof Error ? readError.message : String(readError)}`,
+      ],
+      notices,
+      log,
+      logError,
+    });
+  }
+
+  if (typeof packageJson.name !== 'string' || packageJson.name.trim() === '') {
+    errors.push('package.json is missing a string "name" field.');
+  }
+
+  const expectedBasePath = `/${packageJson.name}/`;
+  const actualBasePath = toolingConfig.release?.basePath;
+
+  if (typeof actualBasePath !== 'string' || actualBasePath.trim() === '') {
+    errors.push('config/tooling.json is missing release.basePath.');
+  } else if (actualBasePath !== expectedBasePath) {
+    errors.push(
+      `config/tooling.json release.basePath "${actualBasePath}" does not match "${expectedBasePath}" derived from package.json name "${packageJson.name}". ` +
+        'Release artifact validation, stable deploy, and GitHub Pages hosting must all agree on this base path.',
+    );
+  } else {
+    notices.push(`release base path: ${expectedBasePath}`);
+  }
+
+  if (env.VITE_DISABLE_PWA === '1') {
+    errors.push(
+      'VITE_DISABLE_PWA=1 is set. Release artifact validation and stable deploy must build with PWA enabled; ' +
+        'VITE_DISABLE_PWA=1 is a PR-preview-only setting (see the deploy-preview job in .github/workflows/verify.yml).',
+    );
+  } else {
+    notices.push('VITE_DISABLE_PWA: not set (PWA enabled, as required for release)');
+  }
+
+  if (typeof env.BASE_URL === 'string' && env.BASE_URL.length > 0) {
+    if (PR_PREVIEW_PATH_PATTERN.test(env.BASE_URL)) {
+      errors.push(
+        `BASE_URL "${env.BASE_URL}" looks like a PR preview path. Release artifact validation and stable deploy ` +
+          `must use the stable base path (${expectedBasePath}), not a PR preview path.`,
+      );
+    } else if (actualBasePath && env.BASE_URL !== actualBasePath) {
+      errors.push(
+        `BASE_URL "${env.BASE_URL}" does not match config/tooling.json release.basePath "${actualBasePath}".`,
+      );
+    } else {
+      notices.push(`BASE_URL: ${env.BASE_URL}`);
+    }
+  } else {
+    notices.push(
+      `BASE_URL: not set; release tooling falls back to config/tooling.json release.basePath (${expectedBasePath}).`,
+    );
+  }
+
+  const isGithubActions = env.GITHUB_ACTIONS === 'true';
+
+  for (const key of OPTIONAL_ENV_KEYS) {
+    if (!(key in env)) {
+      notices.push(
+        `${key}: not set (optional; the dependent feature is disabled at build/runtime)`,
+      );
+      continue;
+    }
+
+    if (env[key].trim() === '') {
+      if (isGithubActions) {
+        // GitHub Actions expands `${{ secrets.X }}` to an empty string when the
+        // secret is not configured, and there is no way from inside the job to
+        // tell that apart from an explicitly empty value. Treat it the same as
+        // "not set" here instead of failing the release gate for an optional
+        // integration that was never configured.
+        notices.push(
+          `${key}: set but empty in GitHub Actions (treated as not configured, not an error — ` +
+            'GitHub Actions cannot distinguish an absent secret from an explicit empty value)',
+        );
+        continue;
+      }
+
+      errors.push(
+        `${key} is set but empty. An empty value silently disables the dependent feature without a clear signal — ` +
+          'either remove the variable/secret entirely, or provide a real value.',
+      );
+      continue;
+    }
+
+    notices.push(`${key}: set`);
+  }
+
+  const hasSentryDsn = typeof env.VITE_SENTRY_DSN === 'string' && env.VITE_SENTRY_DSN.trim() !== '';
+  const hasSentryAuthToken =
+    typeof env.SENTRY_AUTH_TOKEN === 'string' && env.SENTRY_AUTH_TOKEN.trim() !== '';
+
+  if (hasSentryDsn && !hasSentryAuthToken) {
+    notices.push(
+      'VITE_SENTRY_DSN is set without SENTRY_AUTH_TOKEN: runtime error reporting is enabled, but source maps will not be uploaded to Sentry.',
+    );
+  } else if (!hasSentryDsn && hasSentryAuthToken) {
+    notices.push(
+      'SENTRY_AUTH_TOKEN is set without VITE_SENTRY_DSN: the Sentry build plugin may run and upload artifacts, but the runtime will not report errors (no DSN).',
+    );
+  }
+
+  return finish({ errors, notices, log, logError });
+}
+
+function finish({ errors, notices, log, logError }) {
+  for (const notice of notices) {
+    log(`[release-config] ${notice}`);
+  }
+
+  if (errors.length > 0) {
+    for (const message of errors) {
+      logError(`[release-config] ERROR: ${message}`);
+    }
+
+    process.exitCode = 1;
+    return false;
+  }
+
+  log('[release-config] passed');
+  return true;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    validateReleaseConfig();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/release/validateReleaseConfig.test.mjs
+++ b/scripts/release/validateReleaseConfig.test.mjs
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { validateReleaseConfig } from './validateReleaseConfig.mjs';
+
+describe('validateReleaseConfig', () => {
+  const baseDeps = () => ({
+    readFile: vi.fn((filePath) => {
+      if (filePath === 'package.json') {
+        return JSON.stringify({ name: 'mioframe' });
+      }
+
+      if (filePath === 'config/tooling.json') {
+        return JSON.stringify({ release: { basePath: '/mioframe/' } });
+      }
+
+      throw new Error(`unexpected readFile: ${filePath}`);
+    }),
+    log: vi.fn(),
+    logError: vi.fn(),
+  });
+
+  it('passes with a matching base path, PWA enabled, and no env set', () => {
+    const deps = baseDeps();
+    const result = validateReleaseConfig({ env: {}, deps });
+    expect(result).toBe(true);
+    expect(deps.logError).not.toHaveBeenCalled();
+  });
+
+  it('fails when release.basePath does not match package.json name', () => {
+    const deps = baseDeps();
+    deps.readFile = vi.fn((filePath) => {
+      if (filePath === 'package.json') return JSON.stringify({ name: 'mioframe' });
+      if (filePath === 'config/tooling.json') {
+        return JSON.stringify({ release: { basePath: '/wrong/' } });
+      }
+      throw new Error(`unexpected readFile: ${filePath}`);
+    });
+    const result = validateReleaseConfig({ env: {}, deps });
+    expect(result).toBe(false);
+    expect(deps.logError).toHaveBeenCalledWith(
+      expect.stringContaining('does not match "/mioframe/"'),
+    );
+  });
+
+  it('fails when release.basePath is missing', () => {
+    const deps = baseDeps();
+    deps.readFile = vi.fn((filePath) => {
+      if (filePath === 'package.json') return JSON.stringify({ name: 'mioframe' });
+      if (filePath === 'config/tooling.json') return JSON.stringify({ release: {} });
+      throw new Error(`unexpected readFile: ${filePath}`);
+    });
+    const result = validateReleaseConfig({ env: {}, deps });
+    expect(result).toBe(false);
+    expect(deps.logError).toHaveBeenCalledWith(expect.stringContaining('missing release.basePath'));
+  });
+
+  it('fails when VITE_DISABLE_PWA is 1', () => {
+    const deps = baseDeps();
+    const result = validateReleaseConfig({ env: { VITE_DISABLE_PWA: '1' }, deps });
+    expect(result).toBe(false);
+    expect(deps.logError).toHaveBeenCalledWith(expect.stringContaining('VITE_DISABLE_PWA=1'));
+  });
+
+  it('fails when BASE_URL looks like a PR preview path', () => {
+    const deps = baseDeps();
+    const result = validateReleaseConfig({ env: { BASE_URL: '/mioframe/pr-42/' }, deps });
+    expect(result).toBe(false);
+    expect(deps.logError).toHaveBeenCalledWith(expect.stringContaining('PR preview path'));
+  });
+
+  it('fails when BASE_URL does not match the configured release base path', () => {
+    const deps = baseDeps();
+    const result = validateReleaseConfig({ env: { BASE_URL: '/other/' }, deps });
+    expect(result).toBe(false);
+    expect(deps.logError).toHaveBeenCalledWith(
+      expect.stringContaining('does not match config/tooling.json release.basePath'),
+    );
+  });
+
+  it('passes when BASE_URL matches the configured release base path', () => {
+    const deps = baseDeps();
+    const result = validateReleaseConfig({ env: { BASE_URL: '/mioframe/' }, deps });
+    expect(result).toBe(true);
+  });
+
+  it('fails when an optional env var is set but empty outside GitHub Actions', () => {
+    const deps = baseDeps();
+    const result = validateReleaseConfig({ env: { VITE_SENTRY_DSN: '' }, deps });
+    expect(result).toBe(false);
+    expect(deps.logError).toHaveBeenCalledWith(
+      expect.stringContaining('VITE_SENTRY_DSN is set but empty'),
+    );
+  });
+
+  it('does not fail when an optional env var is set but empty inside GitHub Actions', () => {
+    const deps = baseDeps();
+    const result = validateReleaseConfig({
+      env: { GITHUB_ACTIONS: 'true', VITE_SENTRY_DSN: '' },
+      deps,
+    });
+    expect(result).toBe(true);
+    expect(deps.logError).not.toHaveBeenCalled();
+    expect(deps.log).toHaveBeenCalledWith(
+      expect.stringContaining('VITE_SENTRY_DSN: set but empty in GitHub Actions'),
+    );
+  });
+
+  it('reports optional env vars as unset without failing', () => {
+    const deps = baseDeps();
+    const result = validateReleaseConfig({ env: {}, deps });
+    expect(result).toBe(true);
+    expect(deps.log).toHaveBeenCalledWith(
+      expect.stringContaining('VITE_GOOGLE_CLIENT_ID: not set'),
+    );
+  });
+
+  it('notices partial Sentry configuration without failing', () => {
+    const deps = baseDeps();
+    const result = validateReleaseConfig({ env: { VITE_SENTRY_DSN: 'https://dsn' }, deps });
+    expect(result).toBe(true);
+    expect(deps.log).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'runtime error reporting is enabled, but source maps will not be uploaded',
+      ),
+    );
+  });
+});

--- a/scripts/release/validateVersion.mjs
+++ b/scripts/release/validateVersion.mjs
@@ -1,0 +1,286 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const SEMVER_PATTERN = /^(\d+)\.(\d+)\.(\d+)$/;
+const TAG_PATTERN = /^v(\d+\.\d+\.\d+)$/;
+
+/**
+ * Parse a strict `X.Y.Z` SemVer version (no pre-release/build metadata).
+ * @param version Raw version string.
+ * @returns Parsed `{ major, minor, patch }`, or `null` when invalid.
+ */
+export function parseSemver(version) {
+  const match = SEMVER_PATTERN.exec(version.trim());
+
+  if (!match) {
+    return null;
+  }
+
+  const [, major, minor, patch] = match;
+  return { major: Number(major), minor: Number(minor), patch: Number(patch) };
+}
+
+/**
+ * Compare two parsed SemVer versions.
+ * @param left First version.
+ * @param right Second version.
+ * @returns Negative when `left` < `right`, positive when `left` > `right`, `0` when equal.
+ */
+export function compareSemver(left, right) {
+  if (left.major !== right.major) {
+    return left.major - right.major;
+  }
+
+  if (left.minor !== right.minor) {
+    return left.minor - right.minor;
+  }
+
+  return left.patch - right.patch;
+}
+
+/**
+ * Read the `version` field out of a `package.json` file.
+ * @param packageJsonPath Path to the `package.json` file.
+ * @param readFile Injectable file reader, for tests.
+ * @returns The raw version string.
+ */
+export function readPackageVersion(packageJsonPath = 'package.json', readFile = readFileSync) {
+  const raw = readFile(packageJsonPath, 'utf8');
+  const parsed = JSON.parse(raw);
+
+  if (typeof parsed.version !== 'string' || parsed.version.trim() === '') {
+    throw new Error(`${packageJsonPath} is missing a string "version" field.`);
+  }
+
+  return parsed.version;
+}
+
+/**
+ * Read the `version` field of `package.json` as it existed at a given git ref.
+ * @param ref Git ref, e.g. `origin/develop`.
+ * @param packageJsonPath Path to `package.json` relative to the repo root.
+ * @param spawn Injectable `spawnSync`, for tests.
+ * @returns The raw version string, or `null` when the ref/file is unavailable.
+ */
+export function readVersionAtRef(ref, packageJsonPath = 'package.json', spawn = spawnSync) {
+  const result = spawn('git', ['show', `${ref}:${packageJsonPath}`], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  if (result.status !== 0 || typeof result.stdout !== 'string') {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(result.stdout);
+    return typeof parsed.version === 'string' ? parsed.version : null;
+  } catch {
+    return null;
+  }
+}
+
+function getFlagValue(argv, flag) {
+  const index = argv.indexOf(flag);
+  return index !== -1 ? argv[index + 1] : undefined;
+}
+
+/**
+ * Resolve the release-version-validation context from CLI flags or CI
+ * environment variables. CLI flags always win, so the check can be run
+ * locally against an explicit ref or tag.
+ * @param env Process environment.
+ * @param argv Raw CLI arguments.
+ * @returns The resolved context describing which checks apply.
+ */
+export function resolveVersionContext(env = process.env, argv = process.argv.slice(2)) {
+  const explicitTag = getFlagValue(argv, '--tag');
+
+  if (explicitTag) {
+    return { kind: 'tag', tag: explicitTag };
+  }
+
+  const explicitBase = getFlagValue(argv, '--base');
+
+  if (explicitBase) {
+    return { kind: 'compare', baseRef: explicitBase, targetBranch: getFlagValue(argv, '--target') };
+  }
+
+  if (env.GITHUB_ACTIONS !== 'true') {
+    return { kind: 'local' };
+  }
+
+  if (typeof env.GITHUB_REF === 'string' && env.GITHUB_REF.startsWith('refs/tags/')) {
+    return { kind: 'tag', tag: env.GITHUB_REF.slice('refs/tags/'.length) };
+  }
+
+  if (env.GITHUB_EVENT_NAME === 'pull_request' && env.GITHUB_BASE_REF) {
+    return {
+      kind: 'compare',
+      baseRef: `origin/${env.GITHUB_BASE_REF}`,
+      targetBranch: env.GITHUB_BASE_REF,
+    };
+  }
+
+  if (env.GITHUB_EVENT_NAME === 'push' && env.GITHUB_REF === 'refs/heads/main') {
+    return { kind: 'push-main' };
+  }
+
+  return { kind: 'ci-other' };
+}
+
+function requiresReleaseNotes(context) {
+  return (
+    context.kind === 'tag' ||
+    context.kind === 'push-main' ||
+    (context.kind === 'compare' && context.targetBranch === 'main')
+  );
+}
+
+/**
+ * Validate release/version metadata: `package.json` version format, a
+ * monotonic bump against the PR base branch, a tag-matches-version check on
+ * tag pushes, and release notes/checklist existence ahead of a `main`
+ * promotion. See `docs/release.md` for the policy this enforces.
+ * @param [options] Validation inputs.
+ * @param [options.argv] Raw CLI arguments.
+ * @param [options.env] Process environment.
+ * @param [options.deps] Test seams for file/process access and logging.
+ * @returns `true` when validation passed, `false` otherwise. Also sets
+ * `process.exitCode` on failure.
+ */
+export function validateRelease({
+  argv = process.argv.slice(2),
+  env = process.env,
+  deps = {},
+} = {}) {
+  const {
+    readFile = readFileSync,
+    spawn = spawnSync,
+    fileExists = existsSync,
+    log = console.log,
+    logError = console.error,
+  } = deps;
+
+  const errors = [];
+  const notices = [];
+  let currentVersionRaw;
+
+  try {
+    currentVersionRaw = readPackageVersion('package.json', readFile);
+  } catch (readError) {
+    return finish({
+      errors: [readError instanceof Error ? readError.message : String(readError)],
+      notices,
+      log,
+      logError,
+    });
+  }
+
+  const currentVersion = parseSemver(currentVersionRaw);
+
+  if (!currentVersion) {
+    errors.push(`package.json version "${currentVersionRaw}" is not a valid X.Y.Z SemVer version.`);
+    return finish({ errors, notices, log, logError });
+  }
+
+  notices.push(`package.json version: ${currentVersionRaw}`);
+
+  const context = resolveVersionContext(env, argv);
+  notices.push(`release context: ${context.kind}`);
+
+  if (context.kind === 'compare') {
+    const baseVersionRaw = readVersionAtRef(context.baseRef, 'package.json', spawn);
+
+    if (baseVersionRaw === null) {
+      errors.push(
+        `Unable to read package.json version at ${context.baseRef}. Fetch the base branch and rerun (git fetch --no-tags origin <base branch>).`,
+      );
+    } else {
+      const baseVersion = parseSemver(baseVersionRaw);
+
+      if (!baseVersion) {
+        errors.push(
+          `${context.baseRef} package.json version "${baseVersionRaw}" is not valid SemVer.`,
+        );
+      } else if (compareSemver(currentVersion, baseVersion) <= 0) {
+        errors.push(
+          `Version must increase for this PR: package.json is ${currentVersionRaw}, ${context.baseRef} is ${baseVersionRaw}. Bump package.json version (docs/release.md#choosing-patch--minor--major).`,
+        );
+      } else {
+        notices.push(`version bump confirmed: ${baseVersionRaw} -> ${currentVersionRaw}`);
+      }
+    }
+  } else if (context.kind === 'tag') {
+    const tagMatch = TAG_PATTERN.exec(context.tag);
+
+    if (!tagMatch) {
+      errors.push(`Tag "${context.tag}" does not match the required vX.Y.Z format.`);
+    } else if (tagMatch[1] !== currentVersionRaw) {
+      errors.push(
+        `Tag "${context.tag}" does not match package.json version "${currentVersionRaw}".`,
+      );
+    } else {
+      notices.push(`tag ${context.tag} matches package.json version`);
+    }
+  } else if (context.kind === 'local') {
+    notices.push(
+      'skipped: PR base-version and tag-match checks require CI context. Pass --base <ref> or --tag vX.Y.Z to check locally.',
+    );
+  } else if (context.kind === 'push-main') {
+    notices.push(
+      'push to main: bump already enforced at PR time; validating format and release notes.',
+    );
+  }
+
+  if (requiresReleaseNotes(context)) {
+    const releaseNotesPath = join('docs', 'releases', `${currentVersionRaw}.md`);
+
+    if (!fileExists(releaseNotesPath)) {
+      errors.push(
+        `Missing release notes for ${currentVersionRaw}: expected ${releaseNotesPath}. Add release notes before promoting to main (docs/release-checklist.md).`,
+      );
+    } else {
+      notices.push(`release notes found: ${releaseNotesPath}`);
+    }
+  }
+
+  if (!fileExists('docs/release-checklist.md')) {
+    errors.push('Missing docs/release-checklist.md.');
+  }
+
+  if (!fileExists('docs/release.md')) {
+    errors.push('Missing docs/release.md.');
+  }
+
+  return finish({ errors, notices, log, logError });
+}
+
+function finish({ errors, notices, log, logError }) {
+  for (const notice of notices) {
+    log(`[release-version] ${notice}`);
+  }
+
+  if (errors.length > 0) {
+    for (const message of errors) {
+      logError(`[release-version] ERROR: ${message}`);
+    }
+
+    process.exitCode = 1;
+    return false;
+  }
+
+  log('[release-version] passed');
+  return true;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    validateRelease();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/release/validateVersion.test.mjs
+++ b/scripts/release/validateVersion.test.mjs
@@ -1,0 +1,240 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  compareSemver,
+  parseSemver,
+  readPackageVersion,
+  readVersionAtRef,
+  resolveVersionContext,
+  validateRelease,
+} from './validateVersion.mjs';
+
+describe('parseSemver', () => {
+  it('parses a valid X.Y.Z version', () => {
+    expect(parseSemver('0.1.0')).toEqual({ major: 0, minor: 1, patch: 0 });
+    expect(parseSemver('12.34.56')).toEqual({ major: 12, minor: 34, patch: 56 });
+  });
+
+  it('rejects a version with a pre-release or build suffix', () => {
+    expect(parseSemver('0.1.0-beta.1')).toBeNull();
+    expect(parseSemver('0.1.0+build.5')).toBeNull();
+  });
+
+  it('rejects a non-SemVer string', () => {
+    expect(parseSemver('0.1')).toBeNull();
+    expect(parseSemver('v0.1.0')).toBeNull();
+    expect(parseSemver('not-a-version')).toBeNull();
+  });
+});
+
+describe('compareSemver', () => {
+  it('orders by major, then minor, then patch', () => {
+    expect(compareSemver(parseSemver('1.0.0'), parseSemver('0.9.9'))).toBeGreaterThan(0);
+    expect(compareSemver(parseSemver('0.2.0'), parseSemver('0.10.0'))).toBeLessThan(0);
+    expect(compareSemver(parseSemver('0.1.1'), parseSemver('0.1.0'))).toBeGreaterThan(0);
+    expect(compareSemver(parseSemver('0.1.0'), parseSemver('0.1.0'))).toBe(0);
+  });
+});
+
+describe('readPackageVersion', () => {
+  it('reads the version field from package.json content', () => {
+    const readFile = vi.fn().mockReturnValue(JSON.stringify({ version: '0.1.0' }));
+    expect(readPackageVersion('package.json', readFile)).toBe('0.1.0');
+    expect(readFile).toHaveBeenCalledWith('package.json', 'utf8');
+  });
+
+  it('throws when the version field is missing', () => {
+    const readFile = vi.fn().mockReturnValue(JSON.stringify({ name: 'mioframe' }));
+    expect(() => readPackageVersion('package.json', readFile)).toThrow(
+      'missing a string "version" field',
+    );
+  });
+});
+
+describe('readVersionAtRef', () => {
+  it('reads the version from a git show result', () => {
+    const spawn = vi.fn().mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify({ version: '0.0.9' }),
+    });
+    expect(readVersionAtRef('origin/develop', 'package.json', spawn)).toBe('0.0.9');
+    expect(spawn).toHaveBeenCalledWith(
+      'git',
+      ['show', 'origin/develop:package.json'],
+      expect.any(Object),
+    );
+  });
+
+  it('returns null when git show fails', () => {
+    const spawn = vi.fn().mockReturnValue({ status: 1, stdout: '' });
+    expect(readVersionAtRef('origin/develop', 'package.json', spawn)).toBeNull();
+  });
+
+  it('returns null when the output is not valid JSON', () => {
+    const spawn = vi.fn().mockReturnValue({ status: 0, stdout: 'not json' });
+    expect(readVersionAtRef('origin/develop', 'package.json', spawn)).toBeNull();
+  });
+});
+
+describe('resolveVersionContext', () => {
+  it('prefers an explicit --tag flag', () => {
+    expect(resolveVersionContext({}, ['--tag', 'v0.1.0'])).toEqual({
+      kind: 'tag',
+      tag: 'v0.1.0',
+    });
+  });
+
+  it('prefers an explicit --base flag over env', () => {
+    expect(
+      resolveVersionContext({ GITHUB_ACTIONS: 'true', GITHUB_EVENT_NAME: 'push' }, [
+        '--base',
+        'origin/main',
+        '--target',
+        'main',
+      ]),
+    ).toEqual({ kind: 'compare', baseRef: 'origin/main', targetBranch: 'main' });
+  });
+
+  it('returns local outside CI with no explicit flags', () => {
+    expect(resolveVersionContext({}, [])).toEqual({ kind: 'local' });
+  });
+
+  it('detects a tag push in GitHub Actions', () => {
+    expect(
+      resolveVersionContext({ GITHUB_ACTIONS: 'true', GITHUB_REF: 'refs/tags/v0.1.0' }, []),
+    ).toEqual({ kind: 'tag', tag: 'v0.1.0' });
+  });
+
+  it('detects a pull_request context in GitHub Actions', () => {
+    expect(
+      resolveVersionContext(
+        {
+          GITHUB_ACTIONS: 'true',
+          GITHUB_EVENT_NAME: 'pull_request',
+          GITHUB_BASE_REF: 'develop',
+        },
+        [],
+      ),
+    ).toEqual({ kind: 'compare', baseRef: 'origin/develop', targetBranch: 'develop' });
+  });
+
+  it('detects a push to main in GitHub Actions', () => {
+    expect(
+      resolveVersionContext(
+        { GITHUB_ACTIONS: 'true', GITHUB_EVENT_NAME: 'push', GITHUB_REF: 'refs/heads/main' },
+        [],
+      ),
+    ).toEqual({ kind: 'push-main' });
+  });
+
+  it('falls back to ci-other for an unrecognized CI event', () => {
+    expect(
+      resolveVersionContext(
+        { GITHUB_ACTIONS: 'true', GITHUB_EVENT_NAME: 'push', GITHUB_REF: 'refs/heads/develop' },
+        [],
+      ),
+    ).toEqual({ kind: 'ci-other' });
+  });
+});
+
+describe('validateRelease', () => {
+  const baseDeps = () => ({
+    readFile: vi.fn().mockReturnValue(JSON.stringify({ version: '0.2.0' })),
+    fileExists: vi.fn().mockReturnValue(true),
+    log: vi.fn(),
+    logError: vi.fn(),
+  });
+
+  it('passes locally when package.json version is valid and docs exist', () => {
+    const deps = baseDeps();
+    const result = validateRelease({ argv: [], env: {}, deps });
+    expect(result).toBe(true);
+    expect(deps.logError).not.toHaveBeenCalled();
+  });
+
+  it('fails when package.json version is not valid SemVer', () => {
+    const deps = baseDeps();
+    deps.readFile = vi.fn().mockReturnValue(JSON.stringify({ version: '0.2' }));
+    const result = validateRelease({ argv: [], env: {}, deps });
+    expect(result).toBe(false);
+  });
+
+  it('passes a PR-to-develop context when the version increased', () => {
+    const deps = baseDeps();
+    deps.spawn = vi.fn().mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify({ version: '0.1.0' }),
+    });
+    const result = validateRelease({
+      argv: ['--base', 'origin/develop', '--target', 'develop'],
+      env: {},
+      deps,
+    });
+    expect(result).toBe(true);
+  });
+
+  it('fails a PR-to-develop context when the version did not increase', () => {
+    const deps = baseDeps();
+    deps.spawn = vi.fn().mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify({ version: '0.2.0' }),
+    });
+    const result = validateRelease({
+      argv: ['--base', 'origin/develop', '--target', 'develop'],
+      env: {},
+      deps,
+    });
+    expect(result).toBe(false);
+    expect(deps.logError).toHaveBeenCalledWith(
+      expect.stringContaining('Version must increase for this PR'),
+    );
+  });
+
+  it('fails a PR-to-main context and requires release notes when the version increased', () => {
+    const deps = baseDeps();
+    deps.spawn = vi.fn().mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify({ version: '0.1.0' }),
+    });
+    deps.fileExists = vi.fn((filePath) => filePath !== 'docs/releases/0.2.0.md');
+    const result = validateRelease({
+      argv: ['--base', 'origin/main', '--target', 'main'],
+      env: {},
+      deps,
+    });
+    expect(result).toBe(false);
+    expect(deps.logError).toHaveBeenCalledWith(expect.stringContaining('Missing release notes'));
+  });
+
+  it('passes a matching tag context', () => {
+    const deps = baseDeps();
+    const result = validateRelease({ argv: ['--tag', 'v0.2.0'], env: {}, deps });
+    expect(result).toBe(true);
+  });
+
+  it('fails a tag context that does not match package.json version', () => {
+    const deps = baseDeps();
+    const result = validateRelease({ argv: ['--tag', 'v0.9.9'], env: {}, deps });
+    expect(result).toBe(false);
+    expect(deps.logError).toHaveBeenCalledWith(
+      expect.stringContaining('does not match package.json version'),
+    );
+  });
+
+  it('fails a tag context with a malformed tag', () => {
+    const deps = baseDeps();
+    const result = validateRelease({ argv: ['--tag', 'release-1'], env: {}, deps });
+    expect(result).toBe(false);
+  });
+
+  it('fails when required docs are missing', () => {
+    const deps = baseDeps();
+    deps.fileExists = vi.fn().mockReturnValue(false);
+    const result = validateRelease({ argv: [], env: {}, deps });
+    expect(result).toBe(false);
+    expect(deps.logError).toHaveBeenCalledWith(
+      expect.stringContaining('Missing docs/release-checklist.md'),
+    );
+    expect(deps.logError).toHaveBeenCalledWith(expect.stringContaining('Missing docs/release.md'));
+  });
+});

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -17,6 +17,7 @@ const isHelpMode = process.argv.includes('--help') || cliArgs.includes('help');
 const isFixMode = process.argv.includes('--fix');
 const isFixOnlyMode = process.argv.includes('--fix-only');
 const isVerboseMode = process.argv.includes('--verbose');
+const isFullMode = process.argv.includes('--full');
 const shouldApplyFixers = isFixMode || isFixOnlyMode;
 const cliFilesOverride = isHelpMode ? null : getCliFilesOverride(cliArgs);
 const VERIFY_LABELS = [
@@ -30,7 +31,21 @@ const VERIFY_LABELS = [
   'e2e',
   'visual',
   'mutation',
+  'release-version',
+  'release-config',
+  'build',
+  'artifact',
+  'release-smoke',
 ];
+// Release-only labels only run in full/release mode (pnpm verify --full).
+// Focused `pnpm verify` never builds these into its command list.
+const FULL_ONLY_LABELS = new Set([
+  'release-version',
+  'release-config',
+  'build',
+  'artifact',
+  'release-smoke',
+]);
 const VERIFY_DIR = '.verify';
 const VERIFY_LOG_DIR = path.posix.join(VERIFY_DIR, 'logs');
 const MAX_RELEVANT_LINES = 20;
@@ -43,9 +58,19 @@ const COMMAND_TIMEOUT_MS_BY_LABEL = {
   e2e: 12 * 60 * 1000,
   visual: 15 * 60 * 1000,
   mutation: 20 * 60 * 1000,
+  build: 10 * 60 * 1000,
+  artifact: 8 * 60 * 1000,
+  'release-smoke': 10 * 60 * 1000,
 };
 const cliBaseRef = isHelpMode ? null : getCliBaseRef(cliArgs);
 const cliOnlyLabel = isHelpMode ? null : getCliOnlyLabel(cliArgs);
+
+if (cliOnlyLabel !== null && FULL_ONLY_LABELS.has(cliOnlyLabel) && !isFullMode) {
+  throw new Error(
+    `--only ${cliOnlyLabel} requires --full. Run: pnpm verify --full --only ${cliOnlyLabel}`,
+  );
+}
+
 const EXPENSIVE_SKIP_REASON =
   'previous check failed; skipped expensive verification to save CI minutes';
 const FORMATTABLE_EXTENSIONS = new Set([
@@ -761,11 +786,18 @@ function printHelp() {
   console.log('                      Local-only default: set VERIFY_BASE in .env.local.');
   console.log('  --only <label>      Run one focused verification check.');
   console.log('  --files <paths...>  Override changed-file detection with an explicit file list.');
+  console.log(
+    '  --full              Full-project release mode: ignore changed-file scope, run every',
+  );
+  console.log(
+    '                      check unconditionally, plus release-version/release-config/build/',
+  );
+  console.log('                      artifact/release-smoke. Equivalent to `pnpm verify:release`.');
   console.log('');
   console.log('Labels for --only:');
 
   for (const label of VERIFY_LABELS) {
-    console.log(`  ${label}`);
+    console.log(`  ${label}${FULL_ONLY_LABELS.has(label) ? ' (requires --full)' : ''}`);
   }
 
   console.log('');
@@ -778,6 +810,9 @@ function printHelp() {
   console.log('  pnpm verify --only eslint --files src/foo.ts src/bar.vue');
   console.log('  pnpm verify --fix');
   console.log('  pnpm verify --fix-only');
+  console.log('  pnpm verify --full');
+  console.log('  pnpm verify --full --only artifact');
+  console.log('  pnpm verify:release');
   console.log('');
   console.log('Notes:');
   console.log('  - In GitHub Actions, verify scope is based on GITHUB_BASE_REF.');
@@ -1065,7 +1100,66 @@ function createE2ECommand(extraArgs = [], note = null) {
   };
 }
 
-function buildCommands(changedFiles) {
+function addReleaseOnlyCommands(commands) {
+  commands.push({
+    kind: 'run',
+    label: 'release-version',
+    command: 'node',
+    args: ['scripts/release/validateVersion.mjs'],
+    weight: classifyCommandWeight({ label: 'release-version' }),
+  });
+
+  commands.push({
+    kind: 'run',
+    label: 'release-config',
+    command: 'node',
+    args: ['scripts/release/validateReleaseConfig.mjs'],
+    weight: classifyCommandWeight({ label: 'release-config' }),
+  });
+
+  commands.push({
+    kind: 'run',
+    label: 'build',
+    command: 'node',
+    args: ['scripts/release/buildArtifact.mjs'],
+    weight: classifyCommandWeight({ label: 'build' }),
+  });
+
+  commands.push({
+    kind: 'run',
+    label: 'artifact',
+    command: 'pnpm',
+    args: [
+      'e2e:release',
+      '--label',
+      'artifact',
+      'tests/e2e/release/productionArtifactSmoke.spec.ts',
+    ],
+    weight: classifyCommandWeight({ label: 'artifact' }),
+  });
+
+  commands.push({
+    kind: 'run',
+    label: 'release-smoke',
+    command: 'pnpm',
+    args: [
+      'e2e:release',
+      '--label',
+      'release-smoke',
+      'tests/e2e/release/firstUserAndReturningUserSmoke.spec.ts',
+    ],
+    weight: classifyCommandWeight({ label: 'release-smoke' }),
+  });
+}
+
+/**
+ * Build the verify command list for a given changed-file set.
+ * @param changedFiles Sorted unique list of repository-relative changed file paths.
+ * @param [options] Build options.
+ * @param [options.fullMode] Full-project release mode; defaults to the `--full` CLI flag.
+ * @returns Command entries in run order.
+ */
+export function buildCommands(changedFiles, { fullMode = isFullMode } = {}) {
   const existingChangedFiles = changedFiles.filter(fileExists);
   const formatLintFiles = existingChangedFiles.filter((filePath) => !isFormatLintIgnored(filePath));
   const formattableFiles = formatLintFiles.filter((filePath) =>
@@ -1092,7 +1186,14 @@ function buildCommands(changedFiles) {
     args: ['scripts/agentEnvironment.mjs', shouldApplyFixers ? '--fix' : '--check'],
   });
 
-  if (formattableFiles.length > 0) {
+  if (fullMode) {
+    commands.push({
+      kind: 'run',
+      label: 'format',
+      command: 'pnpm',
+      args: ['exec', 'oxfmt', ...(shouldApplyFixers ? [] : ['--check']), '.'],
+    });
+  } else if (formattableFiles.length > 0) {
     commands.push({
       kind: 'run',
       label: 'format',
@@ -1108,7 +1209,29 @@ function buildCommands(changedFiles) {
     });
   }
 
-  if (lintableFiles.length > 0) {
+  if (fullMode) {
+    commands.push({
+      kind: 'run',
+      label: 'oxlint',
+      command: 'pnpm',
+      args: ['exec', 'oxlint', ...(shouldApplyFixers ? ['--fix'] : []), '.'],
+      weight: classifyCommandWeight({ label: 'oxlint', isFullRepo: true }),
+    });
+    commands.push({
+      kind: 'run',
+      label: 'eslint',
+      command: 'pnpm',
+      args: [
+        'exec',
+        'eslint',
+        '--cache',
+        ...(shouldApplyFixers ? ['--fix'] : []),
+        `--concurrency=${eslintConcurrency}`,
+        '.',
+      ],
+      weight: classifyCommandWeight({ label: 'eslint', isFullRepo: true }),
+    });
+  } else if (lintableFiles.length > 0) {
     commands.push({
       kind: 'run',
       label: 'oxlint',
@@ -1149,7 +1272,7 @@ function buildCommands(changedFiles) {
     return commands;
   }
 
-  if (changedFiles.some(isTypeCheckTarget)) {
+  if (fullMode || changedFiles.some(isTypeCheckTarget)) {
     commands.push({
       kind: 'run',
       label: 'type-check',
@@ -1166,7 +1289,15 @@ function buildCommands(changedFiles) {
     });
   }
 
-  if (vitestScope.length > 0) {
+  if (fullMode) {
+    commands.push({
+      kind: 'run',
+      label: 'unit-tests',
+      command: 'pnpm',
+      args: ['exec', 'vitest', 'run'],
+      weight: classifyCommandWeight({ label: 'unit-tests', isFullRepo: true }),
+    });
+  } else if (vitestScope.length > 0) {
     commands.push({
       kind: 'run',
       label: 'unit-tests',
@@ -1183,7 +1314,9 @@ function buildCommands(changedFiles) {
     });
   }
 
-  if (appE2EPlan.mode === 'invalid') {
+  if (fullMode) {
+    addE2ECommands(commands, createE2ECommand([], 'full-project release verification'));
+  } else if (appE2EPlan.mode === 'invalid') {
     commands.push(createE2EInstallCommand('app e2e scope is invalid; e2e check fails closed'));
     commands.push({
       kind: 'failed',
@@ -1205,7 +1338,7 @@ function buildCommands(changedFiles) {
     });
   }
 
-  if (hasVisualRelevantChanges || changedVisualSpecs.length > 0) {
+  if (fullMode || hasVisualRelevantChanges || changedVisualSpecs.length > 0) {
     commands.push({
       kind: 'run',
       label: 'visual',
@@ -1222,7 +1355,10 @@ function buildCommands(changedFiles) {
     });
   }
 
-  if (mutationScope.length > 0) {
+  // Mutation testing is a test-design/PR-quality tool, not a release-publish
+  // blocker: it is expensive/slow and does not validate the production
+  // artifact, so it never runs in full/release mode (pnpm verify:release).
+  if (!fullMode && mutationScope.length > 0) {
     commands.push({
       kind: 'run',
       label: 'mutation',
@@ -1230,13 +1366,17 @@ function buildCommands(changedFiles) {
       args: ['exec', 'stryker', 'run', '-m', mutationScope.join(',')],
       weight: classifyCommandWeight({ label: 'mutation' }),
     });
-  } else {
+  } else if (!fullMode) {
     commands.push({
       kind: 'skipped',
       label: 'mutation',
       command: 'pnpm exec stryker run -m <source file>',
       reason: 'empty mutation scope',
     });
+  }
+
+  if (fullMode) {
+    addReleaseOnlyCommands(commands);
   }
 
   return commands;
@@ -1300,9 +1440,10 @@ function printSummary(changedFiles, scope, results) {
 
   console.log('\nVERIFY RESULT');
   console.log(`mode: ${mode}`);
+  console.log(`release: ${isFullMode ? 'full-project (pnpm verify --full)' : 'off'}`);
   console.log(`verbose: ${isVerboseMode ? 'on' : 'off'}`);
   console.log(`only: ${cliOnlyLabel ?? 'all'}`);
-  console.log(`scope: ${scope}`);
+  console.log(`scope: ${isFullMode ? 'full-project (changed-file scope ignored)' : scope}`);
   console.log(`changed files: ${changedFiles.length}`);
   console.log(`status: ${displayStatus}`);
   console.log(`logs: ${VERIFY_LOG_DIR}`);
@@ -1332,6 +1473,31 @@ function printSummary(changedFiles, scope, results) {
     status,
     hasFailed,
   };
+}
+
+// Release Playwright checks whose webServer builds the production artifact
+// itself (see playwright.release.config.ts). Reused only when the `build`
+// check already produced a fresh artifact earlier in this same run.
+const ARTIFACT_REUSE_LABELS = new Set(['artifact', 'release-smoke']);
+
+/**
+ * Resolve extra env for a command entry, based on prior results in this run.
+ * Sets `RELEASE_ARTIFACT_SKIP_BUILD=1` for the `artifact`/`release-smoke`
+ * release-only checks once the `build` check has already produced a fresh
+ * production artifact in this same `pnpm verify` invocation, so a single
+ * release gate does not rebuild the artifact once per check that needs it.
+ * @param entry Command entry about to run.
+ * @param priorResults Results already collected earlier in this run.
+ * @returns Extra env to merge into the command's environment.
+ */
+export function getExtraEnvForEntry(entry, priorResults) {
+  if (!ARTIFACT_REUSE_LABELS.has(entry.label)) {
+    return {};
+  }
+
+  const buildResult = priorResults.find((result) => result.label === 'build');
+
+  return buildResult?.status === 'passed' ? { RELEASE_ARTIFACT_SKIP_BUILD: '1' } : {};
 }
 
 async function main(verifyLockEnv = {}, verifyLockController = { updateMetadata: () => {} }) {
@@ -1382,6 +1548,7 @@ async function main(verifyLockEnv = {}, verifyLockController = { updateMetadata:
 
     // oxlint-disable-next-line no-await-in-loop -- verify checks run sequentially for deterministic logs and fail-fast expensive gates.
     let result;
+    const extraEnv = getExtraEnvForEntry(entry, results);
 
     if (entry.weight === 'expensive') {
       // oxlint-disable-next-line no-await-in-loop -- verify checks run sequentially for deterministic logs and fail-fast expensive gates.
@@ -1391,7 +1558,11 @@ async function main(verifyLockEnv = {}, verifyLockController = { updateMetadata:
           command: formatCommand(entry.command, entry.args),
         },
         async (lockEnv) =>
-          runCommand(entry.label, entry.command, entry.args, { ...verifyLockEnv, ...lockEnv }),
+          runCommand(entry.label, entry.command, entry.args, {
+            ...verifyLockEnv,
+            ...lockEnv,
+            ...extraEnv,
+          }),
       );
 
       // Signal propagation must happen after withExpensiveCommandLock cleanup,
@@ -1402,7 +1573,10 @@ async function main(verifyLockEnv = {}, verifyLockController = { updateMetadata:
       }
     } else {
       // oxlint-disable-next-line no-await-in-loop -- verify checks run sequentially for deterministic logs and fail-fast expensive gates.
-      result = await runCommand(entry.label, entry.command, entry.args, verifyLockEnv);
+      result = await runCommand(entry.label, entry.command, entry.args, {
+        ...verifyLockEnv,
+        ...extraEnv,
+      });
 
       if (result.terminatedBySignal) {
         applyProcessResult({ signal: result.terminatedBySignal });

--- a/scripts/verify.test.mjs
+++ b/scripts/verify.test.mjs
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  buildCommands,
   getCliFilesOverride,
   getAllSiblingTestFiles,
+  getExtraEnvForEntry,
   getVerifyBaseRef,
   runVerifyCli,
 } from './verify.mjs';
@@ -71,6 +73,123 @@ describe('getCliFilesOverride', () => {
 describe('getVerifyBaseRef', () => {
   it('reads VERIFY_BASE from process env', () => {
     expect(getVerifyBaseRef({ VERIFY_BASE: 'origin/develop' })).toBe('origin/develop');
+  });
+});
+
+describe('buildCommands full mode', () => {
+  it('never skips a check for empty changed-file scope in full mode', () => {
+    const commands = buildCommands([], { fullMode: true });
+    const runByLabel = Object.fromEntries(commands.map((entry) => [entry.label, entry.kind]));
+
+    expect(runByLabel.format).toBe('run');
+    expect(runByLabel.oxlint).toBe('run');
+    expect(runByLabel.eslint).toBe('run');
+    expect(runByLabel['type-check']).toBe('run');
+    expect(runByLabel['unit-tests']).toBe('run');
+    expect(runByLabel.e2e).toBe('run');
+    expect(runByLabel.visual).toBe('run');
+  });
+
+  it('does not run mutation testing in full/release mode', () => {
+    const commands = buildCommands([], { fullMode: true });
+    const labels = commands.map((entry) => entry.label);
+
+    expect(labels).not.toContain('mutation');
+  });
+
+  it('targets the whole project instead of a changed-file list', () => {
+    const commands = buildCommands([], { fullMode: true });
+    const byLabel = Object.fromEntries(commands.map((entry) => [entry.label, entry]));
+
+    expect(byLabel.format.args).toContain('.');
+    expect(byLabel.format.args).not.toContain('src/app/main.ts');
+    expect(byLabel.oxlint.args).toContain('.');
+    expect(byLabel.eslint.args).toContain('.');
+    expect(byLabel['unit-tests'].args).toEqual(['exec', 'vitest', 'run']);
+  });
+
+  it('adds the release-only checks with their own labels and commands', () => {
+    const commands = buildCommands([], { fullMode: true });
+    const byLabel = Object.fromEntries(commands.map((entry) => [entry.label, entry]));
+
+    expect(byLabel['release-version'].args).toEqual(['scripts/release/validateVersion.mjs']);
+    expect(byLabel['release-config'].args).toEqual(['scripts/release/validateReleaseConfig.mjs']);
+    expect(byLabel.build.args).toEqual(['scripts/release/buildArtifact.mjs']);
+    expect(byLabel.artifact.args).toEqual([
+      'e2e:release',
+      '--label',
+      'artifact',
+      'tests/e2e/release/productionArtifactSmoke.spec.ts',
+    ]);
+    expect(byLabel['release-smoke'].args).toEqual([
+      'e2e:release',
+      '--label',
+      'release-smoke',
+      'tests/e2e/release/firstUserAndReturningUserSmoke.spec.ts',
+    ]);
+  });
+
+  it('does not add release-only checks outside full mode', () => {
+    const commands = buildCommands([], { fullMode: false });
+    const labels = commands.map((entry) => entry.label);
+
+    expect(labels).not.toContain('release-version');
+    expect(labels).not.toContain('release-config');
+    expect(labels).not.toContain('build');
+    expect(labels).not.toContain('artifact');
+    expect(labels).not.toContain('release-smoke');
+  });
+});
+
+describe('buildCommands mutation scope', () => {
+  it('still adds a scoped mutation run outside full mode when mutation scope is non-empty', () => {
+    const commands = buildCommands(['src/shared/lib/cache/index.ts'], { fullMode: false });
+    const mutationEntry = commands.find((entry) => entry.label === 'mutation');
+
+    expect(mutationEntry.kind).toBe('run');
+    expect(mutationEntry.args).toEqual([
+      'exec',
+      'stryker',
+      'run',
+      '-m',
+      'src/shared/lib/cache/index.ts',
+    ]);
+  });
+
+  it('skips mutation outside full mode when mutation scope is empty', () => {
+    const commands = buildCommands([], { fullMode: false });
+    const mutationEntry = commands.find((entry) => entry.label === 'mutation');
+
+    expect(mutationEntry.kind).toBe('skipped');
+  });
+});
+
+describe('getExtraEnvForEntry', () => {
+  it('does not set the skip flag for unrelated labels', () => {
+    expect(getExtraEnvForEntry({ label: 'build' }, [{ label: 'build', status: 'passed' }])).toEqual(
+      {},
+    );
+  });
+
+  it('does not set the skip flag when build has not run yet', () => {
+    expect(getExtraEnvForEntry({ label: 'artifact' }, [])).toEqual({});
+  });
+
+  it('does not set the skip flag when build failed', () => {
+    expect(
+      getExtraEnvForEntry({ label: 'artifact' }, [{ label: 'build', status: 'failed' }]),
+    ).toEqual({});
+  });
+
+  it('sets RELEASE_ARTIFACT_SKIP_BUILD once build has passed, for artifact and release-smoke', () => {
+    const priorResults = [{ label: 'build', status: 'passed' }];
+
+    expect(getExtraEnvForEntry({ label: 'artifact' }, priorResults)).toEqual({
+      RELEASE_ARTIFACT_SKIP_BUILD: '1',
+    });
+    expect(getExtraEnvForEntry({ label: 'release-smoke' }, priorResults)).toEqual({
+      RELEASE_ARTIFACT_SKIP_BUILD: '1',
+    });
   });
 });
 

--- a/tests/e2e/release/firstUserAndReturningUserSmoke.spec.ts
+++ b/tests/e2e/release/firstUserAndReturningUserSmoke.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test } from '@playwright/test';
+import {
+  addDatabaseItem,
+  createDatabaseDocument,
+  createDirectory,
+  createStringProperty,
+  createUniqueName,
+  launchApp,
+  openDirectory,
+  openDocumentFromExplorer,
+  openOpfs,
+} from '../helpers';
+
+const noCriticalSaveError = /error reading|corrupt|lost changes|failed to open|save failed/i;
+
+// Minimum release smoke coverage for first-user and returning-user
+// persistence scenarios, run against the production artifact.
+// See docs/release.md#release-smoke-coverage.
+
+test('first-time user creates a space and data, and it survives a reload', async ({ page }) => {
+  await launchApp(page);
+  await expect(page.getByText(/^browser storage$/i)).toBeVisible();
+  await expect(page.getByRole('dialog')).toHaveCount(0);
+
+  await openOpfs(page);
+
+  const directoryName = await createDirectory(page, createUniqueName('release smoke space'));
+  await openDirectory(page, directoryName);
+
+  const documentName = await createDatabaseDocument(page, createUniqueName('release smoke doc'));
+  await openDocumentFromExplorer(page, documentName);
+
+  const propertyName = await createStringProperty(page, createUniqueName('release smoke title'));
+  const itemValue = createUniqueName('release smoke row');
+  await addDatabaseItem(page, propertyName, itemValue);
+
+  await expect(page.getByText(noCriticalSaveError)).toHaveCount(0);
+
+  await page.reload();
+
+  await expect(page.getByText(documentName, { exact: true }).last()).toBeVisible();
+  await expect(page.getByText(itemValue, { exact: true })).toBeVisible();
+  await expect(page.getByText(noCriticalSaveError)).toHaveCount(0);
+});
+
+test('returning user reopens an existing space and sees prior data without duplicates or lost state', async ({
+  page,
+  context,
+}) => {
+  // Test setup: create the "existing space" the returning user will reopen.
+  await launchApp(page);
+  await openOpfs(page);
+
+  const directoryName = await createDirectory(page, createUniqueName('returning user space'));
+  await openDirectory(page, directoryName);
+
+  const documentName = await createDatabaseDocument(page, createUniqueName('returning user doc'));
+  await openDocumentFromExplorer(page, documentName);
+
+  const propertyName = await createStringProperty(page, createUniqueName('returning user title'));
+  const itemValue = createUniqueName('returning user row');
+  await addDatabaseItem(page, propertyName, itemValue);
+
+  // Simulate the user closing and reopening the app (same browser storage
+  // profile / origin, new page) rather than an in-place reload.
+  await page.close();
+  const returningPage = await context.newPage();
+
+  await launchApp(returningPage);
+  await expect(returningPage.getByText(/^browser storage$/i)).toBeVisible();
+  await expect(returningPage.getByRole('dialog')).toHaveCount(0);
+
+  await openOpfs(returningPage);
+
+  // Previous data is visible without repeated onboarding, and reopening
+  // did not create duplicate entries or overlay an empty state on top.
+  await expect(returningPage.getByText(directoryName, { exact: true })).toBeVisible();
+  await expect(returningPage.getByText(directoryName, { exact: true })).toHaveCount(1);
+
+  await openDirectory(returningPage, directoryName);
+  await expect(returningPage.getByText(documentName, { exact: true })).toBeVisible();
+  await expect(returningPage.getByText(documentName, { exact: true })).toHaveCount(1);
+
+  await openDocumentFromExplorer(returningPage, documentName);
+  await expect(returningPage.getByText(itemValue, { exact: true })).toBeVisible();
+  await expect(returningPage.getByText(noCriticalSaveError)).toHaveCount(0);
+});

--- a/tests/e2e/release/productionArtifactSmoke.spec.ts
+++ b/tests/e2e/release/productionArtifactSmoke.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from '@playwright/test';
+import { launchApp, openOpfs } from '../helpers';
+
+// Validates the published production artifact itself (base path, SPA
+// fallback, critical assets, PWA manifest sanity), not internal build or
+// Workbox implementation details. See docs/release.md#production-artifact-validation.
+
+test('opens under the configured GitHub Pages base path with no broken critical assets', async ({
+  page,
+  baseURL,
+}) => {
+  const failedResponses: string[] = [];
+  page.on('response', (response) => {
+    if (response.status() >= 400 && response.url().startsWith(baseURL ?? '')) {
+      failedResponses.push(`${response.status()} ${response.url()}`);
+    }
+  });
+
+  await launchApp(page);
+
+  expect(page.url()).toContain(new URL(baseURL ?? '').pathname);
+  expect(failedResponses).toEqual([]);
+});
+
+test('links a fetchable PWA manifest scoped to the base path', async ({ page, baseURL }) => {
+  await launchApp(page);
+
+  const manifestHref = await page.locator('link[rel="manifest"]').getAttribute('href');
+  expect(manifestHref).toBeTruthy();
+
+  const manifestUrl = new URL(manifestHref ?? '', baseURL);
+  const response = await page.request.get(manifestUrl.toString());
+  expect(response.ok()).toBe(true);
+
+  const manifest = await response.json();
+  expect(typeof manifest.name).toBe('string');
+  expect(String(manifest.start_url ?? manifest.scope ?? '')).toContain(
+    new URL(baseURL ?? '').pathname,
+  );
+});
+
+test('does not throw a page error on first launch with the service worker registered', async ({
+  page,
+}) => {
+  const pageErrors: string[] = [];
+  page.on('pageerror', (error) => pageErrors.push(error.message));
+
+  await launchApp(page);
+  await openOpfs(page);
+
+  expect(pageErrors).toEqual([]);
+});
+
+test('reloading after a deep client route falls back to the app instead of a broken page', async ({
+  page,
+  baseURL,
+}) => {
+  await launchApp(page);
+  await openOpfs(page);
+
+  const deepUrl = page.url();
+  expect(deepUrl).not.toBe(baseURL);
+
+  // A real navigation (not client-side routing) hits the artifact server
+  // directly, which has no physical file for this deep route and returns
+  // the site-wide SPA fallback with a 404 status.
+  await page.goto(deepUrl);
+
+  await expect(page.getByRole('button', { name: /^add$/i })).toBeVisible();
+  await expect(page.getByRole('heading', { name: /not found|404/i })).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary

- Promote `develop` to `main` for Mioframe `0.1.0`.
- Exercise the new `release` workflow on the intended stable branch path.
- Keep stable publish constrained to `main` after the release gate succeeds.

## Architecture Decision

This is a promotion PR, not a feature implementation PR. It validates the release model introduced by PR #116:

- `develop` is the active development branch.
- `main` is the stable public branch.
- PRs into `main` run the full `release` workflow through `release-gate` / `pnpm verify:release`.
- `deploy-stable` runs only after a successful push-to-`main` release gate.

## Verification

Required for this PR:

- `release` workflow / `release-gate` must pass.
- `release-gate` runs `pnpm verify:release`.

After merge to `main`, the push-to-main `release` workflow must pass again before stable deploy. Tag `v0.1.0` is validated separately by the `release-tag` workflow.

## Known Risks

- This is the first real execution of the new `release` workflow on a PR targeting `main`.
- GitHub branch protection and Pages settings are partly manual.
- `deploy-stable` runs only after merge into `main`, so this PR validates the gate but not the final deployment.