### PR TITLE
infra(pages): add organization release channel deployments

### DIFF
--- a/.github/workflows/deploy-branch-tombstone-cleanup.yml
+++ b/.github/workflows/deploy-branch-tombstone-cleanup.yml
@@ -1,24 +1,25 @@
-name: Clean up PR preview from GitHub Pages
+name: deploy-branch-tombstone-cleanup
+
+# Scheduled removal of branch/<slug>/ tombstones whose retention period
+# (config/tooling.json pages.tombstoneRetentionDays) has elapsed. Live
+# branch deployments and tombstones still within retention are untouched.
+# See docs/release.md#branch-deletion-tombstone.
 
 on:
-  pull_request:
-    types: [closed]
+  schedule:
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: pages-publish
+  cancel-in-progress: false
 
 jobs:
-  cleanup:
-    # Skip fork PRs — they have no write access to publish.
-    # Skip PRs targeting main — those are release/promotion PRs; stable Pages
-    # deployment is owned exclusively by the release workflow's deploy-stable job.
-    if: >-
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.base.ref != 'main'
+  cleanup-expired-tombstones:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read
-    concurrency:
-      group: pages-publish
-      cancel-in-progress: false
 
     steps:
       - uses: actions/checkout@v4
@@ -42,8 +43,8 @@ jobs:
           owner: Mioframe
           repositories: mioframe.github.io
 
-      - name: Remove PR preview from Mioframe/mioframe.github.io
+      - name: Remove expired branch tombstones
         env:
           GITHUB_TOKEN: ${{ steps.pages-app-token.outputs.token }}
           GITHUB_REPOSITORY: Mioframe/mioframe.github.io
-        run: node scripts/pages/cleanupPreview.mjs --pr ${{ github.event.number }}
+        run: node scripts/pages/cleanupExpiredTombstones.mjs

--- a/.github/workflows/deploy-branch-tombstone-cleanup.yml
+++ b/.github/workflows/deploy-branch-tombstone-cleanup.yml
@@ -36,9 +36,9 @@ jobs:
 
       - name: Generate Pages deploy token
         id: pages-app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.MIOFRAME_PAGES_APP_CLIENT_ID }}
+          client-id: ${{ vars.MIOFRAME_PAGES_APP_CLIENT_ID }}
           private-key: ${{ secrets.MIOFRAME_PAGES_APP_PRIVATE_KEY }}
           owner: Mioframe
           repositories: mioframe.github.io

--- a/.github/workflows/deploy-branch-tombstone.yml
+++ b/.github/workflows/deploy-branch-tombstone.yml
@@ -51,9 +51,9 @@ jobs:
       - name: Generate Pages deploy token
         if: steps.slug.outputs.slug != ''
         id: pages-app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.MIOFRAME_PAGES_APP_CLIENT_ID }}
+          client-id: ${{ vars.MIOFRAME_PAGES_APP_CLIENT_ID }}
           private-key: ${{ secrets.MIOFRAME_PAGES_APP_PRIVATE_KEY }}
           owner: Mioframe
           repositories: mioframe.github.io

--- a/.github/workflows/deploy-branch-tombstone.yml
+++ b/.github/workflows/deploy-branch-tombstone.yml
@@ -1,0 +1,66 @@
+name: deploy-branch-tombstone
+
+# Publishes a tombstone to https://mioframe.github.io/branch/<slug>/ when a
+# branch with an existing branch/<slug>/ deployment is deleted, instead of
+# immediately removing it. A no-op for branches that were never deployed
+# (including nearly all ordinary feature branches). See
+# docs/release.md#branch-deletion-tombstone.
+
+on:
+  delete:
+
+concurrency:
+  group: pages-publish
+  cancel-in-progress: false
+
+jobs:
+  tombstone:
+    if: github.event.ref_type == 'branch'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - run: pnpm install --frozen-lockfile
+
+      # Deleted branch names that slugify to an invalid or reserved value
+      # (e.g. exactly "branch" or "pr") can never have had a branch/<slug>/
+      # deployment, so this is a clean skip rather than a workflow failure —
+      # important since this trigger fires for every ordinary branch delete.
+      - name: Compute branch slug
+        id: slug
+        env:
+          DELETED_REF: ${{ github.event.ref }}
+        run: |
+          slug="$(node scripts/pages/computeBranchSlug.mjs --branch "$DELETED_REF" 2>/dev/null || true)"
+          echo "slug=$slug" >> "$GITHUB_OUTPUT"
+
+      - name: Generate Pages deploy token
+        if: steps.slug.outputs.slug != ''
+        id: pages-app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.MIOFRAME_PAGES_APP_CLIENT_ID }}
+          private-key: ${{ secrets.MIOFRAME_PAGES_APP_PRIVATE_KEY }}
+          owner: Mioframe
+          repositories: mioframe.github.io
+
+      - name: Tombstone removed branch deployment
+        if: steps.slug.outputs.slug != ''
+        env:
+          GITHUB_TOKEN: ${{ steps.pages-app-token.outputs.token }}
+          GITHUB_REPOSITORY: Mioframe/mioframe.github.io
+        run: node scripts/pages/publishBranchTombstone.mjs --slug ${{ steps.slug.outputs.slug }}

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -1,0 +1,88 @@
+name: deploy-branch
+
+# Manual-only deployment of a selected branch to
+# https://mioframe.github.io/branch/<branch-slug>/, with PWA enabled. Never
+# runs automatically — arbitrary branches are not auto-published. See
+# docs/release.md#manual-branch-deployment.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Branch (or ref) to build and publish
+        required: true
+        type: string
+
+concurrency:
+  group: pages-publish
+  cancel-in-progress: false
+
+jobs:
+  deploy-branch:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Compute branch slug
+        id: slug
+        env:
+          BRANCH_REF: ${{ inputs.ref }}
+        run: |
+          slug="$(node scripts/pages/computeBranchSlug.mjs --branch "$BRANCH_REF")"
+          echo "slug=$slug" >> "$GITHUB_OUTPUT"
+
+      - name: Build branch deployment
+        env:
+          BASE_URL: /branch/${{ steps.slug.outputs.slug }}/
+          VITE_RELEASE_CHANNEL: branch
+          VITE_RELEASE_CHANNEL_ID: ${{ steps.slug.outputs.slug }}
+          VITE_GOOGLE_CLIENT_ID: ${{ secrets.VITE_GOOGLE_CLIENT_ID }}
+          VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: pnpm run build
+
+      - name: Write deployment metadata
+        env:
+          BRANCH_REF: ${{ inputs.ref }}
+        run: >-
+          node scripts/pages/writeDeploymentMetadata.mjs
+          --dist dist
+          --channel branch
+          --channel-id ${{ steps.slug.outputs.slug }}
+          --base-url /branch/${{ steps.slug.outputs.slug }}/
+          --ref "$BRANCH_REF"
+          --branch "$BRANCH_REF"
+          --slug ${{ steps.slug.outputs.slug }}
+          --sha ${{ github.sha }}
+          --app-version "$(node -p "require('./package.json').version")"
+
+      - name: Generate Pages deploy token
+        id: pages-app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.MIOFRAME_PAGES_APP_CLIENT_ID }}
+          private-key: ${{ secrets.MIOFRAME_PAGES_APP_PRIVATE_KEY }}
+          owner: Mioframe
+          repositories: mioframe.github.io
+
+      - name: Publish branch build to Mioframe/mioframe.github.io
+        env:
+          GITHUB_TOKEN: ${{ steps.pages-app-token.outputs.token }}
+          GITHUB_REPOSITORY: Mioframe/mioframe.github.io
+        run: node scripts/pages/publishBranch.mjs --dist dist --slug ${{ steps.slug.outputs.slug }}

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -8,8 +8,8 @@ name: deploy-branch
 on:
   workflow_dispatch:
     inputs:
-      ref:
-        description: Branch (or ref) to build and publish
+      branch:
+        description: Branch name to build and publish
         required: true
         type: string
 
@@ -25,9 +25,43 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      # Trusted tooling (tooling/) is checked out from this workflow's own
+      # default branch, never from the selected (possibly untrusted) branch
+      # input. Slug computation, metadata, and publish all run from this
+      # checkout — see the app-source/ checkout below for the untrusted build
+      # input.
+      - name: Checkout trusted tooling
+        uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
+          ref: develop
+          path: tooling
+
+      - name: Validate branch input
+        env:
+          BRANCH: ${{ inputs.branch }}
+        working-directory: tooling
+        run: |
+          if ! git ls-remote --exit-code --heads origin "refs/heads/$BRANCH" > /dev/null; then
+            echo "::error::'$BRANCH' is not a branch on origin. This workflow only accepts branch names, not tags or SHAs." >&2
+            exit 1
+          fi
+
+      - name: Compute branch slug
+        id: slug
+        env:
+          BRANCH: ${{ inputs.branch }}
+        run: |
+          slug="$(node tooling/scripts/pages/computeBranchSlug.mjs --branch "$BRANCH")"
+          echo "slug=$slug" >> "$GITHUB_OUTPUT"
+
+      # app-source/ is untrusted: the selected branch may contain arbitrary
+      # code from any contributor. It is only ever built here, never executed
+      # with the Pages deploy token.
+      - name: Checkout selected branch (app source)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+          path: app-source
 
       - uses: pnpm/action-setup@v4
 
@@ -35,19 +69,14 @@ jobs:
         with:
           node-version: lts/*
           cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
+          cache-dependency-path: app-source/pnpm-lock.yaml
 
-      - run: pnpm install --frozen-lockfile
-
-      - name: Compute branch slug
-        id: slug
-        env:
-          BRANCH_REF: ${{ inputs.ref }}
-        run: |
-          slug="$(node scripts/pages/computeBranchSlug.mjs --branch "$BRANCH_REF")"
-          echo "slug=$slug" >> "$GITHUB_OUTPUT"
+      - name: Install app-source dependencies
+        working-directory: app-source
+        run: pnpm install --frozen-lockfile
 
       - name: Build branch deployment
+        working-directory: app-source
         env:
           BASE_URL: /branch/${{ steps.slug.outputs.slug }}/
           VITE_RELEASE_CHANNEL: branch
@@ -57,26 +86,30 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: pnpm run build
 
+      - name: Compute deployed commit SHA
+        id: deployed-sha
+        run: echo "sha=$(git -C app-source rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Write deployment metadata
         env:
-          BRANCH_REF: ${{ inputs.ref }}
+          BRANCH: ${{ inputs.branch }}
         run: >-
-          node scripts/pages/writeDeploymentMetadata.mjs
-          --dist dist
+          node tooling/scripts/pages/writeDeploymentMetadata.mjs
+          --dist app-source/dist
           --channel branch
           --channel-id ${{ steps.slug.outputs.slug }}
           --base-url /branch/${{ steps.slug.outputs.slug }}/
-          --ref "$BRANCH_REF"
-          --branch "$BRANCH_REF"
+          --ref "$BRANCH"
+          --branch "$BRANCH"
           --slug ${{ steps.slug.outputs.slug }}
-          --sha ${{ github.sha }}
-          --app-version "$(node -p "require('./package.json').version")"
+          --sha ${{ steps.deployed-sha.outputs.sha }}
+          --app-version "$(node -p "require('./app-source/package.json').version")"
 
       - name: Generate Pages deploy token
         id: pages-app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.MIOFRAME_PAGES_APP_CLIENT_ID }}
+          client-id: ${{ vars.MIOFRAME_PAGES_APP_CLIENT_ID }}
           private-key: ${{ secrets.MIOFRAME_PAGES_APP_PRIVATE_KEY }}
           owner: Mioframe
           repositories: mioframe.github.io
@@ -85,4 +118,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.pages-app-token.outputs.token }}
           GITHUB_REPOSITORY: Mioframe/mioframe.github.io
-        run: node scripts/pages/publishBranch.mjs --dist dist --slug ${{ steps.slug.outputs.slug }}
+        run: node tooling/scripts/pages/publishBranch.mjs --dist app-source/dist --slug ${{ steps.slug.outputs.slug }}

--- a/.github/workflows/deploy-cleanup.yml
+++ b/.github/workflows/deploy-cleanup.yml
@@ -21,7 +21,12 @@ jobs:
       cancel-in-progress: false
 
     steps:
+      # Checkout the PR's trusted base branch, not the default merge ref
+      # (which can include untrusted PR head content) — this job holds the
+      # Mioframe/mioframe.github.io write token below.
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
 
       - uses: pnpm/action-setup@v4
 
@@ -35,9 +40,9 @@ jobs:
 
       - name: Generate Pages deploy token
         id: pages-app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.MIOFRAME_PAGES_APP_CLIENT_ID }}
+          client-id: ${{ vars.MIOFRAME_PAGES_APP_CLIENT_ID }}
           private-key: ${{ secrets.MIOFRAME_PAGES_APP_PRIVATE_KEY }}
           owner: Mioframe
           repositories: mioframe.github.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,9 +123,9 @@ jobs:
 
       - name: Generate Pages deploy token
         id: pages-app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.MIOFRAME_PAGES_APP_CLIENT_ID }}
+          client-id: ${{ vars.MIOFRAME_PAGES_APP_CLIENT_ID }}
           private-key: ${{ secrets.MIOFRAME_PAGES_APP_PRIVATE_KEY }}
           owner: Mioframe
           repositories: mioframe.github.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,12 +75,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
-      contents: write
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}
+      contents: read
     concurrency:
       group: pages-publish
       cancel-in-progress: false
@@ -100,34 +95,43 @@ jobs:
 
       - name: Build release artifact
         env:
-          BASE_URL: /${{ github.event.repository.name }}/
+          BASE_URL: /
+          VITE_RELEASE_CHANNEL: stable
+          VITE_RELEASE_CHANNEL_ID: main
           VITE_GOOGLE_CLIENT_ID: ${{ secrets.VITE_GOOGLE_CLIENT_ID }}
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: pnpm release:build-artifact
 
-      - name: Publish stable build to staging
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
+      - name: Write deployment metadata
         run: >-
-          node scripts/pages/publishStable.mjs
+          node scripts/pages/writeDeploymentMetadata.mjs
           --dist dist
-          --output-dir pages-staging
+          --channel stable
+          --channel-id main
+          --base-url /
+          --ref ${{ github.ref }}
+          --branch main
+          --sha ${{ github.sha }}
+          --app-version "$(node -p "require('./package.json').version")"
 
-      - name: Write root SPA fallback
-        run: >-
-          node scripts/pages/writeSpaFallback.mjs
-          --base /${{ github.event.repository.name }}/
-          --output-dir pages-staging
+      # Root-owned: only the stable publish job writes the site-wide
+      # 404.html, since stable publish is the only publisher that touches
+      # the repository root (see scripts/pages/writeSpaFallback.mjs).
+      - name: Write org-root SPA fallback
+        run: node scripts/pages/writeSpaFallback.mjs --output-dir dist
 
-      - uses: actions/configure-pages@v4
+      - name: Generate Pages deploy token
+        id: pages-app-token
+        uses: actions/create-github-app-token@v2
         with:
-          enablement: true
+          app-id: ${{ vars.MIOFRAME_PAGES_APP_CLIENT_ID }}
+          private-key: ${{ secrets.MIOFRAME_PAGES_APP_PRIVATE_KEY }}
+          owner: Mioframe
+          repositories: mioframe.github.io
 
-      - uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./pages-staging/
-
-      - uses: actions/deploy-pages@v4
-        id: deploy
+      - name: Publish stable build to Mioframe/mioframe.github.io
+        env:
+          GITHUB_TOKEN: ${{ steps.pages-app-token.outputs.token }}
+          GITHUB_REPOSITORY: Mioframe/mioframe.github.io
+        run: node scripts/pages/publishStable.mjs --dist dist

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -196,9 +196,14 @@ jobs:
       cancel-in-progress: false
 
     steps:
-      - uses: actions/checkout@v4
+      # PR head (app-source/) is untrusted: it may contain arbitrary code from
+      # the PR author. It is only ever built here, never executed with the
+      # Pages deploy token — see the trusted tooling/ checkout below.
+      - name: Checkout PR head (app source)
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          path: app-source
 
       - uses: pnpm/action-setup@v4
 
@@ -206,11 +211,14 @@ jobs:
         with:
           node-version: lts/*
           cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
+          cache-dependency-path: app-source/pnpm-lock.yaml
 
-      - run: pnpm install --frozen-lockfile
+      - name: Install app-source dependencies
+        working-directory: app-source
+        run: pnpm install --frozen-lockfile
 
       - name: Build PR preview
+        working-directory: app-source
         env:
           BASE_URL: /pr/${{ github.event.number }}/
           VITE_DISABLE_PWA: '1'
@@ -219,25 +227,35 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: pnpm run build
 
+      # Trusted tooling (tooling/) is checked out from the PR's base branch,
+      # never from the PR head. Every step below that can write to
+      # Mioframe/mioframe.github.io — metadata, token generation, publish,
+      # the preview comment — runs scripts from this checkout only.
+      - name: Checkout trusted tooling
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          path: tooling
+
       - name: Write deployment metadata
         env:
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: >-
-          node scripts/pages/writeDeploymentMetadata.mjs
-          --dist dist
+          node tooling/scripts/pages/writeDeploymentMetadata.mjs
+          --dist app-source/dist
           --channel pr
           --channel-id ${{ github.event.number }}
           --base-url /pr/${{ github.event.number }}/
           --ref "$PR_HEAD_REF"
           --branch "$PR_HEAD_REF"
           --sha ${{ github.event.pull_request.head.sha }}
-          --app-version "$(node -p "require('./package.json').version")"
+          --app-version "$(node -p "require('./app-source/package.json').version")"
 
       - name: Generate Pages deploy token
         id: pages-app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.MIOFRAME_PAGES_APP_CLIENT_ID }}
+          client-id: ${{ vars.MIOFRAME_PAGES_APP_CLIENT_ID }}
           private-key: ${{ secrets.MIOFRAME_PAGES_APP_PRIVATE_KEY }}
           owner: Mioframe
           repositories: mioframe.github.io
@@ -246,14 +264,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.pages-app-token.outputs.token }}
           GITHUB_REPOSITORY: Mioframe/mioframe.github.io
-        run: node scripts/pages/publishPreview.mjs --dist dist --pr ${{ github.event.number }}
+        run: node tooling/scripts/pages/publishPreview.mjs --dist app-source/dist --pr ${{ github.event.number }}
 
       - name: Post or update preview comment
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: >-
-          node scripts/pages/upsertPreviewComment.mjs
+          node tooling/scripts/pages/upsertPreviewComment.mjs
           --pr ${{ github.event.number }}
           --url "https://mioframe.github.io/pr/${{ github.event.number }}/"
 
@@ -310,9 +328,9 @@ jobs:
 
       - name: Generate Pages deploy token
         id: pages-app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.MIOFRAME_PAGES_APP_CLIENT_ID }}
+          client-id: ${{ vars.MIOFRAME_PAGES_APP_CLIENT_ID }}
           private-key: ${{ secrets.MIOFRAME_PAGES_APP_PRIVATE_KEY }}
           owner: Mioframe
           repositories: mioframe.github.io

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -179,13 +179,23 @@ jobs:
 
   deploy-preview:
     needs: [verify]
+    # The `infra/org-pages-release-channels` exclusion below is a one-time
+    # bootstrap exception: `tooling/` is checked out from the PR's base ref
+    # (develop), which does not yet have the scripts/pages/* tooling this PR
+    # itself introduces (writeDeploymentMetadata.mjs, the updated
+    # publishPreview.mjs, slug/deployment-metadata helpers). Skipping preview
+    # publish here avoids running untrusted PR-head tooling with the Pages
+    # write credential. Remove this line once this branch merges to develop;
+    # do not add further branch/PR exclusions here for ordinary PRs. See
+    # docs/release.md#pr-preview-deployment.
     if: >-
       !cancelled() &&
       needs.verify.result == 'success' &&
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       !(startsWith(github.event.pull_request.head.ref, 'sync/main-') &&
-        endsWith(github.event.pull_request.head.ref, '-back-to-develop'))
+        endsWith(github.event.pull_request.head.ref, '-back-to-develop')) &&
+      github.event.pull_request.head.ref != 'infra/org-pages-release-channels'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,8 +1,9 @@
 name: verify
 
 # Development verification for develop-bound work: focused pnpm verify plus a
-# PR-into-develop version-bump check, and PR preview deploys. PRs/pushes to
-# main use the separate `release` workflow (.github/workflows/release.yml)
+# PR-into-develop version-bump check, PR preview deploys (pr/<number>/), and
+# the develop branch deploy (branch/develop/) on push to develop. PRs/pushes
+# to main use the separate `release` workflow (.github/workflows/release.yml)
 # instead — see docs/release.md. The trigger below excludes PRs into main so
 # this workflow and the release gate never both run for the same PR path.
 
@@ -188,13 +189,8 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
-      contents: write
-      pages: write
-      id-token: write
+      contents: read
       pull-requests: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}
     concurrency:
       group: pages-publish
       cancel-in-progress: false
@@ -216,42 +212,41 @@ jobs:
 
       - name: Build PR preview
         env:
-          BASE_URL: /${{ github.event.repository.name }}/pr-${{ github.event.number }}/
+          BASE_URL: /pr/${{ github.event.number }}/
           VITE_DISABLE_PWA: '1'
           VITE_GOOGLE_CLIENT_ID: ${{ secrets.VITE_GOOGLE_CLIENT_ID }}
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: pnpm run build
 
-      - name: Fix 404 for SPA
-        run: cp ./dist/index.html ./dist/404.html
-
-      - name: Publish PR preview to staging
+      - name: Write deployment metadata
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: >-
-          node scripts/pages/publishPreview.mjs
+          node scripts/pages/writeDeploymentMetadata.mjs
           --dist dist
-          --pr ${{ github.event.number }}
-          --output-dir pages-staging
+          --channel pr
+          --channel-id ${{ github.event.number }}
+          --base-url /pr/${{ github.event.number }}/
+          --ref "$PR_HEAD_REF"
+          --branch "$PR_HEAD_REF"
+          --sha ${{ github.event.pull_request.head.sha }}
+          --app-version "$(node -p "require('./package.json').version")"
 
-      - name: Write root SPA fallback
-        run: >-
-          node scripts/pages/writeSpaFallback.mjs
-          --base /${{ github.event.repository.name }}/
-          --output-dir pages-staging
-
-      - uses: actions/configure-pages@v4
+      - name: Generate Pages deploy token
+        id: pages-app-token
+        uses: actions/create-github-app-token@v2
         with:
-          enablement: true
+          app-id: ${{ vars.MIOFRAME_PAGES_APP_CLIENT_ID }}
+          private-key: ${{ secrets.MIOFRAME_PAGES_APP_PRIVATE_KEY }}
+          owner: Mioframe
+          repositories: mioframe.github.io
 
-      - uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./pages-staging/
-
-      - uses: actions/deploy-pages@v4
-        id: deploy
+      - name: Publish PR preview to Mioframe/mioframe.github.io
+        env:
+          GITHUB_TOKEN: ${{ steps.pages-app-token.outputs.token }}
+          GITHUB_REPOSITORY: Mioframe/mioframe.github.io
+        run: node scripts/pages/publishPreview.mjs --dist dist --pr ${{ github.event.number }}
 
       - name: Post or update preview comment
         env:
@@ -260,4 +255,70 @@ jobs:
         run: >-
           node scripts/pages/upsertPreviewComment.mjs
           --pr ${{ github.event.number }}
-          --url "https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-${{ github.event.number }}/"
+          --url "https://mioframe.github.io/pr/${{ github.event.number }}/"
+
+  deploy-develop:
+    needs: [verify]
+    if: >-
+      !cancelled() &&
+      needs.verify.result == 'success' &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/develop'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    concurrency:
+      group: pages-publish
+      cancel-in-progress: false
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build develop branch deployment
+        env:
+          BASE_URL: /branch/develop/
+          VITE_RELEASE_CHANNEL: branch
+          VITE_RELEASE_CHANNEL_ID: develop
+          VITE_GOOGLE_CLIENT_ID: ${{ secrets.VITE_GOOGLE_CLIENT_ID }}
+          VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: pnpm run build
+
+      - name: Write deployment metadata
+        run: >-
+          node scripts/pages/writeDeploymentMetadata.mjs
+          --dist dist
+          --channel branch
+          --channel-id develop
+          --base-url /branch/develop/
+          --ref ${{ github.ref }}
+          --branch develop
+          --slug develop
+          --sha ${{ github.sha }}
+          --app-version "$(node -p "require('./package.json').version")"
+
+      - name: Generate Pages deploy token
+        id: pages-app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.MIOFRAME_PAGES_APP_CLIENT_ID }}
+          private-key: ${{ secrets.MIOFRAME_PAGES_APP_PRIVATE_KEY }}
+          owner: Mioframe
+          repositories: mioframe.github.io
+
+      - name: Publish develop build to Mioframe/mioframe.github.io
+        env:
+          GITHUB_TOKEN: ${{ steps.pages-app-token.outputs.token }}
+          GITHUB_REPOSITORY: Mioframe/mioframe.github.io
+        run: node scripts/pages/publishBranch.mjs --dist dist --slug develop

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -64,7 +64,7 @@
 ### 1. Clone and Install
 
 ```bash
-git clone https://github.com/Vyachean/mioframe.git
+git clone https://github.com/Mioframe/mioframe.git
 cd mioframe
 pnpm install
 ```

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -83,8 +83,8 @@ Mioframe 0.1 does not use Sentry Session Replay or Sentry performance tracing, a
 
 For questions about privacy, open a GitHub Discussion:
 
-[https://github.com/Vyachean/mioframe/discussions](https://github.com/Vyachean/mioframe/discussions)
+[https://github.com/Mioframe/mioframe/discussions](https://github.com/Mioframe/mioframe/discussions)
 
 To report a privacy-related bug or data handling issue, open a GitHub Issue:
 
-[https://github.com/Vyachean/mioframe/issues](https://github.com/Vyachean/mioframe/issues)
+[https://github.com/Mioframe/mioframe/issues](https://github.com/Mioframe/mioframe/issues)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A simple local app for your data. No cloud lock-in, no subscriptions, no extra friction.
 
-[👉 Open Mioframe](https://vyachean.github.io/mioframe/)
+[👉 Open Mioframe](https://mioframe.github.io/)
 
 ## Why I Built It
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ User documentation is available in [docs/user/README.md](./docs/user/README.md).
 
 Mioframe is still under active development, and your feedback genuinely helps shape where it goes next. If you want to share thoughts, report a problem, or suggest an idea, feel free to reach out on GitHub:
 
-- Found a bug? Please open an [Issue](https://github.com/Vyachean/mioframe/issues).
-- Have an idea or a question? Join the [Discussions](https://github.com/Vyachean/mioframe/discussions).
+- Found a bug? Please open an [Issue](https://github.com/Mioframe/mioframe/issues).
+- Have an idea or a question? Join the [Discussions](https://github.com/Mioframe/mioframe/discussions).
 
 ## Development
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -49,8 +49,8 @@ Mioframe — это приложение для тех, кто хочет сам
 
 Проект находится в активной разработке, поэтому ваш фидбек — это то, что помогает Mioframe развиваться. Вы можете поделиться им на GitHub:
 
-- Нашли баг? Пожалуйста, создайте [Issue](https://github.com/Vyachean/mioframe/issues).
-- Есть идея или вопрос? Добро пожаловать в [Обсуждения](https://github.com/Vyachean/mioframe/discussions).
+- Нашли баг? Пожалуйста, создайте [Issue](https://github.com/Mioframe/mioframe/issues).
+- Есть идея или вопрос? Добро пожаловать в [Обсуждения](https://github.com/Mioframe/mioframe/discussions).
 
 ## Разработка
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -4,7 +4,7 @@
 
 [English version](./README.md)
 
-[👉 Запустить Mioframe](https://vyachean.github.io/mioframe/)
+[👉 Запустить Mioframe](https://mioframe.github.io/)
 
 ## Зачем я это сделал?
 

--- a/config/plugins/pwa.test.ts
+++ b/config/plugins/pwa.test.ts
@@ -4,6 +4,7 @@ import {
   buildChannelCacheNamespace,
   buildForeignChannelDenylistPattern,
   buildSameOriginMatcher,
+  buildWorkboxOptions,
   getPwaPlugins,
   isForeignChannelPath,
 } from './pwa.ts';
@@ -100,6 +101,54 @@ describe('buildSameOriginMatcher', () => {
   it('excludes a path that does not match the pattern', () => {
     const matcher = buildSameOriginMatcher(/\.woff2$/i, '/', 'stable');
     expect(matcher({ url: new URL('https://example.com/assets/app.js') })).toBe(false);
+  });
+});
+
+describe('buildWorkboxOptions', () => {
+  it('sets cacheId to the same per-channel namespace used by runtime cache names', () => {
+    expect(buildWorkboxOptions({ base: '/', channel: 'stable' }).cacheId).toBe(
+      buildChannelCacheNamespace('stable'),
+    );
+    expect(
+      buildWorkboxOptions({ base: '/branch/develop/', channel: 'branch', channelId: 'develop' })
+        .cacheId,
+    ).toBe(buildChannelCacheNamespace('branch', 'develop'));
+  });
+
+  it('never shares a cacheId between stable and a branch channel, or between two branches', () => {
+    const cacheIds = [
+      buildWorkboxOptions({ base: '/', channel: 'stable' }).cacheId,
+      buildWorkboxOptions({ base: '/branch/develop/', channel: 'branch', channelId: 'develop' })
+        .cacheId,
+      buildWorkboxOptions({ base: '/branch/feature-x/', channel: 'branch', channelId: 'feature-x' })
+        .cacheId,
+    ];
+
+    expect(new Set(cacheIds).size).toBe(cacheIds.length);
+  });
+
+  // Workbox prepends `cacheId` to any cache name it derives itself (notably
+  // its own default-named precache cache), so this proves the branch
+  // tombstone cleanup prefix (`branch-<slug>-`, see
+  // scripts/pages/lib/tombstoneContent.mjs) covers Workbox's precache too:
+  // every explicit runtime cache name already lives under that same prefix.
+  it('namespaces every explicit runtime cache name under the cacheId prefix', () => {
+    const { cacheId, runtimeCaching } = buildWorkboxOptions({
+      base: '/branch/develop/',
+      channel: 'branch',
+      channelId: 'develop',
+    });
+
+    expect(runtimeCaching?.length).toBeGreaterThan(0);
+    for (const entry of runtimeCaching ?? []) {
+      expect(entry.options?.cacheName?.startsWith(`${cacheId}-`)).toBe(true);
+    }
+  });
+
+  it('throws when the branch channel is used without a channelId', () => {
+    expect(() => buildWorkboxOptions({ base: '/branch/develop/', channel: 'branch' })).toThrow(
+      'channelId is required',
+    );
   });
 });
 

--- a/config/plugins/pwa.test.ts
+++ b/config/plugins/pwa.test.ts
@@ -1,214 +1,112 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  buildPrPreviewDenylistPattern,
+  buildChannelCacheNamespace,
+  buildForeignChannelDenylistPattern,
   buildSameOriginMatcher,
   getPwaPlugins,
-  isPrPreviewPath,
+  isForeignChannelPath,
 } from './pwa.ts';
 
-describe('isPrPreviewPath', () => {
-  describe('PR preview paths return true', () => {
-    it('matches root PR preview path without trailing slash', () => {
-      expect(isPrPreviewPath('/mioframe/pr-86', '/mioframe/')).toBe(true);
-    });
-
-    it('matches root PR preview path with trailing slash', () => {
-      expect(isPrPreviewPath('/mioframe/pr-86/', '/mioframe/')).toBe(true);
-    });
-
-    it('matches nested assets under a PR preview', () => {
-      expect(isPrPreviewPath('/mioframe/pr-86/assets/app.js', '/mioframe/')).toBe(true);
-    });
-
-    it('matches arbitrary PR numbers', () => {
-      expect(isPrPreviewPath('/mioframe/pr-1/', '/mioframe/')).toBe(true);
-      expect(isPrPreviewPath('/mioframe/pr-999/', '/mioframe/')).toBe(true);
-    });
-
-    it('matches under a different base path', () => {
-      expect(isPrPreviewPath('/other-repo/pr-42/', '/other-repo/')).toBe(true);
-      expect(isPrPreviewPath('/other-repo/pr-42/assets/main.css', '/other-repo/')).toBe(true);
-    });
+describe('buildChannelCacheNamespace', () => {
+  it('returns "stable" for the stable channel', () => {
+    expect(buildChannelCacheNamespace('stable')).toBe('stable');
   });
 
-  describe('stable paths return false', () => {
-    it('does not match the stable root path', () => {
-      expect(isPrPreviewPath('/mioframe/', '/mioframe/')).toBe(false);
-    });
-
-    it('does not match stable asset paths', () => {
-      expect(isPrPreviewPath('/mioframe/assets/app.js', '/mioframe/')).toBe(false);
-    });
-
-    it('does not match a path that starts with pr- but has no digits', () => {
-      expect(isPrPreviewPath('/mioframe/pr-preview/', '/mioframe/')).toBe(false);
-    });
-
-    it('does not match paths outside the configured base', () => {
-      expect(isPrPreviewPath('/other/pr-86/', '/mioframe/')).toBe(false);
-    });
-
-    it('does not match the stable index.html', () => {
-      expect(isPrPreviewPath('/mioframe/index.html', '/mioframe/')).toBe(false);
-    });
+  it('returns a branch-prefixed namespace including the channel id', () => {
+    expect(buildChannelCacheNamespace('branch', 'develop')).toBe('branch-develop');
+    expect(buildChannelCacheNamespace('branch', 'feature-x')).toBe('branch-feature-x');
   });
 
-  describe('full URL scenario via url.pathname', () => {
-    it('correctly excludes PR preview when called with url.pathname from a full URL', () => {
-      const url = new URL('https://vyachean.github.io/mioframe/pr-86/assets/app.js');
-      expect(isPrPreviewPath(url.pathname, '/mioframe/')).toBe(true);
-    });
+  it('produces different namespaces for different branch channel ids', () => {
+    expect(buildChannelCacheNamespace('branch', 'develop')).not.toBe(
+      buildChannelCacheNamespace('branch', 'feature-x'),
+    );
+  });
 
-    it('does not exclude stable paths when called with url.pathname from a full URL', () => {
-      const url = new URL('https://vyachean.github.io/mioframe/assets/app.js');
-      expect(isPrPreviewPath(url.pathname, '/mioframe/')).toBe(false);
-    });
+  it('throws when the branch channel is used without a channelId', () => {
+    expect(() => buildChannelCacheNamespace('branch')).toThrow('channelId is required');
   });
 });
 
-describe('buildPrPreviewDenylistPattern', () => {
-  describe('PR preview paths are matched (should be denied)', () => {
-    it('matches a root PR preview path without trailing slash', () => {
-      const pattern = buildPrPreviewDenylistPattern('/mioframe/');
-      expect(pattern.test('/mioframe/pr-86')).toBe(true);
+describe('isForeignChannelPath', () => {
+  describe('foreign channel paths return true (stable base)', () => {
+    it('matches a branch path', () => {
+      expect(isForeignChannelPath('/branch/develop/', '/')).toBe(true);
+      expect(isForeignChannelPath('/branch/develop/assets/app.js', '/')).toBe(true);
     });
 
-    it('matches a root PR preview path with trailing slash', () => {
-      const pattern = buildPrPreviewDenylistPattern('/mioframe/');
-      expect(pattern.test('/mioframe/pr-86/')).toBe(true);
-    });
-
-    it('matches nested assets under a PR preview', () => {
-      const pattern = buildPrPreviewDenylistPattern('/mioframe/');
-      expect(pattern.test('/mioframe/pr-86/assets/app.js')).toBe(true);
-    });
-
-    it('matches index.html under a PR preview', () => {
-      const pattern = buildPrPreviewDenylistPattern('/mioframe/');
-      expect(pattern.test('/mioframe/pr-86/index.html')).toBe(true);
-    });
-
-    it('matches arbitrary PR numbers', () => {
-      const pattern = buildPrPreviewDenylistPattern('/mioframe/');
-      expect(pattern.test('/mioframe/pr-1/')).toBe(true);
-      expect(pattern.test('/mioframe/pr-999/')).toBe(true);
-    });
-
-    it('matches under a different base path', () => {
-      const pattern = buildPrPreviewDenylistPattern('/other-repo/');
-      expect(pattern.test('/other-repo/pr-42/')).toBe(true);
-      expect(pattern.test('/other-repo/pr-42/assets/main.css')).toBe(true);
+    it('matches a PR preview path', () => {
+      expect(isForeignChannelPath('/pr/86/', '/')).toBe(true);
+      expect(isForeignChannelPath('/pr/86/assets/app.js', '/')).toBe(true);
     });
   });
 
-  describe('stable paths are not matched (should not be denied)', () => {
+  describe('own-channel paths return false', () => {
     it('does not match the stable root path', () => {
-      const pattern = buildPrPreviewDenylistPattern('/mioframe/');
-      expect(pattern.test('/mioframe/')).toBe(false);
-    });
-
-    it('does not match a normal stable page path', () => {
-      const pattern = buildPrPreviewDenylistPattern('/mioframe/');
-      expect(pattern.test('/mioframe/index.html')).toBe(false);
+      expect(isForeignChannelPath('/', '/')).toBe(false);
     });
 
     it('does not match stable asset paths', () => {
-      const pattern = buildPrPreviewDenylistPattern('/mioframe/');
-      expect(pattern.test('/mioframe/assets/app.js')).toBe(false);
+      expect(isForeignChannelPath('/assets/app.js', '/')).toBe(false);
     });
 
-    it('does not match a path that starts with pr- but has no digits', () => {
-      const pattern = buildPrPreviewDenylistPattern('/mioframe/');
-      expect(pattern.test('/mioframe/pr-preview/')).toBe(false);
+    it('does not match a path that starts with "branch" but has no separator', () => {
+      expect(isForeignChannelPath('/branchfoo', '/')).toBe(false);
     });
 
-    it('does not match paths outside the base', () => {
-      const pattern = buildPrPreviewDenylistPattern('/mioframe/');
-      expect(pattern.test('/other/pr-86/')).toBe(false);
+    it('does not match paths outside the configured base', () => {
+      expect(isForeignChannelPath('/other/branch/x', '/mioframe/')).toBe(false);
     });
+  });
+
+  it('is scoped relative to a non-root base too', () => {
+    expect(isForeignChannelPath('/branch/develop/branch/nested/', '/branch/develop/')).toBe(true);
+    expect(isForeignChannelPath('/branch/develop/assets/app.js', '/branch/develop/')).toBe(false);
+  });
+});
+
+describe('buildForeignChannelDenylistPattern', () => {
+  it('matches branch and pr paths under the stable root', () => {
+    const pattern = buildForeignChannelDenylistPattern('/');
+    expect(pattern.test('/branch/develop/')).toBe(true);
+    expect(pattern.test('/pr/86/')).toBe(true);
+  });
+
+  it('does not match stable paths', () => {
+    const pattern = buildForeignChannelDenylistPattern('/');
+    expect(pattern.test('/')).toBe(false);
+    expect(pattern.test('/assets/app.js')).toBe(false);
   });
 });
 
 describe('buildSameOriginMatcher', () => {
-  const base = '/mioframe/';
-
-  it('matches a stable path whose extension satisfies the pattern', () => {
-    const matcher = buildSameOriginMatcher(/\.woff2$/i, base);
-    expect(matcher({ url: new URL('https://example.com/mioframe/assets/font.woff2') })).toBe(true);
+  it('excludes foreign-channel paths for the stable channel', () => {
+    const matcher = buildSameOriginMatcher(/\.woff2$/i, '/', 'stable');
+    expect(matcher({ url: new URL('https://example.com/assets/font.woff2') })).toBe(true);
+    expect(matcher({ url: new URL('https://example.com/branch/develop/assets/font.woff2') })).toBe(
+      false,
+    );
+    expect(matcher({ url: new URL('https://example.com/pr/86/assets/font.woff2') })).toBe(false);
   });
 
-  it('excludes a PR preview path even when the extension matches', () => {
-    const matcher = buildSameOriginMatcher(/\.woff2$/i, base);
-    expect(matcher({ url: new URL('https://example.com/mioframe/pr-86/assets/font.woff2') })).toBe(
-      false,
+  it('does not need foreign-channel exclusion for the branch channel (scope already contains it)', () => {
+    const matcher = buildSameOriginMatcher(/\.woff2$/i, '/branch/develop/', 'branch');
+    expect(matcher({ url: new URL('https://example.com/branch/develop/assets/font.woff2') })).toBe(
+      true,
     );
   });
 
   it('excludes a path that does not match the pattern', () => {
-    const matcher = buildSameOriginMatcher(/\.woff2$/i, base);
-    expect(matcher({ url: new URL('https://example.com/mioframe/assets/app.js') })).toBe(false);
-  });
-
-  describe('font asset rule (eot|otf|ttc|ttf|woff|woff2|font.css)', () => {
-    const matcher = buildSameOriginMatcher(/\.(?:eot|otf|ttc|ttf|woff|woff2|font.css)$/i, base);
-
-    it('matches stable font assets', () => {
-      expect(matcher({ url: new URL('https://example.com/mioframe/assets/font.woff2') })).toBe(
-        true,
-      );
-    });
-
-    it('excludes PR preview font assets', () => {
-      expect(
-        matcher({ url: new URL('https://example.com/mioframe/pr-86/assets/font.woff2') }),
-      ).toBe(false);
-    });
-  });
-
-  describe('image asset rule (jpg|jpeg|gif|png|svg|ico|webp)', () => {
-    const matcher = buildSameOriginMatcher(/\.(?:jpg|jpeg|gif|png|svg|ico|webp)$/i, base);
-
-    it('matches stable image assets', () => {
-      expect(matcher({ url: new URL('https://example.com/mioframe/assets/icon.svg') })).toBe(true);
-    });
-
-    it('excludes PR preview image assets', () => {
-      expect(matcher({ url: new URL('https://example.com/mioframe/pr-86/assets/icon.svg') })).toBe(
-        false,
-      );
-    });
-  });
-
-  describe('data asset rule (json|xml|csv)', () => {
-    const matcher = buildSameOriginMatcher(/\.(?:json|xml|csv)$/i, base);
-
-    it('matches stable data assets', () => {
-      expect(matcher({ url: new URL('https://example.com/mioframe/some.json') })).toBe(true);
-    });
-
-    it('excludes PR preview data assets', () => {
-      expect(matcher({ url: new URL('https://example.com/mioframe/pr-86/some.json') })).toBe(false);
-    });
-  });
-
-  describe('API route rule (/api/)', () => {
-    const matcher = buildSameOriginMatcher(/\/api\/.*$/i, base);
-
-    it('matches stable API routes', () => {
-      expect(matcher({ url: new URL('https://example.com/mioframe/api/data') })).toBe(true);
-    });
-
-    it('excludes PR preview API routes', () => {
-      expect(matcher({ url: new URL('https://example.com/mioframe/pr-86/api/data') })).toBe(false);
-    });
+    const matcher = buildSameOriginMatcher(/\.woff2$/i, '/', 'stable');
+    expect(matcher({ url: new URL('https://example.com/assets/app.js') })).toBe(false);
   });
 });
 
 describe('getPwaPlugins', () => {
   it('returns empty array when disablePwa is true (PR preview builds)', () => {
     const plugins = getPwaPlugins({
-      base: '/mioframe/',
+      base: '/pr/42/',
       isPreview: false,
       mode: 'production',
       disablePwa: true,
@@ -216,28 +114,40 @@ describe('getPwaPlugins', () => {
     expect(plugins).toHaveLength(0);
   });
 
-  it('returns empty array when disablePwa is true even in production mode', () => {
+  it('returns plugins for the stable channel in production mode without a channelId', () => {
     const plugins = getPwaPlugins({
-      base: '/mioframe/',
-      isPreview: false,
-      mode: 'production',
-      disablePwa: true,
-    });
-    expect(plugins).toHaveLength(0);
-  });
-
-  it('returns plugins in production mode without disablePwa', () => {
-    const plugins = getPwaPlugins({
-      base: '/mioframe/',
+      base: '/',
       isPreview: false,
       mode: 'production',
     });
     expect(plugins.length).toBeGreaterThan(0);
   });
 
+  it('returns plugins for the branch channel when a channelId is provided', () => {
+    const plugins = getPwaPlugins({
+      base: '/branch/develop/',
+      isPreview: false,
+      mode: 'production',
+      channel: 'branch',
+      channelId: 'develop',
+    });
+    expect(plugins.length).toBeGreaterThan(0);
+  });
+
+  it('throws when the branch channel is used without a channelId', () => {
+    expect(() =>
+      getPwaPlugins({
+        base: '/branch/develop/',
+        isPreview: false,
+        mode: 'production',
+        channel: 'branch',
+      }),
+    ).toThrow('channelId is required');
+  });
+
   it('returns empty array in development mode without isPreview', () => {
     const plugins = getPwaPlugins({
-      base: '/mioframe/',
+      base: '/',
       isPreview: false,
       mode: 'development',
     });

--- a/config/plugins/pwa.ts
+++ b/config/plugins/pwa.ts
@@ -1,76 +1,122 @@
 import type { PluginOption } from 'vite';
 import { VitePWA } from 'vite-plugin-pwa';
 
+type ReleaseChannel = 'stable' | 'branch';
+
 type GetPwaPluginsParams = {
   base: string;
   isPreview: boolean;
   mode: string;
   disablePwa?: boolean;
+  channel?: ReleaseChannel;
+  channelId?: string;
 };
 
 const daysToSeconds = (days: number) => 24 * 60 * 60 * days;
 
 /**
- * Returns true when `pathname` is a PR preview path under the given Vite base.
+ * Build the Cache Storage name prefix for a release channel.
  *
- * Matches `<base>pr-<number>`, `<base>pr-<number>/`, and
- * `<base>pr-<number>/anything` so both the navigation fallback denylist and
- * the runtime cache catch-all can exclude PR preview URLs reliably.
- *
- * Must be called with `url.pathname` (not a full URL string) so that the
- * check works even when Workbox passes a full URL object to the route matcher.
- * @param pathname - The URL pathname to test, e.g. `/mioframe/pr-86/assets/app.js`.
- * @param base - The Vite `base` URL, e.g. `/mioframe/`.
- * @returns `true` when the pathname belongs to a PR preview deployment.
+ * Cache Storage is per-origin, not per service-worker-scope, so channel
+ * isolation across `/`, `/branch/<slug>/`, and `/pr/<number>/` depends on
+ * this prefix, not on scope alone. Must match the prefix
+ * `scripts/pages/lib/tombstoneContent.mjs` uses when clearing a removed
+ * branch's caches.
+ * @param channel - Release channel.
+ * @param channelId - Channel identifier; required for the `branch` channel.
+ * @returns Cache name prefix, e.g. `stable` or `branch-develop`.
  */
-export function isPrPreviewPath(pathname: string, base: string): boolean {
-  if (!pathname.startsWith(base)) return false;
-  const rest = pathname.slice(base.length);
-  return /^pr-\d+(?:\/|$)/.test(rest);
+export function buildChannelCacheNamespace(channel: ReleaseChannel, channelId?: string): string {
+  if (channel === 'branch') {
+    if (!channelId) {
+      throw new Error('channelId is required for the "branch" release channel.');
+    }
+    return `branch-${channelId}`;
+  }
+  return 'stable';
 }
 
 /**
- * Builds a RegExp that matches PR preview paths under the given Vite base path.
+ * Returns true when `pathname` is under `base` but belongs to a different
+ * top-level channel namespace (`/branch/*` or `/pr/*`).
  *
- * Matches `<base>pr-<number>`, `<base>pr-<number>/`, and `<base>pr-<number>/**`
- * so the stable service worker can exclude them from navigation fallback,
- * preventing it from serving the cached stable app for PR preview URLs such as
- * `/mioframe/pr-86/`.
- * @param base - The Vite `base` URL, e.g. `/mioframe/`.
- * @returns A RegExp matching PR preview path prefixes under the given base.
+ * Only meaningful for the stable channel: its service worker scope is `/`,
+ * so it is the only one whose fetch handler can ever see requests for other
+ * channels' paths. A branch channel's scope (e.g. `/branch/develop/`) is
+ * narrower than any other channel's path, so the browser never dispatches
+ * fetch/navigate events for foreign paths to it in the first place.
+ * @param pathname - The URL pathname to test, e.g. `/branch/develop/assets/app.js`.
+ * @param base - The Vite `base` URL for this build, e.g. `/`.
+ * @returns `true` when the pathname belongs to a different channel's deployment.
  */
-export function buildPrPreviewDenylistPattern(base: string): RegExp {
+export function isForeignChannelPath(pathname: string, base: string): boolean {
+  if (!pathname.startsWith(base)) return false;
+  const rest = pathname.slice(base.length);
+  return /^(?:branch|pr)\/.*$/.test(rest);
+}
+
+/**
+ * Builds a RegExp that matches foreign-channel paths (`/branch/*`, `/pr/*`)
+ * under the given Vite base path, for the stable service worker's
+ * `navigateFallbackDenylist`.
+ * @param base - The Vite `base` URL, e.g. `/`.
+ * @returns A RegExp matching `/branch/*` and `/pr/*` path prefixes under `base`.
+ */
+export function buildForeignChannelDenylistPattern(base: string): RegExp {
   const escapedBase = base.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  return new RegExp(`^${escapedBase}pr-\\d+(?:\\/|$)`);
+  return new RegExp(`^${escapedBase}(?:branch|pr)\\/`);
 }
 
 /**
  * Builds a Workbox `urlPattern` function that matches `url.pathname` against
- * `pattern` and additionally excludes PR preview paths.
- *
- * Apply to every same-origin runtime caching rule (fonts, images, data, API,
- * catch-all) so that PR preview assets are never cached by the stable service
- * worker.  External-origin rules (Google Fonts) do not need this wrapper.
+ * `pattern`, additionally excluding foreign-channel paths when `channel` is
+ * `stable` (see {@link isForeignChannelPath}).
  * @param pattern - RegExp tested against `url.pathname`.
- * @param base - The Vite `base` URL, e.g. `/mioframe/`.
+ * @param base - The Vite `base` URL for this build.
+ * @param channel - Release channel this service worker is built for.
  * @returns A Workbox `urlPattern` function.
  */
 export function buildSameOriginMatcher(
   pattern: RegExp,
   base: string,
+  channel: ReleaseChannel,
 ): (context: { url: URL }) => boolean {
+  if (channel !== 'stable') {
+    return ({ url }: { url: URL }) => pattern.test(url.pathname);
+  }
   return ({ url }: { url: URL }) =>
-    pattern.test(url.pathname) && !isPrPreviewPath(url.pathname, base);
+    pattern.test(url.pathname) && !isForeignChannelPath(url.pathname, base);
+}
+
+/**
+ * Build the manifest `name`/`short_name` identity for a release channel, so
+ * an installed branch PWA is visually distinguishable from stable.
+ * @param channel - Release channel.
+ * @param channelId - Channel identifier (e.g. `develop`, a branch slug).
+ * @returns `{ name, short_name }` for the Web App Manifest.
+ */
+function buildManifestIdentity(channel: ReleaseChannel, channelId?: string) {
+  if (channel === 'branch' && channelId) {
+    const label = channelId === 'develop' ? 'Develop' : channelId;
+    return { name: `Mioframe ${label}`, short_name: `Mioframe ${label}` };
+  }
+  return { name: 'Mioframe', short_name: 'Mioframe' };
 }
 
 /**
  * Returns the Vite PWA plugin array for the given build parameters.
  *
  * Returns an empty array when PWA is disabled or the mode is not production
- * and not a preview build.  In all other cases returns a single configured
- * {@link VitePWA} plugin that:
- * - denies the stable service worker from handling PR preview navigation URLs;
- * - excludes PR preview paths from the catch-all runtime cache.
+ * and not a preview build (PR previews always pass `disablePwa: true`). In
+ * all other cases returns a single configured {@link VitePWA} plugin scoped
+ * and namespaced to the given release channel:
+ * - `scope`/`start_url`/`id` are pinned to `base`, so the manifest never
+ *   drifts from the deployment it was built for;
+ * - cache names are namespaced per channel ({@link buildChannelCacheNamespace})
+ *   so stable, develop, and other branches never share Cache Storage entries;
+ * - the stable channel additionally denies `/branch/*` and `/pr/*` from its
+ *   navigation fallback and runtime caching, since its scope (`/`) is the
+ *   only one wide enough to otherwise intercept them.
  * @param params - Build parameters controlling whether and how PWA is enabled.
  * @returns A `PluginOption[]` — either `[VitePWA(...)]` or `[]`.
  */
@@ -79,27 +125,37 @@ export const getPwaPlugins = ({
   isPreview,
   mode,
   disablePwa,
+  channel = 'stable',
+  channelId,
 }: GetPwaPluginsParams): PluginOption[] => {
   if (disablePwa || (mode !== 'production' && !isPreview)) {
     return [];
   }
 
-  const prPreviewPattern = buildPrPreviewDenylistPattern(base);
+  const cacheNamespace = buildChannelCacheNamespace(channel, channelId);
+  const cacheName = (name: string) => `${cacheNamespace}-${name}`;
+  const matcher = (pattern: RegExp) => buildSameOriginMatcher(pattern, base, channel);
 
   return [
     VitePWA({
       manifest: {
+        ...buildManifestIdentity(channel, channelId),
+        scope: base,
+        start_url: base,
+        id: base,
         theme_color: 'rgb(33, 31, 38)',
         background_color: 'rgb(33, 31, 38)',
       },
       workbox: {
-        navigateFallbackDenylist: [prPreviewPattern],
+        ...(channel === 'stable'
+          ? { navigateFallbackDenylist: [buildForeignChannelDenylistPattern(base)] }
+          : {}),
         runtimeCaching: [
           {
             urlPattern: /^https:\/\/fonts\.(?:googleapis|gstatic)\.com\/.*/i,
             handler: 'CacheFirst',
             options: {
-              cacheName: 'google-fonts',
+              cacheName: cacheName('google-fonts'),
               expiration: {
                 maxEntries: 20,
                 maxAgeSeconds: daysToSeconds(365),
@@ -110,10 +166,10 @@ export const getPwaPlugins = ({
             },
           },
           {
-            urlPattern: buildSameOriginMatcher(/\.(?:eot|otf|ttc|ttf|woff|woff2|font.css)$/i, base),
+            urlPattern: matcher(/\.(?:eot|otf|ttc|ttf|woff|woff2|font.css)$/i),
             handler: 'StaleWhileRevalidate',
             options: {
-              cacheName: 'static-font-assets',
+              cacheName: cacheName('static-font-assets'),
               expiration: {
                 maxEntries: 10,
                 maxAgeSeconds: daysToSeconds(30),
@@ -121,10 +177,10 @@ export const getPwaPlugins = ({
             },
           },
           {
-            urlPattern: buildSameOriginMatcher(/\.(?:jpg|jpeg|gif|png|svg|ico|webp)$/i, base),
+            urlPattern: matcher(/\.(?:jpg|jpeg|gif|png|svg|ico|webp)$/i),
             handler: 'StaleWhileRevalidate',
             options: {
-              cacheName: 'static-image-assets',
+              cacheName: cacheName('static-image-assets'),
               expiration: {
                 maxEntries: 64,
                 maxAgeSeconds: daysToSeconds(14),
@@ -132,10 +188,10 @@ export const getPwaPlugins = ({
             },
           },
           {
-            urlPattern: buildSameOriginMatcher(/\.(?:json|xml|csv)$/i, base),
+            urlPattern: matcher(/\.(?:json|xml|csv)$/i),
             handler: 'NetworkFirst',
             options: {
-              cacheName: 'static-data-assets',
+              cacheName: cacheName('static-data-assets'),
               expiration: {
                 maxEntries: 32,
                 maxAgeSeconds: daysToSeconds(7),
@@ -143,11 +199,11 @@ export const getPwaPlugins = ({
             },
           },
           {
-            urlPattern: buildSameOriginMatcher(/\/api\/.*$/i, base),
+            urlPattern: matcher(/\/api\/.*$/i),
             handler: 'NetworkFirst',
             method: 'GET',
             options: {
-              cacheName: 'apis',
+              cacheName: cacheName('apis'),
               expiration: {
                 maxEntries: 16,
                 maxAgeSeconds: daysToSeconds(1),
@@ -156,10 +212,13 @@ export const getPwaPlugins = ({
             },
           },
           {
-            urlPattern: ({ url }: { url: URL }) => !isPrPreviewPath(url.pathname, base),
+            urlPattern:
+              channel === 'stable'
+                ? ({ url }: { url: URL }) => !isForeignChannelPath(url.pathname, base)
+                : () => true,
             handler: 'NetworkFirst',
             options: {
-              cacheName: 'others',
+              cacheName: cacheName('others'),
               expiration: {
                 maxEntries: 32,
                 maxAgeSeconds: daysToSeconds(1),

--- a/config/plugins/pwa.ts
+++ b/config/plugins/pwa.ts
@@ -1,7 +1,10 @@
 import type { PluginOption } from 'vite';
 import { VitePWA } from 'vite-plugin-pwa';
+import type { VitePWAOptions } from 'vite-plugin-pwa';
 
 type ReleaseChannel = 'stable' | 'branch';
+
+type WorkboxOptions = VitePWAOptions['workbox'];
 
 type GetPwaPluginsParams = {
   base: string;
@@ -21,7 +24,9 @@ const daysToSeconds = (days: number) => 24 * 60 * 60 * days;
  * isolation across `/`, `/branch/<slug>/`, and `/pr/<number>/` depends on
  * this prefix, not on scope alone. Must match the prefix
  * `scripts/pages/lib/tombstoneContent.mjs` uses when clearing a removed
- * branch's caches.
+ * branch's caches. Also passed as Workbox's `cacheId` (see
+ * {@link buildWorkboxOptions}) so Workbox's own default-named precache cache
+ * carries the same prefix as the explicit runtime caches below.
  * @param channel - Release channel.
  * @param channelId - Channel identifier; required for the `branch` channel.
  * @returns Cache name prefix, e.g. `stable` or `branch-develop`.
@@ -104,6 +109,124 @@ function buildManifestIdentity(channel: ReleaseChannel, channelId?: string) {
 }
 
 /**
+ * Build the `workbox` (`generateSW`) options for a release channel's
+ * {@link VitePWA} plugin.
+ *
+ * Sets Workbox's `cacheId` to the same per-channel prefix as the explicit
+ * `runtimeCaching` cache names ({@link buildChannelCacheNamespace}). Workbox
+ * prepends `cacheId` to any cache name it derives itself — notably its
+ * default-named precache cache (normally `workbox-precache-v2-<scope>`,
+ * becoming `<cacheId>-precache-v2-<scope>`) — by calling
+ * `workbox-core`'s `setCacheNameDetails({ prefix: cacheId })` in the
+ * generated service worker. Cache names passed explicitly via `cacheName`
+ * above are used as-is and are unaffected by `cacheId`. Without this, a
+ * branch's precache cache would keep the shared `workbox-` prefix and a
+ * branch tombstone's cache cleanup (`branch-<slug>-*`, see
+ * `scripts/pages/lib/tombstoneContent.mjs`) would never remove it.
+ * @param params - The Vite `base` URL, release channel, and (for the
+ * `branch` channel) channel identifier this service worker is built for.
+ * @returns The `workbox` field for {@link VitePWA}'s options.
+ */
+export function buildWorkboxOptions({
+  base,
+  channel,
+  channelId,
+}: {
+  base: string;
+  channel: ReleaseChannel;
+  channelId?: string | undefined;
+}): WorkboxOptions {
+  const cacheNamespace = buildChannelCacheNamespace(channel, channelId);
+  const cacheName = (name: string) => `${cacheNamespace}-${name}`;
+  const matcher = (pattern: RegExp) => buildSameOriginMatcher(pattern, base, channel);
+
+  return {
+    cacheId: cacheNamespace,
+    ...(channel === 'stable'
+      ? { navigateFallbackDenylist: [buildForeignChannelDenylistPattern(base)] }
+      : {}),
+    runtimeCaching: [
+      {
+        urlPattern: /^https:\/\/fonts\.(?:googleapis|gstatic)\.com\/.*/i,
+        handler: 'CacheFirst',
+        options: {
+          cacheName: cacheName('google-fonts'),
+          expiration: {
+            maxEntries: 20,
+            maxAgeSeconds: daysToSeconds(365),
+          },
+          cacheableResponse: {
+            statuses: [0, 200],
+          },
+        },
+      },
+      {
+        urlPattern: matcher(/\.(?:eot|otf|ttc|ttf|woff|woff2|font.css)$/i),
+        handler: 'StaleWhileRevalidate',
+        options: {
+          cacheName: cacheName('static-font-assets'),
+          expiration: {
+            maxEntries: 10,
+            maxAgeSeconds: daysToSeconds(30),
+          },
+        },
+      },
+      {
+        urlPattern: matcher(/\.(?:jpg|jpeg|gif|png|svg|ico|webp)$/i),
+        handler: 'StaleWhileRevalidate',
+        options: {
+          cacheName: cacheName('static-image-assets'),
+          expiration: {
+            maxEntries: 64,
+            maxAgeSeconds: daysToSeconds(14),
+          },
+        },
+      },
+      {
+        urlPattern: matcher(/\.(?:json|xml|csv)$/i),
+        handler: 'NetworkFirst',
+        options: {
+          cacheName: cacheName('static-data-assets'),
+          expiration: {
+            maxEntries: 32,
+            maxAgeSeconds: daysToSeconds(7),
+          },
+        },
+      },
+      {
+        urlPattern: matcher(/\/api\/.*$/i),
+        handler: 'NetworkFirst',
+        method: 'GET',
+        options: {
+          cacheName: cacheName('apis'),
+          expiration: {
+            maxEntries: 16,
+            maxAgeSeconds: daysToSeconds(1),
+          },
+          networkTimeoutSeconds: 10,
+        },
+      },
+      {
+        urlPattern:
+          channel === 'stable'
+            ? ({ url }: { url: URL }) => !isForeignChannelPath(url.pathname, base)
+            : () => true,
+        handler: 'NetworkFirst',
+        options: {
+          cacheName: cacheName('others'),
+          expiration: {
+            maxEntries: 32,
+            maxAgeSeconds: daysToSeconds(1),
+          },
+          networkTimeoutSeconds: 10,
+        },
+      },
+    ],
+    maximumFileSizeToCacheInBytes: 10e6,
+  };
+}
+
+/**
  * Returns the Vite PWA plugin array for the given build parameters.
  *
  * Returns an empty array when PWA is disabled or the mode is not production
@@ -112,8 +235,9 @@ function buildManifestIdentity(channel: ReleaseChannel, channelId?: string) {
  * and namespaced to the given release channel:
  * - `scope`/`start_url`/`id` are pinned to `base`, so the manifest never
  *   drifts from the deployment it was built for;
- * - cache names are namespaced per channel ({@link buildChannelCacheNamespace})
- *   so stable, develop, and other branches never share Cache Storage entries;
+ * - cache names, including Workbox's own precache, are namespaced per
+ *   channel ({@link buildWorkboxOptions}) so stable, develop, and other
+ *   branches never share Cache Storage entries;
  * - the stable channel additionally denies `/branch/*` and `/pr/*` from its
  *   navigation fallback and runtime caching, since its scope (`/`) is the
  *   only one wide enough to otherwise intercept them.
@@ -132,10 +256,6 @@ export const getPwaPlugins = ({
     return [];
   }
 
-  const cacheNamespace = buildChannelCacheNamespace(channel, channelId);
-  const cacheName = (name: string) => `${cacheNamespace}-${name}`;
-  const matcher = (pattern: RegExp) => buildSameOriginMatcher(pattern, base, channel);
-
   return [
     VitePWA({
       manifest: {
@@ -146,89 +266,7 @@ export const getPwaPlugins = ({
         theme_color: 'rgb(33, 31, 38)',
         background_color: 'rgb(33, 31, 38)',
       },
-      workbox: {
-        ...(channel === 'stable'
-          ? { navigateFallbackDenylist: [buildForeignChannelDenylistPattern(base)] }
-          : {}),
-        runtimeCaching: [
-          {
-            urlPattern: /^https:\/\/fonts\.(?:googleapis|gstatic)\.com\/.*/i,
-            handler: 'CacheFirst',
-            options: {
-              cacheName: cacheName('google-fonts'),
-              expiration: {
-                maxEntries: 20,
-                maxAgeSeconds: daysToSeconds(365),
-              },
-              cacheableResponse: {
-                statuses: [0, 200],
-              },
-            },
-          },
-          {
-            urlPattern: matcher(/\.(?:eot|otf|ttc|ttf|woff|woff2|font.css)$/i),
-            handler: 'StaleWhileRevalidate',
-            options: {
-              cacheName: cacheName('static-font-assets'),
-              expiration: {
-                maxEntries: 10,
-                maxAgeSeconds: daysToSeconds(30),
-              },
-            },
-          },
-          {
-            urlPattern: matcher(/\.(?:jpg|jpeg|gif|png|svg|ico|webp)$/i),
-            handler: 'StaleWhileRevalidate',
-            options: {
-              cacheName: cacheName('static-image-assets'),
-              expiration: {
-                maxEntries: 64,
-                maxAgeSeconds: daysToSeconds(14),
-              },
-            },
-          },
-          {
-            urlPattern: matcher(/\.(?:json|xml|csv)$/i),
-            handler: 'NetworkFirst',
-            options: {
-              cacheName: cacheName('static-data-assets'),
-              expiration: {
-                maxEntries: 32,
-                maxAgeSeconds: daysToSeconds(7),
-              },
-            },
-          },
-          {
-            urlPattern: matcher(/\/api\/.*$/i),
-            handler: 'NetworkFirst',
-            method: 'GET',
-            options: {
-              cacheName: cacheName('apis'),
-              expiration: {
-                maxEntries: 16,
-                maxAgeSeconds: daysToSeconds(1),
-              },
-              networkTimeoutSeconds: 10,
-            },
-          },
-          {
-            urlPattern:
-              channel === 'stable'
-                ? ({ url }: { url: URL }) => !isForeignChannelPath(url.pathname, base)
-                : () => true,
-            handler: 'NetworkFirst',
-            options: {
-              cacheName: cacheName('others'),
-              expiration: {
-                maxEntries: 32,
-                maxAgeSeconds: daysToSeconds(1),
-              },
-              networkTimeoutSeconds: 10,
-            },
-          },
-        ],
-        maximumFileSizeToCacheInBytes: 10e6,
-      },
+      workbox: buildWorkboxOptions({ base, channel, channelId }),
       pwaAssets: {
         config: true,
         overrideManifestIcons: true,

--- a/config/tooling.json
+++ b/config/tooling.json
@@ -6,10 +6,14 @@
     "port": 4173
   },
   "release": {
-    "basePath": "/mioframe/",
+    "basePath": "/",
     "artifactServer": {
       "port": 4174
     }
+  },
+  "pages": {
+    "targetRepository": "Mioframe/mioframe.github.io",
+    "tombstoneRetentionDays": 14
   },
   "storybook": {
     "devServer": {

--- a/docs/release.md
+++ b/docs/release.md
@@ -156,18 +156,35 @@ focused and the full gate, and tag pushes never rerun the full gate:
   development verification (`pnpm verify`, changed-file scope) plus, on PRs,
   a version-bump check — the PR version must be strictly greater than
   `develop`'s current version. Its `pull_request` trigger uses
-  `branches-ignore: [main]`, so it never fires for a PR into `main`.
+  `branches-ignore: [main]`, so it never fires for a PR into `main`. It also
+  owns the two verify-gated Pages deployments: `deploy-preview` (PR previews,
+  `/pr/<number>/`) and `deploy-develop` (the develop branch deployment,
+  `/branch/develop/`) — see
+  `docs/release.md#organization-pages-deployment-model`.
 - **`release` workflow** (`.github/workflows/release.yml`): PRs into `main`
   and pushes to `main` only. Runs the full release gate
   (`pnpm verify:release`, full-project scope, see below), which includes
   version/build metadata and release-config validation. Stable deploy
-  (`deploy-stable`) runs only after this gate passes on a push to `main`.
+  (`deploy-stable`, `/`) runs only after this gate passes on a push to
+  `main`.
 - **`release-tag` workflow** (`.github/workflows/release-tag.yml`): `vX.Y.Z`
   tag pushes only. Runs a single lightweight check
   (`node scripts/release/validateVersion.mjs`) confirming the tag matches
   `package.json` version — it does not rerun e2e, visual, artifact, or
   deploy steps, since `main` was already validated by the `release`
   workflow before the tag was created.
+- **`deploy-branch` workflow** (`.github/workflows/deploy-branch.yml`):
+  `workflow_dispatch` only, for a maintainer-selected manual branch
+  deployment (`/branch/<slug>/`). Never runs automatically.
+- **`deploy-branch-tombstone` workflow**
+  (`.github/workflows/deploy-branch-tombstone.yml`): runs on every branch
+  deletion; a no-op unless that branch had an existing `/branch/<slug>/`
+  deployment.
+- **`deploy-branch-tombstone-cleanup` workflow**
+  (`.github/workflows/deploy-branch-tombstone-cleanup.yml`): scheduled,
+  removes tombstones past their retention period.
+- **`deploy-cleanup` workflow** (`.github/workflows/deploy-cleanup.yml`):
+  runs on PR close, removes that PR's `/pr/<number>/` deployment.
 
 ## What remains a manual product/release decision
 
@@ -208,6 +225,147 @@ robustness rather than the published artifact. `pnpm verify --full` and
 `pnpm verify:release` do not run it, and `pnpm verify --full --only
 mutation` is not a valid release check.
 
+## Organization Pages deployment model
+
+Mioframe publishes to the organization Pages repository
+`Mioframe/mioframe.github.io`, not a project-site path inside this
+repository. This source repository (`Mioframe/mioframe`) owns source, CI,
+verification, and build scripts; `Mioframe/mioframe.github.io` owns only
+generated static deployment output, published to its `gh-pages` branch.
+
+Canonical deployment paths:
+
+- stable (`main`): `https://mioframe.github.io/`
+- develop: `https://mioframe.github.io/branch/develop/`
+- manual branch: `https://mioframe.github.io/branch/<branch-slug>/`
+- PR preview: `https://mioframe.github.io/pr/<number>/`
+
+Each deployed channel is isolated by `BASE_URL`, service worker scope,
+manifest identity, and Cache Storage cache-name namespace (see
+`config/plugins/pwa.ts`). Every deployment writes a `deployment.json` at its
+own root, produced by `scripts/pages/writeDeploymentMetadata.mjs`,
+recording channel, channel id, source ref/branch/slug, commit SHA, build
+date, app version, base URL, and a tombstone flag when applicable.
+
+### Cross-repository publishing (GitHub App)
+
+Publishing to `Mioframe/mioframe.github.io` uses a short-lived installation
+token from a GitHub App (`vars.MIOFRAME_PAGES_APP_CLIENT_ID` /
+`secrets.MIOFRAME_PAGES_APP_PRIVATE_KEY`), minted per publish job with
+`actions/create-github-app-token` scoped to `owner: Mioframe`,
+`repositories: mioframe.github.io`. The source repository's own
+`GITHUB_TOKEN` is never used for the cross-repository write — it only needs
+`contents: read` to check out the source and, for PR previews,
+`pull-requests: write` to post the preview comment on this repository. The
+GitHub App is installed only on `Mioframe/mioframe.github.io`, not on this
+repository.
+
+Every publish script (`scripts/pages/publish*.mjs`,
+`scripts/pages/cleanup*.mjs`) commits to the target repository's `gh-pages`
+branch through `scripts/pages/lib/ghPagesBranch.mjs`, retrying on push
+conflicts. Each publish only touches its own slot:
+
+- stable publish (`publishStable.mjs`) replaces everything at the target
+  repository root except `.git/`, `branch/`, and `pr/` — so it never evicts
+  develop, manual branch, or PR preview deployments;
+- branch publish (`publishBranch.mjs`) replaces only `branch/<slug>/`;
+- PR preview publish (`publishPreview.mjs`) replaces only `pr/<number>/`;
+- PR preview cleanup (`cleanupPreview.mjs`, run on PR close) removes only
+  `pr/<number>/`.
+
+The org-root `404.html` SPA fallback (`scripts/pages/writeSpaFallback.mjs`)
+is channel-independent — it dispatches any unmatched deep link to `/`,
+`/branch/<slug>/`, or `/pr/<number>/` based on the URL path alone — so only
+the stable publish job, which owns the repository root, ever writes it.
+
+### Develop branch deployment
+
+On push to `develop`, the `verify` workflow's `deploy-develop` job builds
+with `BASE_URL=/branch/develop/`, `VITE_RELEASE_CHANNEL=branch`,
+`VITE_RELEASE_CHANNEL_ID=develop`, PWA enabled, and publishes to
+`branch/develop/`.
+
+### Manual branch deployment
+
+`.github/workflows/deploy-branch.yml` is `workflow_dispatch`-only and never
+runs automatically — arbitrary branches are not auto-published. Given a
+branch/ref input, it derives a safe branch slug
+(`scripts/pages/lib/slug.mjs` `slugifyBranch`: lower-cased, non-`[a-z0-9]`
+runs collapsed to `-`, truncated to a DNS-label-safe length, and rejecting
+the reserved `branch`/`pr` namespace names), builds with
+`BASE_URL=/branch/<slug>/`, `VITE_RELEASE_CHANNEL=branch`,
+`VITE_RELEASE_CHANNEL_ID=<slug>`, PWA enabled, and publishes to
+`branch/<slug>/`.
+
+### PR preview deployment
+
+PR previews remain owned by the `verify` workflow's `deploy-preview` job:
+`BASE_URL=/pr/<number>/`, `VITE_DISABLE_PWA=1` (PWA stays disabled for PR
+previews in this implementation), publishing to `pr/<number>/`. The sticky
+preview comment links to `https://mioframe.github.io/pr/<number>/`. PR
+previews for release sync-back branches remain skipped, as before (see
+`Release sync-back` above). PR preview cleanup on PR close removes only
+that PR's `pr/<number>/` slot.
+
+### Branch deletion tombstone
+
+When a branch with an existing `branch/<slug>/` deployment is deleted,
+`.github/workflows/deploy-branch-tombstone.yml` (triggered by GitHub's
+`delete` branch event) does not immediately remove that slot. Instead it
+replaces its content with a tombstone
+(`scripts/pages/lib/tombstoneContent.mjs`):
+
+- `index.html` — a static notice that the branch preview was removed, with
+  a link back to the stable app root (`/`);
+- `sw.js` — a service worker that, on activation, deletes only Cache
+  Storage entries whose name is prefixed `branch-<slug>-` (the same
+  namespace that branch's real PWA build used — see
+  `buildChannelCacheNamespace` in `config/plugins/pwa.ts`), then claims
+  existing clients. It registers no `fetch` handler and never messages
+  clients to reload — this is passive cache self-cleanup, not forced-reload
+  coordination;
+- `manifest.webmanifest` — keeps the same `scope`/`start_url`/`id` as the
+  removed deployment so an already-installed PWA icon still resolves;
+- `deployment.json` — the same shape as a normal deployment, with
+  `tombstone: true`.
+
+For branches that were never deployed to `branch/<slug>/` (almost all
+ordinary feature branches), this is a clean no-op — the workflow checks the
+slot exists before doing anything.
+
+Tombstones are retained for `config/tooling.json`
+`pages.tombstoneRetentionDays` (14 days by default). The scheduled
+`.github/workflows/deploy-branch-tombstone-cleanup.yml` workflow removes
+`branch/<slug>/` slots whose `deployment.json` is a tombstone older than the
+retention period (`scripts/pages/lib/tombstoneRetention.mjs`
+`findExpiredTombstoneSlugs`); live deployments and tombstones still within
+retention are left untouched.
+
+### PWA channel isolation
+
+`config/plugins/pwa.ts` makes the Vite PWA plugin channel-aware:
+
+- `manifest.scope`, `start_url`, and `id` are pinned explicitly to the
+  build's `BASE_URL` for every channel, so the manifest never drifts from
+  the deployment it was built for;
+- Cache Storage is per-origin, not per service-worker-scope, so cache names
+  are explicitly namespaced per channel (`stable-*` for the stable build,
+  `branch-<channel-id>-*` for a branch build) — otherwise a stable and a
+  branch build sharing the same origin would silently share (and corrupt)
+  Cache Storage entries;
+- the stable channel's service worker scope is `/`, wide enough to
+  otherwise intercept `/branch/*` and `/pr/*` navigation and asset
+  requests, so it additionally denies those paths from its navigation
+  fallback and runtime caching. A branch channel's scope (e.g.
+  `/branch/develop/`) is narrower than every other channel's path, so the
+  browser never dispatches fetch/navigate events for foreign paths to it in
+  the first place — no equivalent denylist is needed there;
+- manifest `name`/`short_name` make branch identity visible when installed:
+  develop is `Mioframe Develop`; a manual branch uses its slug (or the
+  branch name it was derived from);
+- PR previews build with `VITE_DISABLE_PWA=1` and register no service
+  worker at all.
+
 ## Production artifact validation
 
 Owned by `scripts/release/buildArtifact.mjs`, `scripts/release/artifactServer.mjs`,
@@ -216,7 +374,8 @@ _published_ artifact, not internal build tooling:
 
 - the production build (`vite build`) completes;
 - the built `dist/` opens through a local static server the same way GitHub
-  Pages would serve it, at the configured base path (`/mioframe/`);
+  Pages would serve it, at the configured base path (`/`, the organization
+  root — see `docs/release.md#organization-pages-deployment-model`);
 - an unmatched deep route falls back to the site's `404.html` redirect and
   the app restores the original path after boot (the same mechanism
   `scripts/pages/writeSpaFallback.mjs` writes for the real deployment);
@@ -251,12 +410,15 @@ Owned by `scripts/release/validateReleaseConfig.mjs`, run as the
 `release-config` check. It validates release-mode config assumptions that
 are not covered by `release-version`:
 
-- `config/tooling.json` `release.basePath` matches `/${package.json name}/`,
-  the same base path the release artifact build and `deploy-stable` use;
+- `config/tooling.json` `release.basePath` is `/` — the organization root
+  Pages path, the same base path the release artifact build and
+  `deploy-stable` use (see
+  `docs/release.md#organization-pages-deployment-model`);
 - `VITE_DISABLE_PWA` is not `1` (that is a PR-preview-only setting; see
   `deploy-preview` in `.github/workflows/verify.yml`);
-- `BASE_URL`, if set, is not a PR-preview path and matches the release base
-  path;
+- `BASE_URL`, if set, is exactly `/` — it must not start with `/branch/` or
+  `/pr/` (those are branch and PR preview paths, not the stable release
+  path);
 - `VITE_GOOGLE_CLIENT_ID`, `VITE_SENTRY_DSN`, and `SENTRY_AUTH_TOKEN` are
   optional integrations, not required for a valid public release. Each is
   reported as set/optional-and-unset. Outside GitHub Actions, an explicitly

--- a/docs/release.md
+++ b/docs/release.md
@@ -365,6 +365,30 @@ previews for release sync-back branches remain skipped, as before (see
 `Release sync-back` above). PR preview cleanup on PR close removes only
 that PR's `pr/<number>/` slot.
 
+#### One-time bootstrap exception (`infra/org-pages-release-channels`)
+
+`deploy-preview` checks out trusted tooling from the PR's **base** ref (see
+`Trusted publishing boundary` above), never from the PR head, so that
+publish scripts never run untrusted PR-head code with the Pages write
+credential. This is the correct model for every ordinary PR, but it cannot
+bootstrap the PR that first introduces this org-Pages deployment tooling
+(release-channels PR, branch `infra/org-pages-release-channels`): that PR's
+base (`develop`) does not yet contain
+`scripts/pages/writeDeploymentMetadata.mjs`, the updated
+`scripts/pages/publishPreview.mjs`, or the slug/deployment-metadata helpers
+the trusted-tooling checkout expects.
+
+`deploy-preview`'s `if:` condition therefore excludes
+`github.event.pull_request.head.ref == 'infra/org-pages-release-channels'`
+in addition to the existing sync-back exclusion, so this one PR's preview
+publish step does not run. `verify` (format/lint/type-check/tests/e2e) still
+runs and gates the PR as normal — only preview publishing is skipped. This
+is a one-time exception for this specific branch, not a general fallback:
+once `infra/org-pages-release-channels` merges to `develop`, the tooling
+exists on `develop` for every subsequent PR, the exclusion is dead code, and
+it should be deleted rather than left in place or copied for future
+bootstrap-shaped problems.
+
 ### Branch deletion tombstone
 
 When a branch with an existing `branch/<slug>/` deployment is deleted,

--- a/docs/release.md
+++ b/docs/release.md
@@ -250,15 +250,45 @@ date, app version, base URL, and a tombstone flag when applicable.
 ### Cross-repository publishing (GitHub App)
 
 Publishing to `Mioframe/mioframe.github.io` uses a short-lived installation
-token from a GitHub App (`vars.MIOFRAME_PAGES_APP_CLIENT_ID` /
-`secrets.MIOFRAME_PAGES_APP_PRIVATE_KEY`), minted per publish job with
-`actions/create-github-app-token` scoped to `owner: Mioframe`,
-`repositories: mioframe.github.io`. The source repository's own
-`GITHUB_TOKEN` is never used for the cross-repository write — it only needs
-`contents: read` to check out the source and, for PR previews,
-`pull-requests: write` to post the preview comment on this repository. The
-GitHub App is installed only on `Mioframe/mioframe.github.io`, not on this
-repository.
+token from a GitHub App, minted per publish job with
+`actions/create-github-app-token@v3`, passing the app's **client ID** (not
+its numeric app ID) as `client-id: ${{ vars.MIOFRAME_PAGES_APP_CLIENT_ID }}`
+— the configured repository variable holds a client ID, and `v3`'s
+`client-id` input is the correct match for it — plus
+`private-key: ${{ secrets.MIOFRAME_PAGES_APP_PRIVATE_KEY }}`, scoped to
+`owner: Mioframe`, `repositories: mioframe.github.io`. The source
+repository's own `GITHUB_TOKEN` is never used for the cross-repository
+write — it only needs `contents: read` to check out the source and, for PR
+previews, `pull-requests: write` to post the preview comment on this
+repository. The GitHub App is installed only on
+`Mioframe/mioframe.github.io`, not on this repository.
+
+#### Trusted publishing boundary
+
+A job may build application source from a less-trusted ref — a PR head or a
+manually selected branch — but any step that holds the
+`Mioframe/mioframe.github.io` write token must run only trusted code, never
+scripts checked out from that less-trusted ref. `deploy-preview` (in
+`verify.yml`) and `deploy-branch` (in `deploy-branch.yml`) both check out
+two separate directories to keep this boundary explicit:
+
+- `app-source/` — the PR head or selected branch. Only ever built
+  (`pnpm install` + `pnpm run build`); never executed after the Pages deploy
+  token exists.
+- `tooling/` — this repository's own trusted base (the PR's base ref for
+  `deploy-preview`, `develop` for `deploy-branch`). Every script that
+  computes a slug, writes `deployment.json`, generates the Pages deploy
+  token, or publishes to `Mioframe/mioframe.github.io` runs from this
+  checkout, using `--dist app-source/dist` to point at the untrusted build
+  output.
+
+`deploy-develop` (push to `develop`) and `deploy-stable` (push to `main`)
+do not need this split: by the time either job runs, its source has already
+passed the `verify`/`release-gate` check on a long-lived trusted branch, so
+running publish scripts from that same checkout is acceptable.
+`deploy-branch-tombstone` and `deploy-branch-tombstone-cleanup` also do not
+need it — they check out this repository's default branch only and never
+touch PR/manual-branch source at all.
 
 Every publish script (`scripts/pages/publish*.mjs`,
 `scripts/pages/cleanup*.mjs`) commits to the target repository's `gh-pages`
@@ -288,14 +318,42 @@ with `BASE_URL=/branch/develop/`, `VITE_RELEASE_CHANNEL=branch`,
 ### Manual branch deployment
 
 `.github/workflows/deploy-branch.yml` is `workflow_dispatch`-only and never
-runs automatically — arbitrary branches are not auto-published. Given a
-branch/ref input, it derives a safe branch slug
-(`scripts/pages/lib/slug.mjs` `slugifyBranch`: lower-cased, non-`[a-z0-9]`
-runs collapsed to `-`, truncated to a DNS-label-safe length, and rejecting
-the reserved `branch`/`pr` namespace names), builds with
+runs automatically — arbitrary branches are not auto-published. It takes a
+`branch` input — a branch **name** only, not an arbitrary ref, tag, or SHA —
+and validates it against `origin`'s branch list before building anything
+(`git ls-remote --exit-code --heads origin refs/heads/<branch>`) so tags and
+commit SHAs are rejected outright. This keeps the manual deployment
+lifecycle (slug, metadata, tombstone-on-delete, branch-delete cleanup)
+branch-based end to end.
+
+The slug is derived by `scripts/pages/lib/slug.mjs` `slugifyBranch`:
+
+- the literal `develop` branch name maps to the bare slug `develop`, so a
+  manual dispatch against `develop` resolves to the same `branch/develop/`
+  slot the automatic develop-push deployment uses;
+- every other branch name is lower-cased, has non-`[a-z0-9]` runs (including
+  `/` from `feature/x` names) collapsed to a single `-`, is truncated to
+  leave room for an appended 8-character hex hash, then gets that hash
+  suffix appended — the hash is derived from the raw (pre-normalization)
+  branch name, not the normalized prefix.
+
+This makes the slug collision-safe: branch names that normalize to the same
+prefix (`feature/a`, `feature-a`, `feature_a` all normalize to `feature-a`)
+still produce different slugs, since each has a different raw name and
+therefore a different hash suffix — so one branch's manual deployment can
+never silently overwrite another's, or share its PWA scope/cache/manifest
+identity. The resulting slug still rejects the reserved `branch`/`pr`
+namespace names and stays within a DNS-label-safe length. Deleting a branch
+computes the identical slug from the same branch name (see `Branch deletion
+tombstone` below), so tombstoning always targets the correct slot.
+
+Given the validated branch name, the workflow builds with
 `BASE_URL=/branch/<slug>/`, `VITE_RELEASE_CHANNEL=branch`,
 `VITE_RELEASE_CHANNEL_ID=<slug>`, PWA enabled, and publishes to
-`branch/<slug>/`.
+`branch/<slug>/`. Deployment metadata records the actual checked-out commit
+(`git -C app-source rev-parse HEAD`), not `github.sha` — for a
+`workflow_dispatch` run, `github.sha` is the workflow's own trigger commit,
+not necessarily the selected branch's tip.
 
 ### PR preview deployment
 

--- a/docs/user/data-storage-and-recovery.md
+++ b/docs/user/data-storage-and-recovery.md
@@ -10,8 +10,8 @@ Use these focused guides instead:
 
 If you have a question about storage or recovery, use GitHub Discussions:
 
-[https://github.com/Vyachean/mioframe/discussions](https://github.com/Vyachean/mioframe/discussions)
+[https://github.com/Mioframe/mioframe/discussions](https://github.com/Mioframe/mioframe/discussions)
 
 If you found a bug or need to report a storage or data recovery problem, use GitHub Issues:
 
-[https://github.com/Vyachean/mioframe/issues](https://github.com/Vyachean/mioframe/issues)
+[https://github.com/Mioframe/mioframe/issues](https://github.com/Mioframe/mioframe/issues)

--- a/docs/user/data/03-data-troubleshooting.md
+++ b/docs/user/data/03-data-troubleshooting.md
@@ -95,4 +95,4 @@ If there is no remaining copy and the data was lost from Browser Storage or dele
 
 ## Where to get more help
 
-If these steps do not resolve the problem, ask in [GitHub Discussions](https://github.com/Vyachean/mioframe/discussions) or report it in [GitHub Issues](https://github.com/Vyachean/mioframe/issues).
+If these steps do not resolve the problem, ask in [GitHub Discussions](https://github.com/Mioframe/mioframe/discussions) or report it in [GitHub Issues](https://github.com/Mioframe/mioframe/issues).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mioframe",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/scripts/pages/cleanupExpiredTombstones.mjs
+++ b/scripts/pages/cleanupExpiredTombstones.mjs
@@ -1,0 +1,81 @@
+/**
+ * Remove branch/<slug>/ tombstones whose retention period has elapsed.
+ *
+ * Only tombstones (deployment.json with `tombstone: true`) older than the
+ * retention period are removed; live branch deployments and fresh
+ * tombstones are left untouched. Stable files and pr/* directories are
+ * never touched by this script.
+ *
+ * Usage:
+ *   node scripts/pages/cleanupExpiredTombstones.mjs [--retention-days 14] [--output-dir ./pages-staging]
+ *
+ * Required env:
+ *   GITHUB_TOKEN      - token with contents:write on the target Pages repository
+ *   GITHUB_REPOSITORY - OWNER/REPO of the target Pages repository
+ */
+
+import { appendFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+import toolingConfig from '../../config/tooling.json' with { type: 'json' };
+import { withGhPagesBranch } from './lib/ghPagesBranch.mjs';
+import { applyBranchRemoval } from './lib/pagesFs.mjs';
+import { findExpiredTombstoneSlugs } from './lib/tombstoneRetention.mjs';
+
+/**
+ * @param argv Process arguments (process.argv.slice(2)).
+ * @param env Process environment.
+ * @returns Branch slugs whose expired tombstone was removed.
+ */
+export async function cleanupExpiredTombstones(argv = process.argv.slice(2), env = process.env) {
+  const retentionIndex = argv.indexOf('--retention-days');
+  const retentionDays =
+    retentionIndex !== -1 && argv[retentionIndex + 1]
+      ? Number(argv[retentionIndex + 1])
+      : toolingConfig.pages.tombstoneRetentionDays;
+
+  const outputIndex = argv.indexOf('--output-dir');
+  const outputDir = outputIndex !== -1 ? argv[outputIndex + 1] : undefined;
+
+  const { GITHUB_TOKEN, GITHUB_REPOSITORY, GITHUB_OUTPUT } = env;
+  if (!GITHUB_TOKEN) throw new Error('GITHUB_TOKEN is required');
+  if (!GITHUB_REPOSITORY) throw new Error('GITHUB_REPOSITORY is required');
+
+  const removedSlugs = [];
+
+  await withGhPagesBranch({
+    token: GITHUB_TOKEN,
+    repository: GITHUB_REPOSITORY,
+    commitMessage: 'chore(pages): remove expired branch tombstones',
+    outputDir,
+    fn(workDir) {
+      const expiredSlugs = findExpiredTombstoneSlugs({ workDir, retentionDays });
+      for (const slug of expiredSlugs) {
+        if (applyBranchRemoval(workDir, slug)) {
+          removedSlugs.push(slug);
+        }
+      }
+    },
+  });
+
+  if (GITHUB_OUTPUT) {
+    appendFileSync(GITHUB_OUTPUT, `removed-count=${removedSlugs.length}\n`);
+  }
+
+  console.log(
+    removedSlugs.length > 0
+      ? `Removed ${removedSlugs.length} expired branch tombstone(s): ${removedSlugs.join(', ')}.`
+      : 'No expired branch tombstones found.',
+  );
+
+  return removedSlugs;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    await cleanupExpiredTombstones();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/pages/cleanupExpiredTombstones.mjs
+++ b/scripts/pages/cleanupExpiredTombstones.mjs
@@ -20,7 +20,7 @@ import { pathToFileURL } from 'node:url';
 import toolingConfig from '../../config/tooling.json' with { type: 'json' };
 import { withGhPagesBranch } from './lib/ghPagesBranch.mjs';
 import { applyBranchRemoval } from './lib/pagesFs.mjs';
-import { findExpiredTombstoneSlugs } from './lib/tombstoneRetention.mjs';
+import { findExpiredTombstoneSlugs, validateRetentionDays } from './lib/tombstoneRetention.mjs';
 
 /**
  * @param argv Process arguments (process.argv.slice(2)).
@@ -31,8 +31,11 @@ export async function cleanupExpiredTombstones(argv = process.argv.slice(2), env
   const retentionIndex = argv.indexOf('--retention-days');
   const retentionDays =
     retentionIndex !== -1 && argv[retentionIndex + 1]
-      ? Number(argv[retentionIndex + 1])
-      : toolingConfig.pages.tombstoneRetentionDays;
+      ? validateRetentionDays(argv[retentionIndex + 1], '--retention-days')
+      : validateRetentionDays(
+          toolingConfig.pages.tombstoneRetentionDays,
+          'config/tooling.json pages.tombstoneRetentionDays',
+        );
 
   const outputIndex = argv.indexOf('--output-dir');
   const outputDir = outputIndex !== -1 ? argv[outputIndex + 1] : undefined;

--- a/scripts/pages/cleanupExpiredTombstones.test.mjs
+++ b/scripts/pages/cleanupExpiredTombstones.test.mjs
@@ -1,0 +1,120 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./lib/ghPagesBranch.mjs', () => ({
+  withGhPagesBranch: vi.fn(async ({ fn }) => {
+    await fn(workDir);
+  }),
+}));
+
+const { cleanupExpiredTombstones } = await import('./cleanupExpiredTombstones.mjs');
+
+let workDir = '';
+let outputFile = '';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function writeDeploymentJson(slug, metadata) {
+  mkdirSync(join(workDir, 'branch', slug), { recursive: true });
+  writeFileSync(join(workDir, 'branch', slug, 'deployment.json'), JSON.stringify(metadata));
+  writeFileSync(join(workDir, 'branch', slug, 'index.html'), '<content/>');
+}
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'pages-work-'));
+  outputFile = join(mkdtempSync(join(tmpdir(), 'pages-output-')), 'github-output.txt');
+});
+
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true });
+  rmSync(outputFile, { force: true });
+});
+
+describe('cleanupExpiredTombstones argument validation', () => {
+  it('throws when GITHUB_TOKEN is missing', async () => {
+    await expect(cleanupExpiredTombstones([], { GITHUB_REPOSITORY: 'owner/repo' })).rejects.toThrow(
+      'GITHUB_TOKEN is required',
+    );
+  });
+
+  it('throws when GITHUB_REPOSITORY is missing', async () => {
+    await expect(cleanupExpiredTombstones([], { GITHUB_TOKEN: 'token' })).rejects.toThrow(
+      'GITHUB_REPOSITORY is required',
+    );
+  });
+});
+
+describe('cleanupExpiredTombstones behavior', () => {
+  it('removes only expired tombstones, keeping live branches and fresh tombstones', async () => {
+    writeDeploymentJson('expired-feature', {
+      tombstone: true,
+      buildDate: new Date(Date.now() - 20 * DAY_MS).toISOString(),
+    });
+    writeDeploymentJson('fresh-tombstone', {
+      tombstone: true,
+      buildDate: new Date(Date.now() - 1 * DAY_MS).toISOString(),
+    });
+    writeDeploymentJson('develop', {
+      channel: 'branch',
+      channelId: 'develop',
+      buildDate: new Date(Date.now() - 100 * DAY_MS).toISOString(),
+    });
+
+    const removed = await cleanupExpiredTombstones(['--retention-days', '14'], {
+      GITHUB_TOKEN: 'token',
+      GITHUB_REPOSITORY: 'owner/repo',
+      GITHUB_OUTPUT: outputFile,
+    });
+
+    expect(removed).toEqual(['expired-feature']);
+    expect(readFileSync(outputFile, 'utf8')).toBe('removed-count=1\n');
+
+    let expiredExists = true;
+    try {
+      readFileSync(join(workDir, 'branch', 'expired-feature', 'deployment.json'));
+    } catch {
+      expiredExists = false;
+    }
+    expect(expiredExists).toBe(false);
+
+    expect(readFileSync(join(workDir, 'branch', 'fresh-tombstone', 'index.html'), 'utf8')).toBe(
+      '<content/>',
+    );
+    expect(readFileSync(join(workDir, 'branch', 'develop', 'index.html'), 'utf8')).toBe(
+      '<content/>',
+    );
+  });
+
+  it('is a no-op and reports removed-count=0 when there is nothing expired', async () => {
+    writeDeploymentJson('develop', {
+      channel: 'branch',
+      channelId: 'develop',
+      buildDate: new Date().toISOString(),
+    });
+
+    const removed = await cleanupExpiredTombstones(['--retention-days', '14'], {
+      GITHUB_TOKEN: 'token',
+      GITHUB_REPOSITORY: 'owner/repo',
+      GITHUB_OUTPUT: outputFile,
+    });
+
+    expect(removed).toEqual([]);
+    expect(readFileSync(outputFile, 'utf8')).toBe('removed-count=0\n');
+  });
+
+  it('falls back to config/tooling.json retention days when --retention-days is not passed', async () => {
+    writeDeploymentJson('just-under-default', {
+      tombstone: true,
+      buildDate: new Date(Date.now() - 13 * DAY_MS).toISOString(),
+    });
+
+    const removed = await cleanupExpiredTombstones([], {
+      GITHUB_TOKEN: 'token',
+      GITHUB_REPOSITORY: 'owner/repo',
+    });
+
+    expect(removed).toEqual([]);
+  });
+});

--- a/scripts/pages/cleanupExpiredTombstones.test.mjs
+++ b/scripts/pages/cleanupExpiredTombstones.test.mjs
@@ -44,6 +44,18 @@ describe('cleanupExpiredTombstones argument validation', () => {
       'GITHUB_REPOSITORY is required',
     );
   });
+
+  it.each([['abc'], ['0'], ['-3'], ['1.5']])(
+    'rejects an invalid --retention-days value %s before touching Pages',
+    async (value) => {
+      await expect(
+        cleanupExpiredTombstones(['--retention-days', value], {
+          GITHUB_TOKEN: 'token',
+          GITHUB_REPOSITORY: 'owner/repo',
+        }),
+      ).rejects.toThrow('Invalid retention days from --retention-days');
+    },
+  );
 });
 
 describe('cleanupExpiredTombstones behavior', () => {

--- a/scripts/pages/cleanupPreview.mjs
+++ b/scripts/pages/cleanupPreview.mjs
@@ -1,7 +1,7 @@
 /**
- * Remove the pr-<PR_NUMBER>/ slot from the gh-pages staging branch after a PR is closed.
+ * Remove the pr/<PR_NUMBER>/ slot from the gh-pages staging branch after a PR is closed.
  *
- * Stable files and other pr-* directories are not touched.
+ * Stable files, branch/* deployments, and other pr/* directories are not touched.
  * If the slot does not exist, the script exits cleanly without committing.
  *
  * When --output-dir is provided, the final staging content is also copied
@@ -14,15 +14,16 @@
  *   node scripts/pages/cleanupPreview.mjs --pr 42 [--output-dir ./pages-staging]
  *
  * Required env:
- *   GITHUB_TOKEN      - token with contents:write
- *   GITHUB_REPOSITORY - OWNER/REPO
+ *   GITHUB_TOKEN      - token with contents:write on the target Pages repository
+ *   GITHUB_REPOSITORY - OWNER/REPO of the target Pages repository
  */
 
 import { appendFileSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
 
 import { withGhPagesBranch } from './lib/ghPagesBranch.mjs';
-import { applyPreviewCleanup, validatePrNumber } from './lib/pagesFs.mjs';
+import { applyPrCleanup } from './lib/pagesFs.mjs';
+import { validatePrNumber } from './lib/slug.mjs';
 
 /**
  * @param argv Process arguments (process.argv.slice(2)).
@@ -52,9 +53,9 @@ export async function cleanupPreview(argv = process.argv.slice(2), env = process
     commitMessage: `chore(pages): remove preview for PR #${prNumber}`,
     outputDir,
     fn(workDir) {
-      removed = applyPreviewCleanup(workDir, prNumber);
+      removed = applyPrCleanup(workDir, prNumber);
       if (!removed) {
-        console.log(`Preview slot pr-${prNumber}/ not found, nothing to remove.`);
+        console.log(`Preview slot pr/${prNumber}/ not found, nothing to remove.`);
       }
     },
   });

--- a/scripts/pages/cleanupPreview.test.mjs
+++ b/scripts/pages/cleanupPreview.test.mjs
@@ -53,8 +53,8 @@ describe('cleanupPreview argument validation', () => {
 
 describe('cleanupPreview changed output', () => {
   it('resolves true and writes changed=true when the preview slot existed', async () => {
-    mkdirSync(join(workDir, 'pr-42'), { recursive: true });
-    writeFileSync(join(workDir, 'pr-42', 'index.html'), '<preview/>');
+    mkdirSync(join(workDir, 'pr', '42'), { recursive: true });
+    writeFileSync(join(workDir, 'pr', '42', 'index.html'), '<preview/>');
 
     const removed = await cleanupPreview(['--pr', '42'], {
       GITHUB_TOKEN: 'token',

--- a/scripts/pages/computeBranchSlug.mjs
+++ b/scripts/pages/computeBranchSlug.mjs
@@ -1,0 +1,33 @@
+/**
+ * Print the branch slug for a given branch name to stdout, for capturing
+ * into a GitHub Actions step output.
+ *
+ * Usage:
+ *   node scripts/pages/computeBranchSlug.mjs --branch feature/My-Thing
+ */
+
+import { pathToFileURL } from 'node:url';
+
+import { slugifyBranch } from './lib/slug.mjs';
+
+/**
+ * @param argv Process arguments (process.argv.slice(2)).
+ * @returns The computed branch slug.
+ */
+export function computeBranchSlug(argv = process.argv.slice(2)) {
+  const branchIndex = argv.indexOf('--branch');
+  if (branchIndex === -1 || !argv[branchIndex + 1]) {
+    throw new Error('Usage: computeBranchSlug.mjs --branch <branch-name>');
+  }
+
+  return slugifyBranch(argv[branchIndex + 1]);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    console.log(computeBranchSlug());
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/pages/computeBranchSlug.test.mjs
+++ b/scripts/pages/computeBranchSlug.test.mjs
@@ -3,19 +3,29 @@ import { describe, expect, it } from 'vitest';
 import { computeBranchSlug } from './computeBranchSlug.mjs';
 
 describe('computeBranchSlug', () => {
-  it('prints the slug for a simple branch name', () => {
+  it('prints the bare slug for the literal develop branch', () => {
     expect(computeBranchSlug(['--branch', 'develop'])).toBe('develop');
   });
 
-  it('slugifies a branch name with slashes', () => {
-    expect(computeBranchSlug(['--branch', 'feature/My-Thing'])).toBe('feature-my-thing');
+  it('slugifies a branch name with slashes and appends a hash suffix', () => {
+    expect(computeBranchSlug(['--branch', 'feature/My-Thing'])).toMatch(
+      /^feature-my-thing-[0-9a-f]{8}$/,
+    );
   });
 
   it('throws when --branch is missing', () => {
     expect(() => computeBranchSlug([])).toThrow('Usage:');
   });
 
-  it('throws when the branch name produces a reserved slug', () => {
-    expect(() => computeBranchSlug(['--branch', 'pr'])).toThrow('is reserved');
+  it('produces distinct slugs for branch names that collide after normalization', () => {
+    const slugSlash = computeBranchSlug(['--branch', 'feature/a']);
+    const slugDash = computeBranchSlug(['--branch', 'feature-a']);
+    const slugUnderscore = computeBranchSlug(['--branch', 'feature_a']);
+
+    expect(new Set([slugSlash, slugDash, slugUnderscore]).size).toBe(3);
+  });
+
+  it('throws for a branch name that produces an empty normalized prefix', () => {
+    expect(() => computeBranchSlug(['--branch', '///'])).toThrow('produces an empty slug');
   });
 });

--- a/scripts/pages/computeBranchSlug.test.mjs
+++ b/scripts/pages/computeBranchSlug.test.mjs
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeBranchSlug } from './computeBranchSlug.mjs';
+
+describe('computeBranchSlug', () => {
+  it('prints the slug for a simple branch name', () => {
+    expect(computeBranchSlug(['--branch', 'develop'])).toBe('develop');
+  });
+
+  it('slugifies a branch name with slashes', () => {
+    expect(computeBranchSlug(['--branch', 'feature/My-Thing'])).toBe('feature-my-thing');
+  });
+
+  it('throws when --branch is missing', () => {
+    expect(() => computeBranchSlug([])).toThrow('Usage:');
+  });
+
+  it('throws when the branch name produces a reserved slug', () => {
+    expect(() => computeBranchSlug(['--branch', 'pr'])).toThrow('is reserved');
+  });
+});

--- a/scripts/pages/lib/deploymentMetadata.mjs
+++ b/scripts/pages/lib/deploymentMetadata.mjs
@@ -1,0 +1,67 @@
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Build the `deployment.json` metadata record written alongside every
+ * published channel (stable, develop, manual branch, PR preview, and branch
+ * tombstones). See `docs/release.md#organization-pages-deployment-model`.
+ * @param options Deployment facts.
+ * @param options.channel Release channel, e.g. `stable` or `branch`.
+ * @param options.channelId Channel identifier, e.g. `main`, `develop`, a branch slug, or a PR number.
+ * @param options.baseUrl Vite `BASE_URL` this deployment was built with.
+ * @param [options.ref] Source ref the build was triggered from.
+ * @param [options.branch] Source branch name, when available.
+ * @param [options.slug] Branch slug, for branch channel deployments.
+ * @param [options.sha] Commit SHA the build was produced from.
+ * @param [options.buildDate] ISO build date; defaults to now.
+ * @param [options.appVersion] `package.json` version.
+ * @param [options.tombstone] `true` when this is a tombstone record for a deleted branch.
+ * @returns The deployment metadata record.
+ */
+export function buildDeploymentMetadata({
+  channel,
+  channelId,
+  baseUrl,
+  ref,
+  branch,
+  slug,
+  sha,
+  buildDate,
+  appVersion,
+  tombstone,
+} = {}) {
+  if (typeof channel !== 'string' || channel.trim() === '') {
+    throw new Error('channel is required');
+  }
+  if (typeof channelId !== 'string' || channelId.trim() === '') {
+    throw new Error('channelId is required');
+  }
+  if (typeof baseUrl !== 'string' || baseUrl.trim() === '') {
+    throw new Error('baseUrl is required');
+  }
+
+  const metadata = {
+    channel,
+    channelId,
+    baseUrl,
+    buildDate: buildDate ?? new Date().toISOString(),
+  };
+
+  if (ref) metadata.ref = ref;
+  if (branch) metadata.branch = branch;
+  if (slug) metadata.slug = slug;
+  if (sha) metadata.sha = sha;
+  if (appVersion) metadata.appVersion = appVersion;
+  if (tombstone) metadata.tombstone = true;
+
+  return metadata;
+}
+
+/**
+ * Write a `deployment.json` file into a build output directory.
+ * @param distDir Directory to write into, e.g. `dist`.
+ * @param metadata Deployment metadata record from {@link buildDeploymentMetadata}.
+ */
+export function writeDeploymentMetadataFile(distDir, metadata) {
+  writeFileSync(join(distDir, 'deployment.json'), JSON.stringify(metadata, null, 2) + '\n', 'utf8');
+}

--- a/scripts/pages/lib/deploymentMetadata.test.mjs
+++ b/scripts/pages/lib/deploymentMetadata.test.mjs
@@ -1,0 +1,132 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { buildDeploymentMetadata, writeDeploymentMetadataFile } from './deploymentMetadata.mjs';
+
+describe('buildDeploymentMetadata', () => {
+  it('builds a minimal stable record', () => {
+    const metadata = buildDeploymentMetadata({
+      channel: 'stable',
+      channelId: 'main',
+      baseUrl: '/',
+      buildDate: '2026-07-03T00:00:00.000Z',
+    });
+
+    expect(metadata).toEqual({
+      channel: 'stable',
+      channelId: 'main',
+      baseUrl: '/',
+      buildDate: '2026-07-03T00:00:00.000Z',
+    });
+  });
+
+  it('includes optional fields only when provided', () => {
+    const metadata = buildDeploymentMetadata({
+      channel: 'branch',
+      channelId: 'develop',
+      baseUrl: '/branch/develop/',
+      ref: 'refs/heads/develop',
+      branch: 'develop',
+      slug: 'develop',
+      sha: 'abc123',
+      buildDate: '2026-07-03T00:00:00.000Z',
+      appVersion: '0.1.0',
+    });
+
+    expect(metadata).toEqual({
+      channel: 'branch',
+      channelId: 'develop',
+      baseUrl: '/branch/develop/',
+      ref: 'refs/heads/develop',
+      branch: 'develop',
+      slug: 'develop',
+      sha: 'abc123',
+      buildDate: '2026-07-03T00:00:00.000Z',
+      appVersion: '0.1.0',
+    });
+  });
+
+  it('sets tombstone: true only when tombstone is truthy', () => {
+    const metadata = buildDeploymentMetadata({
+      channel: 'branch',
+      channelId: 'feature-x',
+      baseUrl: '/branch/feature-x/',
+      buildDate: '2026-07-03T00:00:00.000Z',
+      tombstone: true,
+    });
+
+    expect(metadata.tombstone).toBe(true);
+  });
+
+  it('omits tombstone when falsy', () => {
+    const metadata = buildDeploymentMetadata({
+      channel: 'stable',
+      channelId: 'main',
+      baseUrl: '/',
+      buildDate: '2026-07-03T00:00:00.000Z',
+      tombstone: false,
+    });
+
+    expect(metadata.tombstone).toBeUndefined();
+  });
+
+  it('defaults buildDate to now when not provided', () => {
+    const before = Date.now();
+    const metadata = buildDeploymentMetadata({
+      channel: 'stable',
+      channelId: 'main',
+      baseUrl: '/',
+    });
+    const after = Date.now();
+
+    const parsed = Date.parse(metadata.buildDate);
+    expect(parsed).toBeGreaterThanOrEqual(before);
+    expect(parsed).toBeLessThanOrEqual(after);
+  });
+
+  it('throws when channel is missing', () => {
+    expect(() => buildDeploymentMetadata({ channelId: 'main', baseUrl: '/' })).toThrow(
+      'channel is required',
+    );
+  });
+
+  it('throws when channelId is missing', () => {
+    expect(() => buildDeploymentMetadata({ channel: 'stable', baseUrl: '/' })).toThrow(
+      'channelId is required',
+    );
+  });
+
+  it('throws when baseUrl is missing', () => {
+    expect(() => buildDeploymentMetadata({ channel: 'stable', channelId: 'main' })).toThrow(
+      'baseUrl is required',
+    );
+  });
+});
+
+describe('writeDeploymentMetadataFile', () => {
+  let distDir = '';
+
+  beforeEach(() => {
+    distDir = mkdtempSync(join(tmpdir(), 'deployment-metadata-'));
+  });
+
+  afterEach(() => {
+    rmSync(distDir, { recursive: true, force: true });
+  });
+
+  it('writes deployment.json with the given metadata', () => {
+    const metadata = buildDeploymentMetadata({
+      channel: 'stable',
+      channelId: 'main',
+      baseUrl: '/',
+      buildDate: '2026-07-03T00:00:00.000Z',
+    });
+
+    writeDeploymentMetadataFile(distDir, metadata);
+
+    const written = JSON.parse(readFileSync(join(distDir, 'deployment.json'), 'utf8'));
+    expect(written).toEqual(metadata);
+  });
+});

--- a/scripts/pages/lib/pagesFs.mjs
+++ b/scripts/pages/lib/pagesFs.mjs
@@ -1,61 +1,89 @@
-import { cpSync, existsSync, readdirSync, rmSync } from 'node:fs';
+import { cpSync, existsSync, mkdirSync, readdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 
-/**
- * Validate a PR number string and return it.
- * @param prNumber PR number as a string from CLI or event context.
- * @returns The validated PR number string.
- */
-export function validatePrNumber(prNumber) {
-  if (!/^\d+$/.test(prNumber) || prNumber === '0') {
-    throw new Error(`Invalid PR number: ${prNumber}`);
-  }
-  return prNumber;
-}
+import { validateBranchSlug, validatePrNumber } from './slug.mjs';
+
+const PRESERVED_STABLE_ROOT_DIRS = new Set(['branch', 'pr']);
 
 /**
- * Apply a stable build to a Pages work directory.
+ * Apply a stable build to the root of a Pages work directory.
  *
- * Removes all root entries except `.git` and `pr-*` directories, then copies
- * dist. Existing PR preview directories are preserved so stable publishes
- * never evict active previews.
+ * Removes all root entries except `.git`, `branch/`, and `pr/`, then copies
+ * dist into the root. The `branch/` and `pr/` namespaces are preserved so a
+ * stable publish never evicts develop, manual branch, or PR preview
+ * deployments.
  * @param workDir Path to the Pages staging working directory.
  * @param distDir Path to the built dist directory to publish.
  */
 export function applyStablePublish(workDir, distDir) {
   for (const entry of readdirSync(workDir, { withFileTypes: true })) {
     if (entry.name === '.git') continue;
-    if (entry.isDirectory() && /^pr-\d+$/.test(entry.name)) continue;
+    if (entry.isDirectory() && PRESERVED_STABLE_ROOT_DIRS.has(entry.name)) continue;
     rmSync(join(workDir, entry.name), { recursive: true, force: true });
   }
   cpSync(distDir, workDir, { recursive: true });
 }
 
 /**
- * Apply a PR preview build to a Pages work directory.
- *
- * Only the `pr-<prNumber>/` slot is replaced; stable files and other PR
- * preview directories are not touched.
+ * Apply a branch build to its `branch/<slug>/` slot in a Pages work
+ * directory. Only that slot is replaced; stable files, other branch slots,
+ * and PR preview slots are not touched.
  * @param workDir Path to the Pages staging working directory.
  * @param distDir Path to the built dist directory to publish.
- * @param prNumber PR number string.
+ * @param slug Branch slug (see `slugifyBranch`/`validateBranchSlug`).
  */
-export function applyPreviewPublish(workDir, distDir, prNumber) {
-  validatePrNumber(prNumber);
-  const slotDir = join(workDir, `pr-${prNumber}`);
+export function applyBranchPublish(workDir, distDir, slug) {
+  validateBranchSlug(slug);
+  const slotDir = join(workDir, 'branch', slug);
   rmSync(slotDir, { recursive: true, force: true });
+  mkdirSync(slotDir, { recursive: true });
   cpSync(distDir, slotDir, { recursive: true });
 }
 
 /**
- * Remove a PR preview slot from a Pages work directory.
+ * Remove a branch's `branch/<slug>/` slot entirely from a Pages work
+ * directory. Used by the tombstone retention cleanup once a tombstone has
+ * expired; not used for the tombstone publish itself (which replaces the
+ * slot's content in place instead of removing it).
+ * @param workDir Path to the Pages staging working directory.
+ * @param slug Branch slug.
+ * @returns `true` if the slot existed and was removed; `false` if already absent.
+ */
+export function applyBranchRemoval(workDir, slug) {
+  validateBranchSlug(slug);
+  const slotDir = join(workDir, 'branch', slug);
+  if (!existsSync(slotDir)) {
+    return false;
+  }
+  rmSync(slotDir, { recursive: true, force: true });
+  return true;
+}
+
+/**
+ * Apply a PR preview build to its `pr/<number>/` slot in a Pages work
+ * directory. Only that slot is replaced; stable files, branch slots, and
+ * other PR preview slots are not touched.
+ * @param workDir Path to the Pages staging working directory.
+ * @param distDir Path to the built dist directory to publish.
+ * @param prNumber PR number string.
+ */
+export function applyPrPublish(workDir, distDir, prNumber) {
+  validatePrNumber(prNumber);
+  const slotDir = join(workDir, 'pr', prNumber);
+  rmSync(slotDir, { recursive: true, force: true });
+  mkdirSync(slotDir, { recursive: true });
+  cpSync(distDir, slotDir, { recursive: true });
+}
+
+/**
+ * Remove a PR preview's `pr/<number>/` slot from a Pages work directory.
  * @param workDir Path to the Pages staging working directory.
  * @param prNumber PR number string.
  * @returns `true` if the slot existed and was removed; `false` if already absent.
  */
-export function applyPreviewCleanup(workDir, prNumber) {
+export function applyPrCleanup(workDir, prNumber) {
   validatePrNumber(prNumber);
-  const slotDir = join(workDir, `pr-${prNumber}`);
+  const slotDir = join(workDir, 'pr', prNumber);
   if (!existsSync(slotDir)) {
     return false;
   }

--- a/scripts/pages/lib/pagesFs.test.mjs
+++ b/scripts/pages/lib/pagesFs.test.mjs
@@ -4,10 +4,11 @@ import { tmpdir } from 'node:os';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
-  applyPreviewCleanup,
-  applyPreviewPublish,
+  applyBranchPublish,
+  applyBranchRemoval,
+  applyPrCleanup,
+  applyPrPublish,
   applyStablePublish,
-  validatePrNumber,
 } from './pagesFs.mjs';
 
 let workDir = '';
@@ -38,34 +39,8 @@ function fileExists(base, relPath) {
   }
 }
 
-describe('validatePrNumber', () => {
-  it('accepts valid PR numbers', () => {
-    expect(validatePrNumber('1')).toBe('1');
-    expect(validatePrNumber('42')).toBe('42');
-    expect(validatePrNumber('9999')).toBe('9999');
-  });
-
-  it('rejects zero', () => {
-    expect(() => validatePrNumber('0')).toThrow('Invalid PR number: 0');
-  });
-
-  it('rejects non-numeric strings', () => {
-    expect(() => validatePrNumber('abc')).toThrow('Invalid PR number: abc');
-    expect(() => validatePrNumber('1a')).toThrow('Invalid PR number: 1a');
-  });
-
-  it('rejects strings with path separators', () => {
-    expect(() => validatePrNumber('../42')).toThrow();
-    expect(() => validatePrNumber('1/2')).toThrow();
-  });
-
-  it('rejects empty string', () => {
-    expect(() => validatePrNumber('')).toThrow();
-  });
-});
-
 describe('applyStablePublish', () => {
-  it('copies dist files to the work directory', () => {
+  it('copies dist files to the work directory root', () => {
     write(distDir, 'index.html', '<html/>');
     write(distDir, 'assets/main.js', '// js');
 
@@ -75,7 +50,7 @@ describe('applyStablePublish', () => {
     expect(fileExists(workDir, 'assets/main.js')).toBe(true);
   });
 
-  it('removes stale root files that are not preview directories', () => {
+  it('removes stale root files that are not branch/pr directories', () => {
     write(workDir, 'old-file.txt', 'stale');
     write(workDir, 'old-dir/stuff.txt', 'stale');
     write(distDir, 'index.html', '<html/>');
@@ -86,15 +61,26 @@ describe('applyStablePublish', () => {
     expect(fileExists(workDir, 'old-dir/stuff.txt')).toBe(false);
   });
 
-  it('preserves existing pr-* directories', () => {
-    write(workDir, 'pr-5/index.html', '<pr5/>');
-    write(workDir, 'pr-10/index.html', '<pr10/>');
+  it('preserves the entire branch/ namespace', () => {
+    write(workDir, 'branch/develop/index.html', '<develop/>');
+    write(workDir, 'branch/feature-x/index.html', '<feature-x/>');
     write(distDir, 'index.html', '<html/>');
 
     applyStablePublish(workDir, distDir);
 
-    expect(fileExists(workDir, 'pr-5/index.html')).toBe(true);
-    expect(fileExists(workDir, 'pr-10/index.html')).toBe(true);
+    expect(fileExists(workDir, 'branch/develop/index.html')).toBe(true);
+    expect(fileExists(workDir, 'branch/feature-x/index.html')).toBe(true);
+  });
+
+  it('preserves the entire pr/ namespace', () => {
+    write(workDir, 'pr/5/index.html', '<pr5/>');
+    write(workDir, 'pr/10/index.html', '<pr10/>');
+    write(distDir, 'index.html', '<html/>');
+
+    applyStablePublish(workDir, distDir);
+
+    expect(fileExists(workDir, 'pr/5/index.html')).toBe(true);
+    expect(fileExists(workDir, 'pr/10/index.html')).toBe(true);
   });
 
   it('does not remove the .git directory', () => {
@@ -107,7 +93,7 @@ describe('applyStablePublish', () => {
     expect(fileExists(workDir, '.git/HEAD')).toBe(true);
   });
 
-  it('replaces existing non-pr root files with the dist content', () => {
+  it('replaces existing root files with the dist content', () => {
     write(workDir, 'index.html', '<old/>');
     write(distDir, 'index.html', '<new/>');
 
@@ -117,77 +103,165 @@ describe('applyStablePublish', () => {
   });
 });
 
-describe('applyPreviewPublish', () => {
+describe('applyBranchPublish', () => {
+  it('creates the branch slot from dist', () => {
+    write(distDir, 'index.html', '<develop/>');
+
+    applyBranchPublish(workDir, distDir, 'develop');
+
+    expect(fileExists(workDir, 'branch/develop/index.html')).toBe(true);
+    expect(readFileSync(join(workDir, 'branch/develop/index.html'), 'utf8')).toBe('<develop/>');
+  });
+
+  it('replaces an existing branch slot', () => {
+    write(workDir, 'branch/develop/index.html', '<old/>');
+    write(distDir, 'index.html', '<new/>');
+
+    applyBranchPublish(workDir, distDir, 'develop');
+
+    expect(readFileSync(join(workDir, 'branch/develop/index.html'), 'utf8')).toBe('<new/>');
+  });
+
+  it('does not modify stable root files', () => {
+    write(workDir, 'index.html', '<stable/>');
+    write(distDir, 'index.html', '<branch/>');
+
+    applyBranchPublish(workDir, distDir, 'develop');
+
+    expect(readFileSync(join(workDir, 'index.html'), 'utf8')).toBe('<stable/>');
+  });
+
+  it('does not modify other branch slots', () => {
+    write(workDir, 'branch/other/index.html', '<other/>');
+    write(distDir, 'index.html', '<develop/>');
+
+    applyBranchPublish(workDir, distDir, 'develop');
+
+    expect(fileExists(workDir, 'branch/other/index.html')).toBe(true);
+    expect(readFileSync(join(workDir, 'branch/other/index.html'), 'utf8')).toBe('<other/>');
+  });
+
+  it('does not modify pr preview slots', () => {
+    write(workDir, 'pr/5/index.html', '<pr5/>');
+    write(distDir, 'index.html', '<develop/>');
+
+    applyBranchPublish(workDir, distDir, 'develop');
+
+    expect(fileExists(workDir, 'pr/5/index.html')).toBe(true);
+  });
+
+  it('rejects an invalid branch slug', () => {
+    expect(() => applyBranchPublish(workDir, distDir, '../etc')).toThrow('Invalid branch slug');
+  });
+
+  it('rejects the reserved "pr" slug', () => {
+    expect(() => applyBranchPublish(workDir, distDir, 'pr')).toThrow('is reserved');
+  });
+});
+
+describe('applyBranchRemoval', () => {
+  it('removes only the target branch slot', () => {
+    write(workDir, 'branch/develop/index.html', '<develop/>');
+    write(workDir, 'branch/other/index.html', '<other/>');
+    write(workDir, 'index.html', '<stable/>');
+
+    const removed = applyBranchRemoval(workDir, 'develop');
+
+    expect(removed).toBe(true);
+    expect(fileExists(workDir, 'branch/develop/index.html')).toBe(false);
+    expect(fileExists(workDir, 'branch/other/index.html')).toBe(true);
+    expect(fileExists(workDir, 'index.html')).toBe(true);
+  });
+
+  it('is a no-op and returns false when the branch slot does not exist', () => {
+    write(workDir, 'index.html', '<stable/>');
+
+    const removed = applyBranchRemoval(workDir, 'missing');
+
+    expect(removed).toBe(false);
+  });
+});
+
+describe('applyPrPublish', () => {
   it('creates the pr slot from dist', () => {
     write(distDir, 'index.html', '<preview/>');
 
-    applyPreviewPublish(workDir, distDir, '42');
+    applyPrPublish(workDir, distDir, '42');
 
-    expect(fileExists(workDir, 'pr-42/index.html')).toBe(true);
-    expect(readFileSync(join(workDir, 'pr-42/index.html'), 'utf8')).toBe('<preview/>');
+    expect(fileExists(workDir, 'pr/42/index.html')).toBe(true);
+    expect(readFileSync(join(workDir, 'pr/42/index.html'), 'utf8')).toBe('<preview/>');
   });
 
   it('replaces an existing pr slot', () => {
-    write(workDir, 'pr-42/index.html', '<old/>');
+    write(workDir, 'pr/42/index.html', '<old/>');
     write(distDir, 'index.html', '<new/>');
 
-    applyPreviewPublish(workDir, distDir, '42');
+    applyPrPublish(workDir, distDir, '42');
 
-    expect(readFileSync(join(workDir, 'pr-42/index.html'), 'utf8')).toBe('<new/>');
+    expect(readFileSync(join(workDir, 'pr/42/index.html'), 'utf8')).toBe('<new/>');
   });
 
   it('does not modify stable root files', () => {
     write(workDir, 'index.html', '<stable/>');
     write(distDir, 'index.html', '<preview/>');
 
-    applyPreviewPublish(workDir, distDir, '42');
+    applyPrPublish(workDir, distDir, '42');
 
     expect(readFileSync(join(workDir, 'index.html'), 'utf8')).toBe('<stable/>');
   });
 
-  it('does not modify other pr preview directories', () => {
-    write(workDir, 'pr-10/index.html', '<other-preview/>');
+  it('does not modify other pr preview slots', () => {
+    write(workDir, 'pr/10/index.html', '<other-preview/>');
     write(distDir, 'index.html', '<preview/>');
 
-    applyPreviewPublish(workDir, distDir, '42');
+    applyPrPublish(workDir, distDir, '42');
 
-    expect(fileExists(workDir, 'pr-10/index.html')).toBe(true);
-    expect(readFileSync(join(workDir, 'pr-10/index.html'), 'utf8')).toBe('<other-preview/>');
+    expect(fileExists(workDir, 'pr/10/index.html')).toBe(true);
+    expect(readFileSync(join(workDir, 'pr/10/index.html'), 'utf8')).toBe('<other-preview/>');
+  });
+
+  it('does not modify branch slots', () => {
+    write(workDir, 'branch/develop/index.html', '<develop/>');
+    write(distDir, 'index.html', '<preview/>');
+
+    applyPrPublish(workDir, distDir, '42');
+
+    expect(fileExists(workDir, 'branch/develop/index.html')).toBe(true);
   });
 
   it('rejects an invalid PR number', () => {
-    expect(() => applyPreviewPublish(workDir, distDir, 'bad')).toThrow('Invalid PR number: bad');
+    expect(() => applyPrPublish(workDir, distDir, 'bad')).toThrow('Invalid PR number: bad');
   });
 });
 
-describe('applyPreviewCleanup', () => {
+describe('applyPrCleanup', () => {
   it('removes only the target pr slot', () => {
-    write(workDir, 'pr-42/index.html', '<preview/>');
+    write(workDir, 'pr/42/index.html', '<preview/>');
     write(workDir, 'index.html', '<stable/>');
-    write(workDir, 'pr-10/index.html', '<other/>');
+    write(workDir, 'pr/10/index.html', '<other/>');
 
-    const removed = applyPreviewCleanup(workDir, '42');
+    const removed = applyPrCleanup(workDir, '42');
 
     expect(removed).toBe(true);
-    expect(fileExists(workDir, 'pr-42/index.html')).toBe(false);
+    expect(fileExists(workDir, 'pr/42/index.html')).toBe(false);
     expect(fileExists(workDir, 'index.html')).toBe(true);
-    expect(fileExists(workDir, 'pr-10/index.html')).toBe(true);
+    expect(fileExists(workDir, 'pr/10/index.html')).toBe(true);
   });
 
   it('is a no-op and returns false when the preview directory does not exist', () => {
     write(workDir, 'index.html', '<stable/>');
 
-    const removed = applyPreviewCleanup(workDir, '99');
+    const removed = applyPrCleanup(workDir, '99');
 
     expect(removed).toBe(false);
     expect(fileExists(workDir, 'index.html')).toBe(true);
   });
 
   it('rejects an invalid PR number', () => {
-    expect(() => applyPreviewCleanup(workDir, '0')).toThrow('Invalid PR number: 0');
+    expect(() => applyPrCleanup(workDir, '0')).toThrow('Invalid PR number: 0');
   });
 
   it('rejects a non-numeric PR number', () => {
-    expect(() => applyPreviewCleanup(workDir, 'abc')).toThrow('Invalid PR number: abc');
+    expect(() => applyPrCleanup(workDir, 'abc')).toThrow('Invalid PR number: abc');
   });
 });

--- a/scripts/pages/lib/slug.mjs
+++ b/scripts/pages/lib/slug.mjs
@@ -1,0 +1,64 @@
+const MAX_SLUG_LENGTH = 63;
+const SLUG_PATTERN = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/;
+const RESERVED_SLUGS = new Set(['branch', 'pr']);
+
+/**
+ * Derive a safe, URL-path-safe branch slug from a branch name.
+ *
+ * Lower-cases, replaces any run of non `[a-z0-9]` characters (including `/`
+ * from `feature/x` branch names) with a single `-`, trims leading/trailing
+ * `-`, and truncates to a DNS-label-safe length. Used to build the
+ * `/branch/<slug>/` publish path so arbitrary branch names never introduce
+ * unsafe path segments.
+ * @param branchName Raw branch name, e.g. `feature/My Branch`.
+ * @returns The derived slug, e.g. `feature-my-branch`.
+ */
+export function slugifyBranch(branchName) {
+  if (typeof branchName !== 'string' || branchName.trim() === '') {
+    throw new Error(`Invalid branch name: ${JSON.stringify(branchName)}`);
+  }
+
+  const slug = branchName
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, MAX_SLUG_LENGTH)
+    .replace(/-+$/g, '');
+
+  if (slug === '') {
+    throw new Error(`Branch name ${JSON.stringify(branchName)} produces an empty slug.`);
+  }
+
+  return validateBranchSlug(slug);
+}
+
+/**
+ * Validate a branch slug is safe to use as a `/branch/<slug>/` path segment.
+ *
+ * Rejects reserved top-level namespace names (`branch`, `pr`) so a branch
+ * can never publish over the shared `/branch/` or `/pr/` roots.
+ * @param slug Candidate slug.
+ * @returns The validated slug.
+ */
+export function validateBranchSlug(slug) {
+  if (typeof slug !== 'string' || !SLUG_PATTERN.test(slug)) {
+    throw new Error(`Invalid branch slug: ${JSON.stringify(slug)}`);
+  }
+  if (RESERVED_SLUGS.has(slug)) {
+    throw new Error(`Branch slug ${JSON.stringify(slug)} is reserved.`);
+  }
+  return slug;
+}
+
+/**
+ * Validate a PR number string and return it.
+ * @param prNumber PR number as a string from CLI or event context.
+ * @returns The validated PR number string.
+ */
+export function validatePrNumber(prNumber) {
+  if (!/^\d+$/.test(prNumber) || prNumber === '0') {
+    throw new Error(`Invalid PR number: ${prNumber}`);
+  }
+  return prNumber;
+}

--- a/scripts/pages/lib/slug.mjs
+++ b/scripts/pages/lib/slug.mjs
@@ -1,36 +1,71 @@
+import { createHash } from 'node:crypto';
+
 const MAX_SLUG_LENGTH = 63;
 const SLUG_PATTERN = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/;
 const RESERVED_SLUGS = new Set(['branch', 'pr']);
+const HASH_LENGTH = 8;
+const DEVELOP_BRANCH_NAME = 'develop';
 
 /**
- * Derive a safe, URL-path-safe branch slug from a branch name.
+ * Derive a deterministic hash suffix from the raw (pre-normalization) branch
+ * name, so branch names that normalize to the same prefix (e.g.
+ * `feature/a`, `feature-a`, `feature_a` all normalize to `feature-a`) never
+ * collide on the same `/branch/<slug>/` deployment path.
+ * @param branchName Raw branch name.
+ * @returns An 8-character lowercase hex hash, e.g. `a1b2c3d4`.
+ */
+function hashBranchName(branchName) {
+  return createHash('sha256').update(branchName, 'utf8').digest('hex').slice(0, HASH_LENGTH);
+}
+
+/**
+ * Derive a safe, URL-path-safe, collision-resistant branch slug from a
+ * branch name.
  *
- * Lower-cases, replaces any run of non `[a-z0-9]` characters (including `/`
- * from `feature/x` branch names) with a single `-`, trims leading/trailing
- * `-`, and truncates to a DNS-label-safe length. Used to build the
- * `/branch/<slug>/` publish path so arbitrary branch names never introduce
- * unsafe path segments.
+ * The literal `develop` branch name maps to the bare slug `develop`, so a
+ * manual dispatch against `develop` resolves to the same `branch/develop/`
+ * slot the automatic develop-push deployment uses (see `deploy-develop` in
+ * `.github/workflows/verify.yml`, which publishes with a fixed `--slug
+ * develop` and does not call this function). Every other branch name always
+ * gets a hash suffix below, so nothing else can ever collide with that bare
+ * slug.
+ *
+ * For every other branch name: lower-cases, replaces any run of non
+ * `[a-z0-9]` characters (including `/` from `feature/x` branch names) with a
+ * single `-`, trims leading/trailing `-`, truncates to leave room for an
+ * 8-character hex suffix derived from the raw branch name, and appends that
+ * suffix. Two branch names that normalize to the same prefix (`feature/a`,
+ * `feature-a`, `feature_a`) therefore always produce different slugs, since
+ * the hash is derived from the distinct raw names, not the normalized
+ * prefix.
  * @param branchName Raw branch name, e.g. `feature/My Branch`.
- * @returns The derived slug, e.g. `feature-my-branch`.
+ * @returns The derived slug, e.g. `feature-my-branch-a1b2c3d4`.
  */
 export function slugifyBranch(branchName) {
   if (typeof branchName !== 'string' || branchName.trim() === '') {
     throw new Error(`Invalid branch name: ${JSON.stringify(branchName)}`);
   }
 
-  const slug = branchName
-    .trim()
+  const trimmed = branchName.trim();
+
+  if (trimmed === DEVELOP_BRANCH_NAME) {
+    return validateBranchSlug(DEVELOP_BRANCH_NAME);
+  }
+
+  const suffix = `-${hashBranchName(trimmed)}`;
+
+  const prefix = trimmed
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
-    .slice(0, MAX_SLUG_LENGTH)
+    .slice(0, MAX_SLUG_LENGTH - suffix.length)
     .replace(/-+$/g, '');
 
-  if (slug === '') {
+  if (prefix === '') {
     throw new Error(`Branch name ${JSON.stringify(branchName)} produces an empty slug.`);
   }
 
-  return validateBranchSlug(slug);
+  return validateBranchSlug(`${prefix}${suffix}`);
 }
 
 /**

--- a/scripts/pages/lib/slug.test.mjs
+++ b/scripts/pages/lib/slug.test.mjs
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+
+import { slugifyBranch, validateBranchSlug, validatePrNumber } from './slug.mjs';
+
+describe('slugifyBranch', () => {
+  it('lower-cases a simple branch name', () => {
+    expect(slugifyBranch('Develop')).toBe('develop');
+  });
+
+  it('replaces slashes with dashes', () => {
+    expect(slugifyBranch('feature/my-thing')).toBe('feature-my-thing');
+  });
+
+  it('replaces spaces and other unsafe characters with dashes', () => {
+    expect(slugifyBranch('fix/Weird Branch@Name!')).toBe('fix-weird-branch-name');
+  });
+
+  it('collapses consecutive unsafe characters into a single dash', () => {
+    expect(slugifyBranch('a///b')).toBe('a-b');
+  });
+
+  it('trims leading and trailing dashes', () => {
+    expect(slugifyBranch('-leading-and-trailing-')).toBe('leading-and-trailing');
+  });
+
+  it('truncates very long branch names to a DNS-label-safe length', () => {
+    const longName = 'feature/' + 'x'.repeat(100);
+    const slug = slugifyBranch(longName);
+    expect(slug.length).toBeLessThanOrEqual(63);
+    expect(slug.endsWith('-')).toBe(false);
+  });
+
+  it('throws for an empty branch name', () => {
+    expect(() => slugifyBranch('')).toThrow('Invalid branch name');
+  });
+
+  it('throws for a branch name that produces an empty slug', () => {
+    expect(() => slugifyBranch('///')).toThrow('produces an empty slug');
+  });
+
+  it('throws for a branch name that slugifies to a reserved namespace', () => {
+    expect(() => slugifyBranch('branch')).toThrow('is reserved');
+    expect(() => slugifyBranch('pr')).toThrow('is reserved');
+  });
+});
+
+describe('validateBranchSlug', () => {
+  it('accepts a valid slug', () => {
+    expect(validateBranchSlug('develop')).toBe('develop');
+    expect(validateBranchSlug('feature-123')).toBe('feature-123');
+  });
+
+  it('rejects uppercase characters', () => {
+    expect(() => validateBranchSlug('Develop')).toThrow('Invalid branch slug');
+  });
+
+  it('rejects a slug with a path separator', () => {
+    expect(() => validateBranchSlug('../etc')).toThrow('Invalid branch slug');
+    expect(() => validateBranchSlug('a/b')).toThrow('Invalid branch slug');
+  });
+
+  it('rejects a slug starting or ending with a dash', () => {
+    expect(() => validateBranchSlug('-foo')).toThrow('Invalid branch slug');
+    expect(() => validateBranchSlug('foo-')).toThrow('Invalid branch slug');
+  });
+
+  it('rejects an empty slug', () => {
+    expect(() => validateBranchSlug('')).toThrow('Invalid branch slug');
+  });
+
+  it('rejects the reserved "branch" and "pr" namespaces', () => {
+    expect(() => validateBranchSlug('branch')).toThrow('is reserved');
+    expect(() => validateBranchSlug('pr')).toThrow('is reserved');
+  });
+});
+
+describe('validatePrNumber', () => {
+  it('accepts valid PR numbers', () => {
+    expect(validatePrNumber('1')).toBe('1');
+    expect(validatePrNumber('42')).toBe('42');
+    expect(validatePrNumber('9999')).toBe('9999');
+  });
+
+  it('rejects zero', () => {
+    expect(() => validatePrNumber('0')).toThrow('Invalid PR number: 0');
+  });
+
+  it('rejects non-numeric strings', () => {
+    expect(() => validatePrNumber('abc')).toThrow('Invalid PR number: abc');
+    expect(() => validatePrNumber('1a')).toThrow('Invalid PR number: 1a');
+  });
+
+  it('rejects strings with path separators', () => {
+    expect(() => validatePrNumber('../42')).toThrow();
+    expect(() => validatePrNumber('1/2')).toThrow();
+  });
+
+  it('rejects empty string', () => {
+    expect(() => validatePrNumber('')).toThrow();
+  });
+});

--- a/scripts/pages/lib/slug.test.mjs
+++ b/scripts/pages/lib/slug.test.mjs
@@ -2,45 +2,83 @@ import { describe, expect, it } from 'vitest';
 
 import { slugifyBranch, validateBranchSlug, validatePrNumber } from './slug.mjs';
 
+const HASH_SUFFIX_PATTERN = /-[0-9a-f]{8}$/;
+
 describe('slugifyBranch', () => {
-  it('lower-cases a simple branch name', () => {
-    expect(slugifyBranch('Develop')).toBe('develop');
+  it('maps the literal "develop" branch to the bare "develop" slug', () => {
+    expect(slugifyBranch('develop')).toBe('develop');
   });
 
-  it('replaces slashes with dashes', () => {
-    expect(slugifyBranch('feature/my-thing')).toBe('feature-my-thing');
+  it('does not bare-map a differently-cased "develop" variant, to avoid colliding with the real develop branch', () => {
+    const slug = slugifyBranch('Develop');
+    expect(slug).not.toBe('develop');
+    expect(slug).toMatch(/^develop-[0-9a-f]{8}$/);
+  });
+
+  it('replaces slashes with dashes and appends a hash suffix', () => {
+    expect(slugifyBranch('feature/my-thing')).toMatch(/^feature-my-thing-[0-9a-f]{8}$/);
   });
 
   it('replaces spaces and other unsafe characters with dashes', () => {
-    expect(slugifyBranch('fix/Weird Branch@Name!')).toBe('fix-weird-branch-name');
+    expect(slugifyBranch('fix/Weird Branch@Name!')).toMatch(/^fix-weird-branch-name-[0-9a-f]{8}$/);
   });
 
   it('collapses consecutive unsafe characters into a single dash', () => {
-    expect(slugifyBranch('a///b')).toBe('a-b');
+    expect(slugifyBranch('a///b')).toMatch(/^a-b-[0-9a-f]{8}$/);
   });
 
-  it('trims leading and trailing dashes', () => {
-    expect(slugifyBranch('-leading-and-trailing-')).toBe('leading-and-trailing');
+  it('trims leading and trailing dashes from the normalized prefix', () => {
+    expect(slugifyBranch('-leading-and-trailing-')).toMatch(/^leading-and-trailing-[0-9a-f]{8}$/);
   });
 
-  it('truncates very long branch names to a DNS-label-safe length', () => {
+  it('is deterministic for the same branch name', () => {
+    expect(slugifyBranch('feature/my-thing')).toBe(slugifyBranch('feature/my-thing'));
+  });
+
+  it('truncates very long branch names to a DNS-label-safe length while keeping the hash suffix', () => {
     const longName = 'feature/' + 'x'.repeat(100);
     const slug = slugifyBranch(longName);
     expect(slug.length).toBeLessThanOrEqual(63);
     expect(slug.endsWith('-')).toBe(false);
+    expect(slug).toMatch(HASH_SUFFIX_PATTERN);
   });
 
   it('throws for an empty branch name', () => {
     expect(() => slugifyBranch('')).toThrow('Invalid branch name');
   });
 
-  it('throws for a branch name that produces an empty slug', () => {
+  it('throws for a branch name that produces an empty normalized prefix', () => {
     expect(() => slugifyBranch('///')).toThrow('produces an empty slug');
   });
 
-  it('throws for a branch name that slugifies to a reserved namespace', () => {
-    expect(() => slugifyBranch('branch')).toThrow('is reserved');
-    expect(() => slugifyBranch('pr')).toThrow('is reserved');
+  it('produces a non-reserved hashed slug for a branch literally named "branch" or "pr"', () => {
+    // Unlike the reserved bare `branch`/`pr` namespace roots, a branch
+    // literally named this way always gets a hash suffix, so it can never
+    // collide with the reserved namespace.
+    expect(slugifyBranch('branch')).toMatch(/^branch-[0-9a-f]{8}$/);
+    expect(slugifyBranch('pr')).toMatch(/^pr-[0-9a-f]{8}$/);
+  });
+
+  describe('collision safety', () => {
+    it('produces distinct slugs for branch names that normalize to the same prefix', () => {
+      const slugSlash = slugifyBranch('feature/a');
+      const slugDash = slugifyBranch('feature-a');
+      const slugUnderscore = slugifyBranch('feature_a');
+
+      expect(slugSlash).toMatch(/^feature-a-[0-9a-f]{8}$/);
+      expect(slugDash).toMatch(/^feature-a-[0-9a-f]{8}$/);
+      expect(slugUnderscore).toMatch(/^feature-a-[0-9a-f]{8}$/);
+
+      const slugs = new Set([slugSlash, slugDash, slugUnderscore]);
+      expect(slugs.size).toBe(3);
+    });
+
+    it('produces distinct slugs for long branch names that collide after truncation', () => {
+      const longNameA = 'feature/' + 'x'.repeat(100) + '-a';
+      const longNameB = 'feature/' + 'x'.repeat(100) + '-b';
+
+      expect(slugifyBranch(longNameA)).not.toBe(slugifyBranch(longNameB));
+    });
   });
 });
 

--- a/scripts/pages/lib/tombstoneContent.mjs
+++ b/scripts/pages/lib/tombstoneContent.mjs
@@ -1,0 +1,117 @@
+/**
+ * Build the Cache Storage name prefix owned by a branch channel's service
+ * worker. Must match the prefix `config/plugins/pwa.ts` uses when building
+ * `runtimeCaching` cache names for the same branch channel, so a tombstone
+ * clears exactly (and only) the caches its own branch ever wrote.
+ * @param slug Branch slug.
+ * @returns Cache name prefix, e.g. `branch-develop-`.
+ */
+export function buildBranchCacheNamePrefix(slug) {
+  return `branch-${slug}-`;
+}
+
+/**
+ * Build the literal `sw.js` source for a branch tombstone.
+ *
+ * On activation, deletes only caches in this branch's own namespace
+ * (`buildBranchCacheNamePrefix`) — never stable, PR, or other branch
+ * caches — then claims existing clients so the next navigation in this
+ * scope is served fresh. Registers no `fetch` handler (network passthrough)
+ * and never messages open clients to reload: this is passive self-cleanup,
+ * not forced-reload coordination.
+ * @param slug Branch slug the tombstone belongs to.
+ * @returns Service worker source text.
+ */
+export function buildTombstoneServiceWorker(slug) {
+  const cachePrefix = buildBranchCacheNamePrefix(slug);
+
+  return `// Tombstone service worker for the removed "${slug}" branch deployment.
+// Clears only this branch's own cache namespace; does not touch stable, PR,
+// or other branch caches, and does not force any client reload.
+const CACHE_PREFIX = ${JSON.stringify(cachePrefix)};
+
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(keys.filter((key) => key.startsWith(CACHE_PREFIX)).map((key) => caches.delete(key))),
+      )
+      .then(() => self.clients.claim()),
+  );
+});
+`;
+}
+
+/**
+ * Build the `manifest.webmanifest` object for a branch tombstone. Keeps the
+ * same `scope`/`start_url`/`id` as the removed branch deployment so an
+ * already-installed PWA icon still resolves to this page.
+ * @param slug Branch slug.
+ * @param baseUrl Branch base URL, e.g. `/branch/develop/`.
+ * @returns Web app manifest object.
+ */
+export function buildTombstoneManifest(slug, baseUrl) {
+  return {
+    name: `Mioframe ${slug} (removed)`,
+    short_name: 'Removed',
+    start_url: baseUrl,
+    scope: baseUrl,
+    id: baseUrl,
+    display: 'minimal-ui',
+  };
+}
+
+/**
+ * Build the `index.html` source for a branch tombstone: a static page
+ * announcing the branch was removed, linking to the stable app root, and
+ * registering the tombstone service worker at the branch's own scope.
+ * @param slug Branch slug.
+ * @param baseUrl Branch base URL, e.g. `/branch/develop/`.
+ * @returns HTML source text.
+ */
+export function buildTombstoneHtml(slug, baseUrl) {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Branch removed — Mioframe</title>
+  <link rel="manifest" href="manifest.webmanifest" />
+</head>
+<body>
+  <main>
+    <h1>This branch preview was removed</h1>
+    <p>The "${slug}" branch no longer exists, so this preview is no longer updated.</p>
+    <p><a href="/">Go to the stable app</a></p>
+  </main>
+  <script>
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('sw.js', { scope: ${JSON.stringify(baseUrl)} });
+    }
+  </script>
+</body>
+</html>
+`;
+}
+
+/**
+ * Build the full set of static tombstone files for a removed branch
+ * deployment, keyed by filename relative to the branch's `branch/<slug>/`
+ * directory.
+ * @param slug Branch slug.
+ * @param baseUrl Branch base URL, e.g. `/branch/develop/`.
+ * @returns Map of relative filename to file content (strings; the manifest
+ * value is a JSON string).
+ */
+export function buildTombstoneFiles(slug, baseUrl) {
+  return {
+    'index.html': buildTombstoneHtml(slug, baseUrl),
+    'sw.js': buildTombstoneServiceWorker(slug),
+    'manifest.webmanifest': JSON.stringify(buildTombstoneManifest(slug, baseUrl), null, 2) + '\n',
+  };
+}

--- a/scripts/pages/lib/tombstoneContent.test.mjs
+++ b/scripts/pages/lib/tombstoneContent.test.mjs
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildBranchCacheNamePrefix,
+  buildTombstoneFiles,
+  buildTombstoneHtml,
+  buildTombstoneManifest,
+  buildTombstoneServiceWorker,
+} from './tombstoneContent.mjs';
+
+describe('buildBranchCacheNamePrefix', () => {
+  it('builds a branch-scoped cache prefix', () => {
+    expect(buildBranchCacheNamePrefix('develop')).toBe('branch-develop-');
+    expect(buildBranchCacheNamePrefix('feature-x')).toBe('branch-feature-x-');
+  });
+});
+
+describe('buildTombstoneServiceWorker', () => {
+  it('embeds the branch-scoped cache prefix', () => {
+    const sw = buildTombstoneServiceWorker('develop');
+    expect(sw).toContain('"branch-develop-"');
+  });
+
+  it('only deletes caches matching this branch prefix', () => {
+    const sw = buildTombstoneServiceWorker('develop');
+    expect(sw).toContain('key.startsWith(CACHE_PREFIX)');
+    expect(sw).toContain('caches.delete(key)');
+  });
+
+  it('uses a different cache prefix per branch', () => {
+    const developSw = buildTombstoneServiceWorker('develop');
+    const otherSw = buildTombstoneServiceWorker('feature-x');
+    expect(developSw).toContain('"branch-develop-"');
+    expect(otherSw).toContain('"branch-feature-x-"');
+    expect(developSw).not.toContain('"branch-feature-x-"');
+  });
+
+  it('does not message clients or force a reload', () => {
+    const sw = buildTombstoneServiceWorker('develop');
+    expect(sw).not.toMatch(/postMessage/);
+    expect(sw).not.toMatch(/location\.reload/);
+  });
+
+  it('claims clients passively via clients.claim, not forced reload', () => {
+    const sw = buildTombstoneServiceWorker('develop');
+    expect(sw).toContain('self.clients.claim()');
+  });
+});
+
+describe('buildTombstoneManifest', () => {
+  it('scopes the manifest to the branch base URL', () => {
+    const manifest = buildTombstoneManifest('develop', '/branch/develop/');
+    expect(manifest.scope).toBe('/branch/develop/');
+    expect(manifest.start_url).toBe('/branch/develop/');
+    expect(manifest.id).toBe('/branch/develop/');
+  });
+
+  it('names the manifest for the removed branch', () => {
+    const manifest = buildTombstoneManifest('feature-x', '/branch/feature-x/');
+    expect(manifest.name).toContain('feature-x');
+    expect(manifest.name).toContain('removed');
+  });
+});
+
+describe('buildTombstoneHtml', () => {
+  it('links to the stable root', () => {
+    const html = buildTombstoneHtml('develop', '/branch/develop/');
+    expect(html).toContain('href="/"');
+  });
+
+  it('mentions the removed branch by name', () => {
+    const html = buildTombstoneHtml('develop', '/branch/develop/');
+    expect(html).toContain('develop');
+  });
+
+  it('registers the service worker at the branch scope', () => {
+    const html = buildTombstoneHtml('develop', '/branch/develop/');
+    expect(html).toContain("register('sw.js'");
+    expect(html).toContain('/branch/develop/');
+  });
+});
+
+describe('buildTombstoneFiles', () => {
+  it('returns index.html, sw.js, and manifest.webmanifest', () => {
+    const files = buildTombstoneFiles('develop', '/branch/develop/');
+    expect(Object.keys(files).sort()).toEqual(['index.html', 'manifest.webmanifest', 'sw.js']);
+  });
+
+  it('produces valid JSON for the manifest', () => {
+    const files = buildTombstoneFiles('develop', '/branch/develop/');
+    expect(() => JSON.parse(files['manifest.webmanifest'])).not.toThrow();
+  });
+});

--- a/scripts/pages/lib/tombstoneRetention.mjs
+++ b/scripts/pages/lib/tombstoneRetention.mjs
@@ -4,6 +4,30 @@ import { join } from 'node:path';
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 /**
+ * Validate a tombstone retention period in days.
+ *
+ * Used for both the `--retention-days` CLI argument and the
+ * `config/tooling.json` `pages.tombstoneRetentionDays` fallback, so
+ * `cleanupExpiredTombstones.mjs` fails fast on a malformed value instead of
+ * silently treating `NaN`/`0`/a negative number as "never expire" or
+ * "always expire".
+ * @param value Raw value to validate: a CLI string argument, or the parsed config number.
+ * @param source Human-readable source of the value, used in the thrown error message.
+ * @returns The validated retention days as a finite positive integer.
+ */
+export function validateRetentionDays(value, source) {
+  const retentionDays = typeof value === 'string' ? Number(value) : value;
+
+  if (!Number.isInteger(retentionDays) || retentionDays <= 0) {
+    throw new Error(
+      `Invalid retention days from ${source}: ${JSON.stringify(value)}. Must be a finite positive integer.`,
+    );
+  }
+
+  return retentionDays;
+}
+
+/**
  * Decide whether a branch's `deployment.json` record is an expired
  * tombstone that the scheduled cleanup should remove.
  *

--- a/scripts/pages/lib/tombstoneRetention.mjs
+++ b/scripts/pages/lib/tombstoneRetention.mjs
@@ -1,0 +1,77 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Decide whether a branch's `deployment.json` record is an expired
+ * tombstone that the scheduled cleanup should remove.
+ *
+ * For tombstone records, `buildDate` is the moment the tombstone was
+ * published (see `deploymentMetadata.mjs`), so it doubles as the retention
+ * clock start.
+ * @param deploymentMetadata Parsed `deployment.json` contents, or `undefined`.
+ * @param now Current time in epoch milliseconds.
+ * @param retentionDays Retention period in days (see `config/tooling.json` `pages.tombstoneRetentionDays`).
+ * @returns `true` when this is a tombstone whose retention period has elapsed.
+ */
+export function isTombstoneExpired(deploymentMetadata, now, retentionDays) {
+  if (!deploymentMetadata || deploymentMetadata.tombstone !== true) {
+    return false;
+  }
+
+  const tombstonedAt = Date.parse(deploymentMetadata.buildDate ?? '');
+  if (Number.isNaN(tombstonedAt)) {
+    return false;
+  }
+
+  return now - tombstonedAt >= retentionDays * DAY_MS;
+}
+
+/**
+ * Scan a Pages work directory's `branch/*` slots for expired tombstones.
+ *
+ * Slots with no `deployment.json`, an unparseable one, or a non-tombstone
+ * (live) deployment are left untouched — this never removes a live branch
+ * deployment, only tombstones past their retention period.
+ * @param options Scan options.
+ * @param options.workDir Path to the Pages staging working directory.
+ * @param [options.now] Current time in epoch milliseconds; defaults to `Date.now()`.
+ * @param options.retentionDays Retention period in days.
+ * @param [options.deps] Test seams for filesystem access.
+ * @returns Branch slugs whose tombstone has expired and should be removed.
+ */
+export function findExpiredTombstoneSlugs({ workDir, now = Date.now(), retentionDays, deps = {} }) {
+  const {
+    readdirSync: listDir = readdirSync,
+    readFileSync: readFile = readFileSync,
+    existsSync: exists = existsSync,
+  } = deps;
+
+  const branchDir = join(workDir, 'branch');
+  if (!exists(branchDir)) {
+    return [];
+  }
+
+  const expired = [];
+
+  for (const entry of listDir(branchDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+
+    const metadataPath = join(branchDir, entry.name, 'deployment.json');
+    if (!exists(metadataPath)) continue;
+
+    let metadata;
+    try {
+      metadata = JSON.parse(readFile(metadataPath, 'utf8'));
+    } catch {
+      continue;
+    }
+
+    if (isTombstoneExpired(metadata, now, retentionDays)) {
+      expired.push(entry.name);
+    }
+  }
+
+  return expired;
+}

--- a/scripts/pages/lib/tombstoneRetention.test.mjs
+++ b/scripts/pages/lib/tombstoneRetention.test.mjs
@@ -1,9 +1,58 @@
 import { describe, expect, it } from 'vitest';
 
-import { findExpiredTombstoneSlugs, isTombstoneExpired } from './tombstoneRetention.mjs';
+import {
+  findExpiredTombstoneSlugs,
+  isTombstoneExpired,
+  validateRetentionDays,
+} from './tombstoneRetention.mjs';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const NOW = Date.parse('2026-07-03T00:00:00.000Z');
+
+describe('validateRetentionDays', () => {
+  it('returns the value unchanged for a valid positive integer', () => {
+    expect(validateRetentionDays(14, 'config/tooling.json')).toBe(14);
+    expect(validateRetentionDays('14', '--retention-days')).toBe(14);
+  });
+
+  it('throws for a non-numeric CLI string', () => {
+    expect(() => validateRetentionDays('abc', '--retention-days')).toThrow(
+      'Invalid retention days from --retention-days',
+    );
+  });
+
+  it('throws for zero', () => {
+    expect(() => validateRetentionDays(0, 'config/tooling.json')).toThrow(
+      'Invalid retention days from config/tooling.json',
+    );
+    expect(() => validateRetentionDays('0', '--retention-days')).toThrow('Invalid retention days');
+  });
+
+  it('throws for a negative number', () => {
+    expect(() => validateRetentionDays(-3, 'config/tooling.json')).toThrow(
+      'Invalid retention days',
+    );
+    expect(() => validateRetentionDays('-3', '--retention-days')).toThrow('Invalid retention days');
+  });
+
+  it('throws for a decimal number', () => {
+    expect(() => validateRetentionDays(1.5, 'config/tooling.json')).toThrow(
+      'Invalid retention days',
+    );
+    expect(() => validateRetentionDays('1.5', '--retention-days')).toThrow(
+      'Invalid retention days',
+    );
+  });
+
+  it('throws for NaN and Infinity', () => {
+    expect(() => validateRetentionDays(NaN, 'config/tooling.json')).toThrow(
+      'Invalid retention days',
+    );
+    expect(() => validateRetentionDays(Infinity, 'config/tooling.json')).toThrow(
+      'Invalid retention days',
+    );
+  });
+});
 
 describe('isTombstoneExpired', () => {
   it('returns false for a non-tombstone (live) record', () => {

--- a/scripts/pages/lib/tombstoneRetention.test.mjs
+++ b/scripts/pages/lib/tombstoneRetention.test.mjs
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+
+import { findExpiredTombstoneSlugs, isTombstoneExpired } from './tombstoneRetention.mjs';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = Date.parse('2026-07-03T00:00:00.000Z');
+
+describe('isTombstoneExpired', () => {
+  it('returns false for a non-tombstone (live) record', () => {
+    const metadata = {
+      channel: 'branch',
+      channelId: 'develop',
+      buildDate: '2026-01-01T00:00:00.000Z',
+    };
+    expect(isTombstoneExpired(metadata, NOW, 14)).toBe(false);
+  });
+
+  it('returns false for a tombstone still within the retention window', () => {
+    const buildDate = new Date(NOW - 5 * DAY_MS).toISOString();
+    const metadata = { tombstone: true, buildDate };
+    expect(isTombstoneExpired(metadata, NOW, 14)).toBe(false);
+  });
+
+  it('returns true for a tombstone past the retention window', () => {
+    const buildDate = new Date(NOW - 15 * DAY_MS).toISOString();
+    const metadata = { tombstone: true, buildDate };
+    expect(isTombstoneExpired(metadata, NOW, 14)).toBe(true);
+  });
+
+  it('returns true exactly at the retention boundary', () => {
+    const buildDate = new Date(NOW - 14 * DAY_MS).toISOString();
+    const metadata = { tombstone: true, buildDate };
+    expect(isTombstoneExpired(metadata, NOW, 14)).toBe(true);
+  });
+
+  it('returns false when metadata is missing', () => {
+    expect(isTombstoneExpired(undefined, NOW, 14)).toBe(false);
+  });
+
+  it('returns false when buildDate is unparseable', () => {
+    const metadata = { tombstone: true, buildDate: 'not-a-date' };
+    expect(isTombstoneExpired(metadata, NOW, 14)).toBe(false);
+  });
+});
+
+describe('findExpiredTombstoneSlugs', () => {
+  function makeDeps(files) {
+    return {
+      existsSync: (path) => path in files || path.endsWith('/branch'),
+      readdirSync: () =>
+        Object.keys(files).map((name) => ({
+          name: name.split('/').at(-2),
+          isDirectory: () => true,
+        })),
+      readFileSync: (path) => {
+        if (!(path in files)) throw new Error(`ENOENT: ${path}`);
+        return files[path];
+      },
+    };
+  }
+
+  it('returns branch slugs whose tombstone has expired', () => {
+    const expiredDate = new Date(NOW - 20 * DAY_MS).toISOString();
+    const freshDate = new Date(NOW - 1 * DAY_MS).toISOString();
+    const deps = makeDeps({
+      '/work/branch/old-feature/deployment.json': JSON.stringify({
+        tombstone: true,
+        buildDate: expiredDate,
+      }),
+      '/work/branch/develop/deployment.json': JSON.stringify({
+        channel: 'branch',
+        channelId: 'develop',
+        buildDate: freshDate,
+      }),
+      '/work/branch/recent-tombstone/deployment.json': JSON.stringify({
+        tombstone: true,
+        buildDate: freshDate,
+      }),
+    });
+
+    const expired = findExpiredTombstoneSlugs({
+      workDir: '/work',
+      now: NOW,
+      retentionDays: 14,
+      deps,
+    });
+
+    expect(expired).toEqual(['old-feature']);
+  });
+
+  it('returns an empty array when the branch directory does not exist', () => {
+    const deps = {
+      existsSync: () => false,
+      readdirSync: () => {
+        throw new Error('should not be called');
+      },
+      readFileSync: () => {
+        throw new Error('should not be called');
+      },
+    };
+
+    expect(
+      findExpiredTombstoneSlugs({ workDir: '/work', now: NOW, retentionDays: 14, deps }),
+    ).toEqual([]);
+  });
+
+  it('skips entries without a deployment.json', () => {
+    const deps = {
+      existsSync: (path) => path === '/work/branch',
+      readdirSync: () => [{ name: 'no-metadata', isDirectory: () => true }],
+      readFileSync: () => {
+        throw new Error('should not be called');
+      },
+    };
+
+    expect(
+      findExpiredTombstoneSlugs({ workDir: '/work', now: NOW, retentionDays: 14, deps }),
+    ).toEqual([]);
+  });
+
+  it('skips entries with unparseable deployment.json', () => {
+    const deps = {
+      existsSync: (path) => path === '/work/branch' || path.endsWith('deployment.json'),
+      readdirSync: () => [{ name: 'broken', isDirectory: () => true }],
+      readFileSync: () => 'not json',
+    };
+
+    expect(
+      findExpiredTombstoneSlugs({ workDir: '/work', now: NOW, retentionDays: 14, deps }),
+    ).toEqual([]);
+  });
+});

--- a/scripts/pages/publishBranch.mjs
+++ b/scripts/pages/publishBranch.mjs
@@ -1,14 +1,15 @@
 /**
- * Publish a PR preview build to pr/<PR_NUMBER>/ on the gh-pages staging branch.
+ * Publish a branch build to branch/<slug>/ on the gh-pages staging branch.
  *
- * Only the target PR slot is touched; stable files, branch/* deployments,
- * and other pr/* directories are not modified.
+ * Only the target branch slot is touched; stable files, other branch
+ * slots, and pr/* directories are not modified. Used both by the develop
+ * push deployment and the manual branch-dispatch deployment.
  *
  * When --output-dir is provided, the final staging content is also copied
  * there so the caller can upload it as a GitHub Pages artifact.
  *
  * Usage:
- *   node scripts/pages/publishPreview.mjs --dist ./dist --pr 42 [--output-dir ./pages-staging]
+ *   node scripts/pages/publishBranch.mjs --dist ./dist --slug develop [--output-dir ./pages-staging]
  *
  * Required env:
  *   GITHUB_TOKEN      - token with contents:write on the target Pages repository
@@ -19,29 +20,29 @@ import { existsSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
 
 import { withGhPagesBranch } from './lib/ghPagesBranch.mjs';
-import { applyPrPublish } from './lib/pagesFs.mjs';
-import { validatePrNumber } from './lib/slug.mjs';
+import { applyBranchPublish } from './lib/pagesFs.mjs';
+import { validateBranchSlug } from './lib/slug.mjs';
 
 /**
  * @param argv Process arguments (process.argv.slice(2)).
  * @param env Process environment.
  */
-export async function publishPreview(argv = process.argv.slice(2), env = process.env) {
+export async function publishBranch(argv = process.argv.slice(2), env = process.env) {
   const distIndex = argv.indexOf('--dist');
-  const prIndex = argv.indexOf('--pr');
+  const slugIndex = argv.indexOf('--slug');
 
   if (distIndex === -1 || !argv[distIndex + 1]) {
-    throw new Error('Usage: publishPreview.mjs --dist <dist-dir> --pr <number>');
+    throw new Error('Usage: publishBranch.mjs --dist <dist-dir> --slug <branch-slug>');
   }
-  if (prIndex === -1 || !argv[prIndex + 1]) {
-    throw new Error('Usage: publishPreview.mjs --dist <dist-dir> --pr <number>');
+  if (slugIndex === -1 || !argv[slugIndex + 1]) {
+    throw new Error('Usage: publishBranch.mjs --dist <dist-dir> --slug <branch-slug>');
   }
 
   const distDir = argv[distIndex + 1];
   if (!existsSync(distDir)) {
     throw new Error(`dist directory does not exist: ${distDir}`);
   }
-  const prNumber = validatePrNumber(argv[prIndex + 1]);
+  const slug = validateBranchSlug(argv[slugIndex + 1]);
 
   const outputIndex = argv.indexOf('--output-dir');
   const outputDir = outputIndex !== -1 ? argv[outputIndex + 1] : undefined;
@@ -53,19 +54,19 @@ export async function publishPreview(argv = process.argv.slice(2), env = process
   await withGhPagesBranch({
     token: GITHUB_TOKEN,
     repository: GITHUB_REPOSITORY,
-    commitMessage: `chore(pages): deploy preview for PR #${prNumber}`,
+    commitMessage: `chore(pages): deploy branch ${slug}`,
     outputDir,
     fn(workDir) {
-      applyPrPublish(workDir, distDir, prNumber);
+      applyBranchPublish(workDir, distDir, slug);
     },
   });
 
-  console.log(`Preview for PR #${prNumber} published to pr/${prNumber}/.`);
+  console.log(`Branch ${slug} published to branch/${slug}/.`);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   try {
-    await publishPreview();
+    await publishBranch();
   } catch (error) {
     console.error(error instanceof Error ? error.message : String(error));
     process.exitCode = 1;

--- a/scripts/pages/publishBranch.test.mjs
+++ b/scripts/pages/publishBranch.test.mjs
@@ -1,0 +1,71 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { publishBranch } from './publishBranch.mjs';
+
+let distDir = '';
+
+beforeEach(() => {
+  distDir = mkdtempSync(join(tmpdir(), 'pages-dist-'));
+});
+
+afterEach(() => {
+  rmSync(distDir, { recursive: true, force: true });
+});
+
+describe('publishBranch validation', () => {
+  it('throws before git operations when distDir does not exist', async () => {
+    await expect(
+      publishBranch(['--dist', '/nonexistent/dist-12345', '--slug', 'develop'], {
+        GITHUB_TOKEN: 'token',
+        GITHUB_REPOSITORY: 'owner/repo',
+      }),
+    ).rejects.toThrow('dist directory does not exist');
+  });
+
+  it('throws when --dist argument is missing', async () => {
+    await expect(
+      publishBranch(['--slug', 'develop'], {
+        GITHUB_TOKEN: 'token',
+        GITHUB_REPOSITORY: 'owner/repo',
+      }),
+    ).rejects.toThrow('Usage:');
+  });
+
+  it('throws when --slug argument is missing', async () => {
+    await expect(
+      publishBranch(['--dist', distDir], {
+        GITHUB_TOKEN: 'token',
+        GITHUB_REPOSITORY: 'owner/repo',
+      }),
+    ).rejects.toThrow('Usage:');
+  });
+
+  it('throws when the slug is invalid', async () => {
+    await expect(
+      publishBranch(['--dist', distDir, '--slug', '../etc'], {
+        GITHUB_TOKEN: 'token',
+        GITHUB_REPOSITORY: 'owner/repo',
+      }),
+    ).rejects.toThrow('Invalid branch slug');
+  });
+
+  it('throws when the slug is a reserved namespace', async () => {
+    await expect(
+      publishBranch(['--dist', distDir, '--slug', 'pr'], {
+        GITHUB_TOKEN: 'token',
+        GITHUB_REPOSITORY: 'owner/repo',
+      }),
+    ).rejects.toThrow('is reserved');
+  });
+
+  it('throws when GITHUB_TOKEN is missing', async () => {
+    await expect(
+      publishBranch(['--dist', distDir, '--slug', 'develop'], {
+        GITHUB_REPOSITORY: 'owner/repo',
+      }),
+    ).rejects.toThrow('GITHUB_TOKEN is required');
+  });
+});

--- a/scripts/pages/publishBranchTombstone.mjs
+++ b/scripts/pages/publishBranchTombstone.mjs
@@ -71,24 +71,26 @@ export async function publishBranchTombstone(argv = process.argv.slice(2), env =
   let tombstoned = false;
   let tombstoneDistDir;
 
-  await withGhPagesBranch({
-    token: GITHUB_TOKEN,
-    repository: GITHUB_REPOSITORY,
-    commitMessage: `chore(pages): tombstone removed branch ${slug}`,
-    outputDir,
-    fn(workDir) {
-      if (!existsSync(join(workDir, 'branch', slug))) {
-        console.log(`Branch slot branch/${slug}/ not found, nothing to tombstone.`);
-        return;
-      }
-      tombstoneDistDir = buildTombstoneDistDir(slug, baseUrl);
-      applyBranchPublish(workDir, tombstoneDistDir, slug);
-      tombstoned = true;
-    },
-  });
-
-  if (tombstoneDistDir) {
-    rmSync(tombstoneDistDir, { recursive: true, force: true });
+  try {
+    await withGhPagesBranch({
+      token: GITHUB_TOKEN,
+      repository: GITHUB_REPOSITORY,
+      commitMessage: `chore(pages): tombstone removed branch ${slug}`,
+      outputDir,
+      fn(workDir) {
+        if (!existsSync(join(workDir, 'branch', slug))) {
+          console.log(`Branch slot branch/${slug}/ not found, nothing to tombstone.`);
+          return;
+        }
+        tombstoneDistDir = buildTombstoneDistDir(slug, baseUrl);
+        applyBranchPublish(workDir, tombstoneDistDir, slug);
+        tombstoned = true;
+      },
+    });
+  } finally {
+    if (tombstoneDistDir) {
+      rmSync(tombstoneDistDir, { recursive: true, force: true });
+    }
   }
 
   if (GITHUB_OUTPUT) {

--- a/scripts/pages/publishBranchTombstone.mjs
+++ b/scripts/pages/publishBranchTombstone.mjs
@@ -1,0 +1,110 @@
+/**
+ * Publish a tombstone to branch/<slug>/ after that branch has been deleted.
+ *
+ * Every branch/<slug>/ deployment is PWA-enabled by construction (PR
+ * previews are the only PWA-disabled channel, and they are cleaned up via a
+ * separate `pull_request: closed` path, not this one) — so an existing
+ * `/branch/<slug>/` slot is always eligible for tombstoning. If the slot
+ * does not exist (the branch was never deployed), this is a clean no-op.
+ *
+ * The tombstone replaces the slot's content with a static removal notice
+ * plus a service worker that clears only that branch's own cache namespace
+ * (see `lib/tombstoneContent.mjs`). Only the target branch slot is touched;
+ * stable files, other branch slots, and pr/* directories are not modified.
+ *
+ * When GITHUB_OUTPUT is set, writes a `tombstoned` output (`true`/`false`).
+ *
+ * Usage:
+ *   node scripts/pages/publishBranchTombstone.mjs --slug develop [--output-dir ./pages-staging]
+ *
+ * Required env:
+ *   GITHUB_TOKEN      - token with contents:write on the target Pages repository
+ *   GITHUB_REPOSITORY - OWNER/REPO of the target Pages repository
+ */
+
+import { appendFileSync, existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { buildDeploymentMetadata, writeDeploymentMetadataFile } from './lib/deploymentMetadata.mjs';
+import { withGhPagesBranch } from './lib/ghPagesBranch.mjs';
+import { applyBranchPublish } from './lib/pagesFs.mjs';
+import { validateBranchSlug } from './lib/slug.mjs';
+import { buildTombstoneFiles } from './lib/tombstoneContent.mjs';
+
+function buildTombstoneDistDir(slug, baseUrl) {
+  const distDir = mkdtempSync(join(tmpdir(), 'branch-tombstone-'));
+
+  for (const [name, content] of Object.entries(buildTombstoneFiles(slug, baseUrl))) {
+    writeFileSync(join(distDir, name), content, 'utf8');
+  }
+
+  writeDeploymentMetadataFile(
+    distDir,
+    buildDeploymentMetadata({ channel: 'branch', channelId: slug, baseUrl, slug, tombstone: true }),
+  );
+
+  return distDir;
+}
+
+/**
+ * @param argv Process arguments (process.argv.slice(2)).
+ * @param env Process environment.
+ * @returns `true` if a tombstone was published; `false` if the branch slot did not exist.
+ */
+export async function publishBranchTombstone(argv = process.argv.slice(2), env = process.env) {
+  const slugIndex = argv.indexOf('--slug');
+  if (slugIndex === -1 || !argv[slugIndex + 1]) {
+    throw new Error('Usage: publishBranchTombstone.mjs --slug <branch-slug>');
+  }
+  const slug = validateBranchSlug(argv[slugIndex + 1]);
+  const baseUrl = `/branch/${slug}/`;
+
+  const outputIndex = argv.indexOf('--output-dir');
+  const outputDir = outputIndex !== -1 ? argv[outputIndex + 1] : undefined;
+
+  const { GITHUB_TOKEN, GITHUB_REPOSITORY, GITHUB_OUTPUT } = env;
+  if (!GITHUB_TOKEN) throw new Error('GITHUB_TOKEN is required');
+  if (!GITHUB_REPOSITORY) throw new Error('GITHUB_REPOSITORY is required');
+
+  let tombstoned = false;
+  let tombstoneDistDir;
+
+  await withGhPagesBranch({
+    token: GITHUB_TOKEN,
+    repository: GITHUB_REPOSITORY,
+    commitMessage: `chore(pages): tombstone removed branch ${slug}`,
+    outputDir,
+    fn(workDir) {
+      if (!existsSync(join(workDir, 'branch', slug))) {
+        console.log(`Branch slot branch/${slug}/ not found, nothing to tombstone.`);
+        return;
+      }
+      tombstoneDistDir = buildTombstoneDistDir(slug, baseUrl);
+      applyBranchPublish(workDir, tombstoneDistDir, slug);
+      tombstoned = true;
+    },
+  });
+
+  if (tombstoneDistDir) {
+    rmSync(tombstoneDistDir, { recursive: true, force: true });
+  }
+
+  if (GITHUB_OUTPUT) {
+    appendFileSync(GITHUB_OUTPUT, `tombstoned=${tombstoned}\n`);
+  }
+
+  console.log(tombstoned ? `Branch ${slug} tombstoned.` : `No tombstone published for ${slug}.`);
+
+  return tombstoned;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    await publishBranchTombstone();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/pages/publishBranchTombstone.test.mjs
+++ b/scripts/pages/publishBranchTombstone.test.mjs
@@ -9,6 +9,7 @@ vi.mock('./lib/ghPagesBranch.mjs', () => ({
   }),
 }));
 
+const { withGhPagesBranch } = await import('./lib/ghPagesBranch.mjs');
 const { publishBranchTombstone } = await import('./publishBranchTombstone.mjs');
 
 let workDir = '';
@@ -120,6 +121,35 @@ describe('publishBranchTombstone behavior', () => {
       GITHUB_TOKEN: 'token',
       GITHUB_REPOSITORY: 'owner/repo',
     });
+
+    const tmpEntriesAfter = readdirSync(tmpdir()).filter((name) =>
+      name.startsWith('branch-tombstone-'),
+    );
+
+    expect(tmpEntriesAfter.filter((name) => !tmpEntriesBefore.has(name))).toEqual([]);
+  });
+
+  it('removes the temporary tombstone dist directory even when publish fails after it is created', async () => {
+    mkdirSync(join(workDir, 'branch', 'develop'), { recursive: true });
+    writeFileSync(join(workDir, 'branch', 'develop', 'index.html'), '<app/>');
+
+    const tmpEntriesBefore = new Set(
+      readdirSync(tmpdir()).filter((name) => name.startsWith('branch-tombstone-')),
+    );
+
+    vi.mocked(withGhPagesBranch).mockImplementationOnce(async ({ fn }) => {
+      // Simulate applyBranchPublish having already created the temp dist dir
+      // (via fn) before a later publish step (e.g. git push) fails.
+      await fn(workDir);
+      throw new Error('simulated publish failure after temp dir creation');
+    });
+
+    await expect(
+      publishBranchTombstone(['--slug', 'develop'], {
+        GITHUB_TOKEN: 'token',
+        GITHUB_REPOSITORY: 'owner/repo',
+      }),
+    ).rejects.toThrow('simulated publish failure after temp dir creation');
 
     const tmpEntriesAfter = readdirSync(tmpdir()).filter((name) =>
       name.startsWith('branch-tombstone-'),

--- a/scripts/pages/publishBranchTombstone.test.mjs
+++ b/scripts/pages/publishBranchTombstone.test.mjs
@@ -1,0 +1,130 @@
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./lib/ghPagesBranch.mjs', () => ({
+  withGhPagesBranch: vi.fn(async ({ fn }) => {
+    await fn(workDir);
+  }),
+}));
+
+const { publishBranchTombstone } = await import('./publishBranchTombstone.mjs');
+
+let workDir = '';
+let outputFile = '';
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'pages-work-'));
+  outputFile = join(mkdtempSync(join(tmpdir(), 'pages-output-')), 'github-output.txt');
+});
+
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true });
+  rmSync(outputFile, { force: true });
+});
+
+describe('publishBranchTombstone argument validation', () => {
+  it('throws when --slug argument is missing', async () => {
+    await expect(
+      publishBranchTombstone([], { GITHUB_TOKEN: 'token', GITHUB_REPOSITORY: 'owner/repo' }),
+    ).rejects.toThrow('Usage:');
+  });
+
+  it('throws when the slug is invalid', async () => {
+    await expect(
+      publishBranchTombstone(['--slug', '../etc'], {
+        GITHUB_TOKEN: 'token',
+        GITHUB_REPOSITORY: 'owner/repo',
+      }),
+    ).rejects.toThrow('Invalid branch slug');
+  });
+
+  it('throws when GITHUB_TOKEN is missing', async () => {
+    await expect(
+      publishBranchTombstone(['--slug', 'develop'], { GITHUB_REPOSITORY: 'owner/repo' }),
+    ).rejects.toThrow('GITHUB_TOKEN is required');
+  });
+});
+
+describe('publishBranchTombstone behavior', () => {
+  it('is a no-op when the branch slot does not exist', async () => {
+    const tombstoned = await publishBranchTombstone(['--slug', 'develop'], {
+      GITHUB_TOKEN: 'token',
+      GITHUB_REPOSITORY: 'owner/repo',
+      GITHUB_OUTPUT: outputFile,
+    });
+
+    expect(tombstoned).toBe(false);
+    expect(readFileSync(outputFile, 'utf8')).toBe('tombstoned=false\n');
+  });
+
+  it('replaces an existing branch slot with tombstone content', async () => {
+    mkdirSync(join(workDir, 'branch', 'develop'), { recursive: true });
+    writeFileSync(join(workDir, 'branch', 'develop', 'index.html'), '<old develop app/>');
+    writeFileSync(join(workDir, 'branch', 'develop', 'sw.js'), '// old sw');
+
+    const tombstoned = await publishBranchTombstone(['--slug', 'develop'], {
+      GITHUB_TOKEN: 'token',
+      GITHUB_REPOSITORY: 'owner/repo',
+      GITHUB_OUTPUT: outputFile,
+    });
+
+    expect(tombstoned).toBe(true);
+    expect(readFileSync(outputFile, 'utf8')).toBe('tombstoned=true\n');
+
+    const html = readFileSync(join(workDir, 'branch', 'develop', 'index.html'), 'utf8');
+    expect(html).toContain('removed');
+    expect(html).not.toContain('old develop app');
+
+    const sw = readFileSync(join(workDir, 'branch', 'develop', 'sw.js'), 'utf8');
+    expect(sw).toContain('branch-develop-');
+
+    const manifest = JSON.parse(
+      readFileSync(join(workDir, 'branch', 'develop', 'manifest.webmanifest'), 'utf8'),
+    );
+    expect(manifest.scope).toBe('/branch/develop/');
+
+    const deployment = JSON.parse(
+      readFileSync(join(workDir, 'branch', 'develop', 'deployment.json'), 'utf8'),
+    );
+    expect(deployment.tombstone).toBe(true);
+    expect(deployment.channelId).toBe('develop');
+  });
+
+  it('does not modify other branch slots or stable root', async () => {
+    mkdirSync(join(workDir, 'branch', 'develop'), { recursive: true });
+    writeFileSync(join(workDir, 'branch', 'develop', 'index.html'), '<app/>');
+    mkdirSync(join(workDir, 'branch', 'other'), { recursive: true });
+    writeFileSync(join(workDir, 'branch', 'other', 'index.html'), '<other/>');
+    writeFileSync(join(workDir, 'index.html'), '<stable/>');
+
+    await publishBranchTombstone(['--slug', 'develop'], {
+      GITHUB_TOKEN: 'token',
+      GITHUB_REPOSITORY: 'owner/repo',
+    });
+
+    expect(readFileSync(join(workDir, 'branch', 'other', 'index.html'), 'utf8')).toBe('<other/>');
+    expect(readFileSync(join(workDir, 'index.html'), 'utf8')).toBe('<stable/>');
+  });
+
+  it('does not leave a temporary tombstone build directory behind', async () => {
+    mkdirSync(join(workDir, 'branch', 'develop'), { recursive: true });
+    writeFileSync(join(workDir, 'branch', 'develop', 'index.html'), '<app/>');
+
+    const tmpEntriesBefore = new Set(
+      readdirSync(tmpdir()).filter((name) => name.startsWith('branch-tombstone-')),
+    );
+
+    await publishBranchTombstone(['--slug', 'develop'], {
+      GITHUB_TOKEN: 'token',
+      GITHUB_REPOSITORY: 'owner/repo',
+    });
+
+    const tmpEntriesAfter = readdirSync(tmpdir()).filter((name) =>
+      name.startsWith('branch-tombstone-'),
+    );
+
+    expect(tmpEntriesAfter.filter((name) => !tmpEntriesBefore.has(name))).toEqual([]);
+  });
+});

--- a/scripts/pages/writeDeploymentMetadata.mjs
+++ b/scripts/pages/writeDeploymentMetadata.mjs
@@ -1,0 +1,60 @@
+/**
+ * Write a `deployment.json` file into a build output directory, describing
+ * the channel, source, and build facts for that deployment
+ * (see `docs/release.md#organization-pages-deployment-model`).
+ *
+ * Usage:
+ *   node scripts/pages/writeDeploymentMetadata.mjs \
+ *     --dist ./dist --channel stable --channel-id main --base-url / \
+ *     [--ref refs/heads/main] [--branch main] [--slug develop] \
+ *     [--sha abc123] [--app-version 0.1.0] [--build-date 2026-07-03T00:00:00.000Z] \
+ *     [--tombstone]
+ */
+
+import { pathToFileURL } from 'node:url';
+
+import { buildDeploymentMetadata, writeDeploymentMetadataFile } from './lib/deploymentMetadata.mjs';
+
+function readFlag(argv, flag) {
+  const index = argv.indexOf(flag);
+  return index !== -1 ? argv[index + 1] : undefined;
+}
+
+/**
+ * @param argv Process arguments (`process.argv.slice(2)`).
+ */
+export function writeDeploymentMetadata(argv = process.argv.slice(2)) {
+  const distDir = readFlag(argv, '--dist');
+  if (!distDir) {
+    throw new Error(
+      'Usage: writeDeploymentMetadata.mjs --dist <dir> --channel <channel> --channel-id <id> --base-url <base>',
+    );
+  }
+
+  const metadata = buildDeploymentMetadata({
+    channel: readFlag(argv, '--channel'),
+    channelId: readFlag(argv, '--channel-id'),
+    baseUrl: readFlag(argv, '--base-url'),
+    ref: readFlag(argv, '--ref'),
+    branch: readFlag(argv, '--branch'),
+    slug: readFlag(argv, '--slug'),
+    sha: readFlag(argv, '--sha'),
+    appVersion: readFlag(argv, '--app-version'),
+    buildDate: readFlag(argv, '--build-date'),
+    tombstone: argv.includes('--tombstone'),
+  });
+
+  writeDeploymentMetadataFile(distDir, metadata);
+  console.log(
+    `Wrote deployment.json to ${distDir}/deployment.json (channel: ${metadata.channel}/${metadata.channelId}).`,
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    writeDeploymentMetadata();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/pages/writeDeploymentMetadata.test.mjs
+++ b/scripts/pages/writeDeploymentMetadata.test.mjs
@@ -1,0 +1,83 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { writeDeploymentMetadata } from './writeDeploymentMetadata.mjs';
+
+let distDir = '';
+
+beforeEach(() => {
+  distDir = mkdtempSync(join(tmpdir(), 'pages-dist-'));
+});
+
+afterEach(() => {
+  rmSync(distDir, { recursive: true, force: true });
+});
+
+describe('writeDeploymentMetadata', () => {
+  it('writes deployment.json with the given flags', () => {
+    writeDeploymentMetadata([
+      '--dist',
+      distDir,
+      '--channel',
+      'branch',
+      '--channel-id',
+      'develop',
+      '--base-url',
+      '/branch/develop/',
+      '--ref',
+      'refs/heads/develop',
+      '--branch',
+      'develop',
+      '--slug',
+      'develop',
+      '--sha',
+      'abc123',
+      '--app-version',
+      '0.1.0',
+      '--build-date',
+      '2026-07-03T00:00:00.000Z',
+    ]);
+
+    const written = JSON.parse(readFileSync(join(distDir, 'deployment.json'), 'utf8'));
+    expect(written).toEqual({
+      channel: 'branch',
+      channelId: 'develop',
+      baseUrl: '/branch/develop/',
+      buildDate: '2026-07-03T00:00:00.000Z',
+      ref: 'refs/heads/develop',
+      branch: 'develop',
+      slug: 'develop',
+      sha: 'abc123',
+      appVersion: '0.1.0',
+    });
+  });
+
+  it('sets tombstone: true when --tombstone is passed', () => {
+    writeDeploymentMetadata([
+      '--dist',
+      distDir,
+      '--channel',
+      'branch',
+      '--channel-id',
+      'feature-x',
+      '--base-url',
+      '/branch/feature-x/',
+      '--build-date',
+      '2026-07-03T00:00:00.000Z',
+      '--tombstone',
+    ]);
+
+    const written = JSON.parse(readFileSync(join(distDir, 'deployment.json'), 'utf8'));
+    expect(written.tombstone).toBe(true);
+  });
+
+  it('throws when --dist is missing', () => {
+    expect(() => writeDeploymentMetadata(['--channel', 'stable'])).toThrow('Usage:');
+  });
+
+  it('throws when a required buildDeploymentMetadata field is missing', () => {
+    expect(() => writeDeploymentMetadata(['--dist', distDir])).toThrow('channel is required');
+  });
+});

--- a/scripts/pages/writeSpaFallback.mjs
+++ b/scripts/pages/writeSpaFallback.mjs
@@ -1,14 +1,22 @@
 /**
- * Write the root GitHub Pages 404.html SPA fallback dispatcher.
+ * Write the org-root GitHub Pages 404.html SPA fallback dispatcher.
  *
- * GitHub Pages serves the root 404.html for any URL that maps to no physical
- * file in the deployment.  The inline script detects whether the 404'd path
- * belongs to a PR preview slot or the stable app, redirects to the correct
- * index.html root, and stores the original path in sessionStorage so the app
- * can restore it via History API after loading.
+ * GitHub Pages serves the single site-wide root 404.html for any URL that
+ * maps to no physical file anywhere in the Mioframe/mioframe.github.io
+ * deployment. The inline script classifies the 404'd path into one of the
+ * three channel roots (stable `/`, a branch `/branch/<slug>/`, or a PR
+ * preview `/pr/<number>/`), redirects to that root's index.html, and stores
+ * the original path in sessionStorage so the app can restore it via the
+ * History API after loading (see `src/app/ghPagesSpaFallback.ts`).
+ *
+ * This file is root-owned: only the stable publish job writes it, since
+ * stable publish is the only publisher that touches the repository root.
+ * Branch and PR preview publishers never write it, and its content does not
+ * depend on which channel triggered the write — it is safe to regenerate
+ * from any deployment.
  *
  * Usage:
- *   node scripts/pages/writeSpaFallback.mjs --base /mioframe/ --output-dir ./pages-staging
+ *   node scripts/pages/writeSpaFallback.mjs --output-dir ./pages-staging
  */
 
 import { writeFileSync } from 'node:fs';
@@ -18,29 +26,24 @@ import { pathToFileURL } from 'node:url';
 /**
  * Classify a URL pathname for the SPA fallback redirect.
  * @param pathname - `window.location.pathname` of the 404'd URL.
- * @param base - Repository base path, e.g. `/mioframe/`.
- * @returns The index.html root to redirect to (`base` for stable,
- *   `base + pr-N/` for PR previews), or `null` when the path is outside the
- *   repository base and should remain a genuine 404.
+ * @returns The index.html root to redirect to: `/` for stable, `/branch/<slug>/`
+ *   for a branch deployment, or `/pr/<number>/` for a PR preview.
  */
-export function classifySpaPath(pathname, base) {
-  if (!pathname.startsWith(base)) return null;
-  const rest = pathname.slice(base.length);
-  const prMatch = rest.match(/^(pr-\d+)(?:\/|$)/);
-  return prMatch ? base + prMatch[1] + '/' : base;
+export function classifySpaPath(pathname) {
+  const branchMatch = pathname.match(/^\/branch\/([^/]+)(?:\/|$)/);
+  if (branchMatch) return `/branch/${branchMatch[1]}/`;
+
+  const prMatch = pathname.match(/^\/pr\/(\d+)(?:\/|$)/);
+  if (prMatch) return `/pr/${prMatch[1]}/`;
+
+  return '/';
 }
 
 /**
- * Build the HTML content for the root GitHub Pages SPA fallback.
- *
- * The generated `404.html` is served by GitHub Pages for every missing path
- * under the deployment.  Its inline script classifies the path, stores it in
- * `sessionStorage` for post-load restoration, and redirects to the right
- * index.html root without exposing the app to a 404 error page.
- * @param base - The Vite base path, e.g. `/mioframe/`.
+ * Build the HTML content for the org-root GitHub Pages SPA fallback.
  * @returns HTML string for `404.html`.
  */
-export function buildSpaFallbackHtml(base) {
+export function buildSpaFallbackHtml() {
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -48,17 +51,14 @@ export function buildSpaFallbackHtml(base) {
   <title>Redirecting…</title>
   <script>
     (function () {
-      var base = ${JSON.stringify(base)};
       var path = window.location.pathname;
-
-      if (!path.startsWith(base)) {
-        // Path is outside the repository base — genuine 404.
-        return;
-      }
-
-      var rest = path.slice(base.length);
-      var prMatch = rest.match(/^(pr-\\d+)(?:\\/|$)/);
-      var targetRoot = prMatch ? base + prMatch[1] + '/' : base;
+      var branchMatch = path.match(/^\\/branch\\/([^/]+)(?:\\/|$)/);
+      var prMatch = path.match(/^\\/pr\\/(\\d+)(?:\\/|$)/);
+      var targetRoot = branchMatch
+        ? '/branch/' + branchMatch[1] + '/'
+        : prMatch
+          ? '/pr/' + prMatch[1] + '/'
+          : '/';
 
       sessionStorage.setItem('ghPagesSpaFallback', path + window.location.search + window.location.hash);
       window.location.replace(targetRoot);
@@ -74,22 +74,17 @@ export function buildSpaFallbackHtml(base) {
  * @param argv Process arguments (`process.argv.slice(2)`).
  */
 export function writeSpaFallback(argv = process.argv.slice(2)) {
-  const baseIndex = argv.indexOf('--base');
   const outputIndex = argv.indexOf('--output-dir');
 
-  if (baseIndex === -1 || !argv[baseIndex + 1]) {
-    throw new Error('Usage: writeSpaFallback.mjs --base <base-path> --output-dir <dir>');
-  }
   if (outputIndex === -1 || !argv[outputIndex + 1]) {
-    throw new Error('Usage: writeSpaFallback.mjs --base <base-path> --output-dir <dir>');
+    throw new Error('Usage: writeSpaFallback.mjs --output-dir <dir>');
   }
 
-  const base = argv[baseIndex + 1];
   const outputDir = argv[outputIndex + 1];
 
-  const html = buildSpaFallbackHtml(base);
+  const html = buildSpaFallbackHtml();
   writeFileSync(join(outputDir, '404.html'), html, 'utf8');
-  console.log(`Wrote SPA fallback 404.html to ${outputDir}/404.html (base: ${base})`);
+  console.log(`Wrote SPA fallback 404.html to ${outputDir}/404.html`);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/scripts/pages/writeSpaFallback.test.mjs
+++ b/scripts/pages/writeSpaFallback.test.mjs
@@ -6,93 +6,76 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { buildSpaFallbackHtml, classifySpaPath, writeSpaFallback } from './writeSpaFallback.mjs';
 
 describe('classifySpaPath', () => {
-  it('redirects a stable deep link to the base root', () => {
-    expect(classifySpaPath('/mioframe/home', '/mioframe/')).toBe('/mioframe/');
+  it('redirects a stable deep link to the site root', () => {
+    expect(classifySpaPath('/home')).toBe('/');
+    expect(classifySpaPath('/settings/documents')).toBe('/');
   });
 
-  it('redirects a stable nested path to the base root', () => {
-    expect(classifySpaPath('/mioframe/settings/documents', '/mioframe/')).toBe('/mioframe/');
+  it('redirects the root itself to the root (no infinite loop risk)', () => {
+    expect(classifySpaPath('/')).toBe('/');
   });
 
-  it('redirects a PR preview path to its own root', () => {
-    expect(classifySpaPath('/mioframe/pr-86/home', '/mioframe/')).toBe('/mioframe/pr-86/');
+  it('redirects a branch deep link to its own branch root', () => {
+    expect(classifySpaPath('/branch/develop/home')).toBe('/branch/develop/');
+    expect(classifySpaPath('/branch/develop/settings/documents')).toBe('/branch/develop/');
   });
 
-  it('redirects a deeply nested PR preview path to its own root', () => {
-    expect(classifySpaPath('/mioframe/pr-86/settings/documents', '/mioframe/')).toBe(
-      '/mioframe/pr-86/',
-    );
+  it('redirects a manual branch slug deep link to its own root', () => {
+    expect(classifySpaPath('/branch/feature-x/a/b/c')).toBe('/branch/feature-x/');
   });
 
-  it('handles different PR numbers without hard-coding', () => {
-    expect(classifySpaPath('/mioframe/pr-1/page', '/mioframe/')).toBe('/mioframe/pr-1/');
-    expect(classifySpaPath('/mioframe/pr-999/page', '/mioframe/')).toBe('/mioframe/pr-999/');
-    expect(classifySpaPath('/mioframe/pr-123/a/b/c', '/mioframe/')).toBe('/mioframe/pr-123/');
+  it('redirects a PR preview deep link to its own root', () => {
+    expect(classifySpaPath('/pr/86/home')).toBe('/pr/86/');
+    expect(classifySpaPath('/pr/1/page')).toBe('/pr/1/');
+    expect(classifySpaPath('/pr/999/a/b/c')).toBe('/pr/999/');
   });
 
-  it('returns null for paths outside the repository base (genuine 404)', () => {
-    expect(classifySpaPath('/other/path', '/mioframe/')).toBeNull();
-    expect(classifySpaPath('/', '/mioframe/')).toBeNull();
-    expect(classifySpaPath('/different-repo/home', '/mioframe/')).toBeNull();
+  it('treats a non-numeric segment after /pr/ as a stable path (genuine unmatched route)', () => {
+    expect(classifySpaPath('/pr/preview/page')).toBe('/');
   });
 
-  it('handles a different base path', () => {
-    expect(classifySpaPath('/other-repo/home', '/other-repo/')).toBe('/other-repo/');
-    expect(classifySpaPath('/other-repo/pr-42/page', '/other-repo/')).toBe('/other-repo/pr-42/');
-  });
-
-  it('redirects the base root itself to base (no infinite loop risk)', () => {
-    expect(classifySpaPath('/mioframe/', '/mioframe/')).toBe('/mioframe/');
+  it('redirects the branch/pr namespace roots themselves without a trailing segment', () => {
+    expect(classifySpaPath('/branch/develop')).toBe('/branch/develop/');
+    expect(classifySpaPath('/pr/42')).toBe('/pr/42/');
   });
 });
 
 describe('buildSpaFallbackHtml', () => {
-  it('contains the base path as a literal string', () => {
-    const html = buildSpaFallbackHtml('/mioframe/');
-    expect(html).toContain('"/mioframe/"');
+  it('does not hard-code a specific branch slug or PR number', () => {
+    const html = buildSpaFallbackHtml();
+    expect(html).not.toMatch(/\/branch\/[a-z0-9-]+\//);
+    expect(html).not.toMatch(/\/pr\/\d+\//);
   });
 
-  it('does not hard-code a specific PR number', () => {
-    const html = buildSpaFallbackHtml('/mioframe/');
-    expect(html).not.toMatch(/pr-\d+/);
+  it('dispatches on /branch/ and /pr/ path prefixes', () => {
+    const html = buildSpaFallbackHtml();
+    expect(html).toContain('/^\\/branch\\/([^/]+)(?:\\/|$)/');
+    expect(html).toContain('/^\\/pr\\/(\\d+)(?:\\/|$)/');
   });
 
-  it('uses a different base when one is provided', () => {
-    const html = buildSpaFallbackHtml('/other-repo/');
-    expect(html).toContain('"/other-repo/"');
-    expect(html).not.toContain('"/mioframe/"');
+  it('falls back to the root for unmatched paths', () => {
+    const html = buildSpaFallbackHtml();
+    expect(html).toContain(": '/';");
   });
 
   it('stores the original path in sessionStorage for restoration', () => {
-    const html = buildSpaFallbackHtml('/mioframe/');
+    const html = buildSpaFallbackHtml();
     expect(html).toContain("sessionStorage.setItem('ghPagesSpaFallback'");
   });
 
   it('stores the hash with the original path when one is present', () => {
-    const html = buildSpaFallbackHtml('/mioframe/');
+    const html = buildSpaFallbackHtml();
     expect(html).toContain('window.location.hash');
   });
 
-  it('redirects to PR preview root when path matches pr-N pattern', () => {
-    const html = buildSpaFallbackHtml('/mioframe/');
-    expect(html).toContain("base + prMatch[1] + '/'");
-  });
-
-  it('falls back to base root for stable paths', () => {
-    const html = buildSpaFallbackHtml('/mioframe/');
-    expect(html).toContain('var targetRoot = prMatch ? base + prMatch[1] +');
-  });
-
-  it('exits without redirecting when path is outside the base', () => {
-    const html = buildSpaFallbackHtml('/mioframe/');
-    expect(html).toContain('if (!path.startsWith(base))');
-    expect(html).toContain('return;');
-  });
-
   it('produces valid HTML', () => {
-    const html = buildSpaFallbackHtml('/mioframe/');
+    const html = buildSpaFallbackHtml();
     expect(html).toContain('<!doctype html>');
     expect(html).toContain('</html>');
+  });
+
+  it('produces identical output regardless of caller (channel-independent)', () => {
+    expect(buildSpaFallbackHtml()).toBe(buildSpaFallbackHtml());
   });
 });
 
@@ -108,23 +91,12 @@ describe('writeSpaFallback', () => {
   });
 
   it('writes a 404.html to the output directory', () => {
-    writeSpaFallback(['--base', '/mioframe/', '--output-dir', outputDir]);
+    writeSpaFallback(['--output-dir', outputDir]);
     const content = readFileSync(join(outputDir, '404.html'), 'utf8');
     expect(content).toContain('<!doctype html>');
-    expect(content).toContain('"/mioframe/"');
-  });
-
-  it('bakes the provided base path into the file', () => {
-    writeSpaFallback(['--base', '/custom-repo/', '--output-dir', outputDir]);
-    const content = readFileSync(join(outputDir, '404.html'), 'utf8');
-    expect(content).toContain('"/custom-repo/"');
-  });
-
-  it('throws when --base is missing', () => {
-    expect(() => writeSpaFallback(['--output-dir', outputDir])).toThrow('Usage:');
   });
 
   it('throws when --output-dir is missing', () => {
-    expect(() => writeSpaFallback(['--base', '/mioframe/'])).toThrow('Usage:');
+    expect(() => writeSpaFallback([])).toThrow('Usage:');
   });
 });

--- a/scripts/release/artifactServer.mjs
+++ b/scripts/release/artifactServer.mjs
@@ -33,8 +33,8 @@ function getContentType(filePath) {
  * Resolve a decoded request pathname to a dist file path under a deployment
  * base path, guarding against path traversal outside `distDir`.
  * @param distDir Absolute production build output directory.
- * @param basePath Deployment base path, e.g. `/mioframe/`.
- * @param pathname Decoded request pathname, e.g. `/mioframe/assets/app.js`.
+ * @param basePath Deployment base path, e.g. `/`.
+ * @param pathname Decoded request pathname, e.g. `/assets/app.js`.
  * @returns Absolute candidate file path, or `null` when the pathname is
  * outside `basePath` or would escape `distDir`.
  */
@@ -73,13 +73,13 @@ async function readExistingFile(filePath) {
  * `404.html` across the whole Pages site.
  * @param options Server configuration.
  * @param options.distDir Absolute or relative production build output directory.
- * @param options.basePath Deployment base path, e.g. `/mioframe/`.
+ * @param options.basePath Deployment base path, e.g. `/`.
  * @param [options.host] Host to bind to.
  * @param [options.port] Port to bind to; `0` picks a free port.
  * @returns Running server handle with its base URL and a `close` function.
  */
 export function createArtifactServer({ distDir, basePath, host = '127.0.0.1', port = 0 }) {
-  const fallbackHtml = buildSpaFallbackHtml(basePath);
+  const fallbackHtml = buildSpaFallbackHtml();
 
   const server = createServer((req, res) => {
     void handleRequest(req, res, { distDir, basePath, fallbackHtml });

--- a/scripts/release/artifactServer.test.mjs
+++ b/scripts/release/artifactServer.test.mjs
@@ -11,27 +11,25 @@ import { createArtifactServer, resolveArtifactFilePath } from './artifactServer.
 
 describe('resolveArtifactFilePath', () => {
   it('maps the base root to index.html', () => {
-    expect(resolveArtifactFilePath('dist', '/mioframe/', '/mioframe/')).toBe(
-      resolve('dist', 'index.html'),
-    );
+    expect(resolveArtifactFilePath('dist', '/', '/')).toBe(resolve('dist', 'index.html'));
   });
 
   it('maps a nested asset path under the base', () => {
-    expect(resolveArtifactFilePath('dist', '/mioframe/', '/mioframe/assets/app.js')).toBe(
+    expect(resolveArtifactFilePath('dist', '/', '/assets/app.js')).toBe(
       resolve('dist', 'assets', 'app.js'),
     );
   });
 
-  it('returns null for a path outside the base', () => {
-    expect(resolveArtifactFilePath('dist', '/mioframe/', '/other/app.js')).toBeNull();
+  it('returns null for a path outside a non-root base', () => {
+    expect(resolveArtifactFilePath('dist', '/branch/develop/', '/other/app.js')).toBeNull();
   });
 
   it('returns null when a path traversal would escape distDir', () => {
-    expect(resolveArtifactFilePath('dist', '/mioframe/', '/mioframe/../../etc/passwd')).toBeNull();
+    expect(resolveArtifactFilePath('dist', '/', '/../../etc/passwd')).toBeNull();
   });
 
   it('keeps a distDir-relative path that stays within distDir', () => {
-    const filePath = resolveArtifactFilePath('dist', '/mioframe/', '/mioframe/sub/dir/file.txt');
+    const filePath = resolveArtifactFilePath('dist', '/', '/sub/dir/file.txt');
     expect(filePath).toBe(resolve('dist', 'sub', 'dir', 'file.txt'));
     expect(filePath.startsWith(resolve('dist') + sep)).toBe(true);
   });
@@ -53,7 +51,7 @@ describe('createArtifactServer', () => {
   });
 
   it('serves an existing file under the base path with a 200 status', async () => {
-    server = await createArtifactServer({ distDir, basePath: '/mioframe/' });
+    server = await createArtifactServer({ distDir, basePath: '/' });
 
     const response = await fetch(`${server.url}manifest.webmanifest`);
     expect(response.status).toBe(200);
@@ -61,7 +59,7 @@ describe('createArtifactServer', () => {
   });
 
   it('serves index.html at the base root', async () => {
-    server = await createArtifactServer({ distDir, basePath: '/mioframe/' });
+    server = await createArtifactServer({ distDir, basePath: '/' });
 
     const response = await fetch(server.url);
     expect(response.status).toBe(200);
@@ -69,19 +67,18 @@ describe('createArtifactServer', () => {
   });
 
   it('returns the site-wide SPA fallback with a 404 status for an unmatched deep route', async () => {
-    server = await createArtifactServer({ distDir, basePath: '/mioframe/' });
+    server = await createArtifactServer({ distDir, basePath: '/' });
 
     const response = await fetch(`${server.url}some/deep/route`);
     expect(response.status).toBe(404);
     const body = await response.text();
-    expect(body).toContain('"/mioframe/"');
     expect(body).toContain("sessionStorage.setItem('ghPagesSpaFallback'");
   });
 
-  it('returns the same fallback for a path outside the base', async () => {
-    server = await createArtifactServer({ distDir, basePath: '/mioframe/' });
+  it('returns the same fallback for a path outside a non-root base', async () => {
+    server = await createArtifactServer({ distDir, basePath: '/branch/develop/' });
 
-    const response = await fetch(`${server.url.replace(/\/mioframe\/$/, '/')}other-app/`);
+    const response = await fetch(`${server.url.replace(/\/branch\/develop\/$/, '/')}other-app/`);
     expect(response.status).toBe(404);
   });
 });

--- a/scripts/release/buildArtifact.mjs
+++ b/scripts/release/buildArtifact.mjs
@@ -17,7 +17,7 @@ const defaultDeps = {
  * Resolve the GitHub Pages base path for a release artifact build.
  * @param [argv] Raw CLI arguments.
  * @param [env] Process environment.
- * @returns Resolved base path, e.g. `/mioframe/`.
+ * @returns Resolved base path, e.g. `/`.
  */
 export function resolveArtifactBasePath(argv = process.argv.slice(2), env = process.env) {
   const baseIndex = argv.indexOf('--base');

--- a/scripts/release/buildArtifact.test.mjs
+++ b/scripts/release/buildArtifact.test.mjs
@@ -11,7 +11,7 @@ import {
 
 describe('resolveArtifactBasePath', () => {
   it('uses the tooling.json release base path by default', () => {
-    expect(resolveArtifactBasePath([], {})).toBe('/mioframe/');
+    expect(resolveArtifactBasePath([], {})).toBe('/');
   });
 
   it('prefers an explicit --base flag', () => {

--- a/scripts/release/validateReleaseConfig.mjs
+++ b/scripts/release/validateReleaseConfig.mjs
@@ -2,7 +2,8 @@ import { readFileSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
 
 const OPTIONAL_ENV_KEYS = ['VITE_GOOGLE_CLIENT_ID', 'VITE_SENTRY_DSN', 'SENTRY_AUTH_TOKEN'];
-const PR_PREVIEW_PATH_PATTERN = /\/pr-\d+\/?/;
+const STABLE_BASE_PATH = '/';
+const BRANCH_OR_PR_PATH_PATTERN = /^\/(?:branch|pr)\//;
 
 /**
  * Read and parse a JSON file, for release config validation.
@@ -35,21 +36,7 @@ export function validateReleaseConfig({ env = process.env, deps = {} } = {}) {
   const errors = [];
   const notices = [];
 
-  let packageJson;
   let toolingConfig;
-
-  try {
-    packageJson = readJson('package.json', readFile);
-  } catch (readError) {
-    return finish({
-      errors: [
-        `Unable to read/parse package.json: ${readError instanceof Error ? readError.message : String(readError)}`,
-      ],
-      notices,
-      log,
-      logError,
-    });
-  }
 
   try {
     toolingConfig = readJson('config/tooling.json', readFile);
@@ -64,22 +51,17 @@ export function validateReleaseConfig({ env = process.env, deps = {} } = {}) {
     });
   }
 
-  if (typeof packageJson.name !== 'string' || packageJson.name.trim() === '') {
-    errors.push('package.json is missing a string "name" field.');
-  }
-
-  const expectedBasePath = `/${packageJson.name}/`;
   const actualBasePath = toolingConfig.release?.basePath;
 
   if (typeof actualBasePath !== 'string' || actualBasePath.trim() === '') {
     errors.push('config/tooling.json is missing release.basePath.');
-  } else if (actualBasePath !== expectedBasePath) {
+  } else if (actualBasePath !== STABLE_BASE_PATH) {
     errors.push(
-      `config/tooling.json release.basePath "${actualBasePath}" does not match "${expectedBasePath}" derived from package.json name "${packageJson.name}". ` +
+      `config/tooling.json release.basePath "${actualBasePath}" must be "${STABLE_BASE_PATH}" for the organization root Pages deployment. ` +
         'Release artifact validation, stable deploy, and GitHub Pages hosting must all agree on this base path.',
     );
   } else {
-    notices.push(`release base path: ${expectedBasePath}`);
+    notices.push(`release base path: ${STABLE_BASE_PATH}`);
   }
 
   if (env.VITE_DISABLE_PWA === '1') {
@@ -92,21 +74,21 @@ export function validateReleaseConfig({ env = process.env, deps = {} } = {}) {
   }
 
   if (typeof env.BASE_URL === 'string' && env.BASE_URL.length > 0) {
-    if (PR_PREVIEW_PATH_PATTERN.test(env.BASE_URL)) {
+    if (BRANCH_OR_PR_PATH_PATTERN.test(env.BASE_URL)) {
       errors.push(
-        `BASE_URL "${env.BASE_URL}" looks like a PR preview path. Release artifact validation and stable deploy ` +
-          `must use the stable base path (${expectedBasePath}), not a PR preview path.`,
+        `BASE_URL "${env.BASE_URL}" looks like a branch or PR preview path. Release artifact validation and ` +
+          `stable deploy must use the stable base path (${STABLE_BASE_PATH}), not a branch or PR preview path.`,
       );
-    } else if (actualBasePath && env.BASE_URL !== actualBasePath) {
+    } else if (env.BASE_URL !== STABLE_BASE_PATH) {
       errors.push(
-        `BASE_URL "${env.BASE_URL}" does not match config/tooling.json release.basePath "${actualBasePath}".`,
+        `BASE_URL "${env.BASE_URL}" does not match the stable base path "${STABLE_BASE_PATH}".`,
       );
     } else {
       notices.push(`BASE_URL: ${env.BASE_URL}`);
     }
   } else {
     notices.push(
-      `BASE_URL: not set; release tooling falls back to config/tooling.json release.basePath (${expectedBasePath}).`,
+      `BASE_URL: not set; release tooling falls back to config/tooling.json release.basePath (${STABLE_BASE_PATH}).`,
     );
   }
 

--- a/scripts/release/validateReleaseConfig.test.mjs
+++ b/scripts/release/validateReleaseConfig.test.mjs
@@ -5,12 +5,8 @@ import { validateReleaseConfig } from './validateReleaseConfig.mjs';
 describe('validateReleaseConfig', () => {
   const baseDeps = () => ({
     readFile: vi.fn((filePath) => {
-      if (filePath === 'package.json') {
-        return JSON.stringify({ name: 'mioframe' });
-      }
-
       if (filePath === 'config/tooling.json') {
-        return JSON.stringify({ release: { basePath: '/mioframe/' } });
+        return JSON.stringify({ release: { basePath: '/' } });
       }
 
       throw new Error(`unexpected readFile: ${filePath}`);
@@ -19,33 +15,29 @@ describe('validateReleaseConfig', () => {
     logError: vi.fn(),
   });
 
-  it('passes with a matching base path, PWA enabled, and no env set', () => {
+  it('passes with the stable base path, PWA enabled, and no env set', () => {
     const deps = baseDeps();
     const result = validateReleaseConfig({ env: {}, deps });
     expect(result).toBe(true);
     expect(deps.logError).not.toHaveBeenCalled();
   });
 
-  it('fails when release.basePath does not match package.json name', () => {
+  it('fails when release.basePath is not "/"', () => {
     const deps = baseDeps();
     deps.readFile = vi.fn((filePath) => {
-      if (filePath === 'package.json') return JSON.stringify({ name: 'mioframe' });
       if (filePath === 'config/tooling.json') {
-        return JSON.stringify({ release: { basePath: '/wrong/' } });
+        return JSON.stringify({ release: { basePath: '/mioframe/' } });
       }
       throw new Error(`unexpected readFile: ${filePath}`);
     });
     const result = validateReleaseConfig({ env: {}, deps });
     expect(result).toBe(false);
-    expect(deps.logError).toHaveBeenCalledWith(
-      expect.stringContaining('does not match "/mioframe/"'),
-    );
+    expect(deps.logError).toHaveBeenCalledWith(expect.stringContaining('must be "/"'));
   });
 
   it('fails when release.basePath is missing', () => {
     const deps = baseDeps();
     deps.readFile = vi.fn((filePath) => {
-      if (filePath === 'package.json') return JSON.stringify({ name: 'mioframe' });
       if (filePath === 'config/tooling.json') return JSON.stringify({ release: {} });
       throw new Error(`unexpected readFile: ${filePath}`);
     });
@@ -61,25 +53,36 @@ describe('validateReleaseConfig', () => {
     expect(deps.logError).toHaveBeenCalledWith(expect.stringContaining('VITE_DISABLE_PWA=1'));
   });
 
-  it('fails when BASE_URL looks like a PR preview path', () => {
+  it('fails when BASE_URL looks like a branch path', () => {
     const deps = baseDeps();
-    const result = validateReleaseConfig({ env: { BASE_URL: '/mioframe/pr-42/' }, deps });
+    const result = validateReleaseConfig({ env: { BASE_URL: '/branch/develop/' }, deps });
     expect(result).toBe(false);
-    expect(deps.logError).toHaveBeenCalledWith(expect.stringContaining('PR preview path'));
+    expect(deps.logError).toHaveBeenCalledWith(
+      expect.stringContaining('branch or PR preview path'),
+    );
   });
 
-  it('fails when BASE_URL does not match the configured release base path', () => {
+  it('fails when BASE_URL looks like a PR preview path', () => {
+    const deps = baseDeps();
+    const result = validateReleaseConfig({ env: { BASE_URL: '/pr/42/' }, deps });
+    expect(result).toBe(false);
+    expect(deps.logError).toHaveBeenCalledWith(
+      expect.stringContaining('branch or PR preview path'),
+    );
+  });
+
+  it('fails when BASE_URL does not match the stable base path', () => {
     const deps = baseDeps();
     const result = validateReleaseConfig({ env: { BASE_URL: '/other/' }, deps });
     expect(result).toBe(false);
     expect(deps.logError).toHaveBeenCalledWith(
-      expect.stringContaining('does not match config/tooling.json release.basePath'),
+      expect.stringContaining('does not match the stable base path'),
     );
   });
 
-  it('passes when BASE_URL matches the configured release base path', () => {
+  it('passes when BASE_URL matches the stable base path', () => {
     const deps = baseDeps();
-    const result = validateReleaseConfig({ env: { BASE_URL: '/mioframe/' }, deps });
+    const result = validateReleaseConfig({ env: { BASE_URL: '/' }, deps });
     expect(result).toBe(true);
   });
 

--- a/src/app/ghPagesSpaFallback.test.ts
+++ b/src/app/ghPagesSpaFallback.test.ts
@@ -2,195 +2,109 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { restoreGhPagesSpaFallbackPath } from './ghPagesSpaFallback';
 
+function withMockedWindow(
+  storedValue: string | null,
+  run: (history: { replaceState: ReturnType<typeof vi.fn> }) => void,
+) {
+  const getItem = vi.fn(() => storedValue);
+  const removeItem = vi.fn();
+  const replaceState = vi.fn();
+
+  const sessionStorage = { getItem, removeItem };
+  const history = { replaceState };
+
+  const originalSessionStorage = window.sessionStorage;
+  const originalHistory = window.history;
+
+  Object.defineProperty(window, 'sessionStorage', { configurable: true, value: sessionStorage });
+  Object.defineProperty(window, 'history', { configurable: true, value: history });
+
+  try {
+    run(history);
+  } finally {
+    Object.defineProperty(window, 'sessionStorage', {
+      configurable: true,
+      value: originalSessionStorage,
+    });
+    Object.defineProperty(window, 'history', { configurable: true, value: originalHistory });
+  }
+
+  return { getItem, removeItem, replaceState };
+}
+
 describe('restoreGhPagesSpaFallbackPath', () => {
   it('restores a stable deep link when the current base is stable', () => {
-    const getItem = vi.fn(() => '/mioframe/home');
-    const removeItem = vi.fn();
-    const replaceState = vi.fn();
+    const { getItem, removeItem, replaceState } = withMockedWindow('/home', () => {
+      expect(restoreGhPagesSpaFallbackPath('/')).toBe('/home');
+    });
+    expect(getItem).toHaveBeenCalledWith('ghPagesSpaFallback');
+    expect(removeItem).toHaveBeenCalledWith('ghPagesSpaFallback');
+    expect(replaceState).toHaveBeenCalledWith(null, '', '/home');
+  });
 
-    const sessionStorage = { getItem, removeItem };
-    const history = { replaceState };
-
-    const originalSessionStorage = window.sessionStorage;
-    const originalHistory = window.history;
-
-    Object.defineProperty(window, 'sessionStorage', { configurable: true, value: sessionStorage });
-    Object.defineProperty(window, 'history', { configurable: true, value: history });
-
-    try {
-      expect(restoreGhPagesSpaFallbackPath('/mioframe/')).toBe('/mioframe/home');
-      expect(getItem).toHaveBeenCalledWith('ghPagesSpaFallback');
-      expect(removeItem).toHaveBeenCalledWith('ghPagesSpaFallback');
-      expect(replaceState).toHaveBeenCalledWith(null, '', '/mioframe/home');
-    } finally {
-      Object.defineProperty(window, 'sessionStorage', {
-        configurable: true,
-        value: originalSessionStorage,
-      });
-      Object.defineProperty(window, 'history', { configurable: true, value: originalHistory });
-    }
+  it('restores a branch deep link when the current base is that branch', () => {
+    const { replaceState } = withMockedWindow('/branch/develop/settings/documents', () => {
+      expect(restoreGhPagesSpaFallbackPath('/branch/develop/')).toBe(
+        '/branch/develop/settings/documents',
+      );
+    });
+    expect(replaceState).toHaveBeenCalledWith(null, '', '/branch/develop/settings/documents');
   });
 
   it('restores a PR preview deep link when the current base is that PR preview', () => {
-    const sessionStorage = {
-      getItem: vi.fn(() => '/mioframe/pr-86/settings/documents'),
-      removeItem: vi.fn(),
-    };
-    const history = { replaceState: vi.fn() };
-
-    const originalSessionStorage = window.sessionStorage;
-    const originalHistory = window.history;
-
-    Object.defineProperty(window, 'sessionStorage', { configurable: true, value: sessionStorage });
-    Object.defineProperty(window, 'history', { configurable: true, value: history });
-
-    try {
-      expect(restoreGhPagesSpaFallbackPath('/mioframe/pr-86/')).toBe(
-        '/mioframe/pr-86/settings/documents',
-      );
-      expect(history.replaceState).toHaveBeenCalledWith(
-        null,
-        '',
-        '/mioframe/pr-86/settings/documents',
-      );
-    } finally {
-      Object.defineProperty(window, 'sessionStorage', {
-        configurable: true,
-        value: originalSessionStorage,
-      });
-      Object.defineProperty(window, 'history', { configurable: true, value: originalHistory });
-    }
+    const { replaceState } = withMockedWindow('/pr/86/settings/documents', () => {
+      expect(restoreGhPagesSpaFallbackPath('/pr/86/')).toBe('/pr/86/settings/documents');
+    });
+    expect(replaceState).toHaveBeenCalledWith(null, '', '/pr/86/settings/documents');
   });
 
   it('rejects a path outside the current base', () => {
-    const sessionStorage = {
-      getItem: vi.fn(() => '/other-repo/home'),
-      removeItem: vi.fn(),
-    };
-    const history = { replaceState: vi.fn() };
-
-    const originalSessionStorage = window.sessionStorage;
-    const originalHistory = window.history;
-
-    Object.defineProperty(window, 'sessionStorage', { configurable: true, value: sessionStorage });
-    Object.defineProperty(window, 'history', { configurable: true, value: history });
-
-    try {
-      expect(restoreGhPagesSpaFallbackPath('/mioframe/')).toBeNull();
-      expect(history.replaceState).not.toHaveBeenCalled();
-    } finally {
-      Object.defineProperty(window, 'sessionStorage', {
-        configurable: true,
-        value: originalSessionStorage,
-      });
-      Object.defineProperty(window, 'history', { configurable: true, value: originalHistory });
-    }
+    const { replaceState } = withMockedWindow('/other-repo/home', () => {
+      expect(restoreGhPagesSpaFallbackPath('/branch/develop/')).toBeNull();
+    });
+    expect(replaceState).not.toHaveBeenCalled();
   });
 
   it('rejects another PR preview path when running inside a specific PR preview base', () => {
-    const sessionStorage = {
-      getItem: vi.fn(() => '/mioframe/pr-123/home'),
-      removeItem: vi.fn(),
-    };
-    const history = { replaceState: vi.fn() };
+    const { replaceState } = withMockedWindow('/pr/123/home', () => {
+      expect(restoreGhPagesSpaFallbackPath('/pr/86/')).toBeNull();
+    });
+    expect(replaceState).not.toHaveBeenCalled();
+  });
 
-    const originalSessionStorage = window.sessionStorage;
-    const originalHistory = window.history;
+  it('rejects a branch path when running inside a different branch base', () => {
+    const { replaceState } = withMockedWindow('/branch/feature-x/home', () => {
+      expect(restoreGhPagesSpaFallbackPath('/branch/develop/')).toBeNull();
+    });
+    expect(replaceState).not.toHaveBeenCalled();
+  });
 
-    Object.defineProperty(window, 'sessionStorage', { configurable: true, value: sessionStorage });
-    Object.defineProperty(window, 'history', { configurable: true, value: history });
-
-    try {
-      expect(restoreGhPagesSpaFallbackPath('/mioframe/pr-86/')).toBeNull();
-      expect(history.replaceState).not.toHaveBeenCalled();
-    } finally {
-      Object.defineProperty(window, 'sessionStorage', {
-        configurable: true,
-        value: originalSessionStorage,
-      });
-      Object.defineProperty(window, 'history', { configurable: true, value: originalHistory });
-    }
+  it('rejects a branch path when running inside the stable base', () => {
+    const { replaceState } = withMockedWindow('/branch/develop/home', () => {
+      expect(restoreGhPagesSpaFallbackPath('/')).toBeNull();
+    });
+    expect(replaceState).not.toHaveBeenCalled();
   });
 
   it('rejects a PR preview path when running inside the stable base', () => {
-    const sessionStorage = {
-      getItem: vi.fn(() => '/mioframe/pr-123/home'),
-      removeItem: vi.fn(),
-    };
-    const history = { replaceState: vi.fn() };
-
-    const originalSessionStorage = window.sessionStorage;
-    const originalHistory = window.history;
-
-    Object.defineProperty(window, 'sessionStorage', { configurable: true, value: sessionStorage });
-    Object.defineProperty(window, 'history', { configurable: true, value: history });
-
-    try {
-      expect(restoreGhPagesSpaFallbackPath('/mioframe/')).toBeNull();
-      expect(history.replaceState).not.toHaveBeenCalled();
-    } finally {
-      Object.defineProperty(window, 'sessionStorage', {
-        configurable: true,
-        value: originalSessionStorage,
-      });
-      Object.defineProperty(window, 'history', { configurable: true, value: originalHistory });
-    }
+    const { replaceState } = withMockedWindow('/pr/123/home', () => {
+      expect(restoreGhPagesSpaFallbackPath('/')).toBeNull();
+    });
+    expect(replaceState).not.toHaveBeenCalled();
   });
 
-  it('allows preview-base routes whose next segment happens to look like another preview id', () => {
-    const sessionStorage = {
-      getItem: vi.fn(() => '/mioframe/pr-86/pr-123/home'),
-      removeItem: vi.fn(),
-    };
-    const history = { replaceState: vi.fn() };
-
-    const originalSessionStorage = window.sessionStorage;
-    const originalHistory = window.history;
-
-    Object.defineProperty(window, 'sessionStorage', { configurable: true, value: sessionStorage });
-    Object.defineProperty(window, 'history', { configurable: true, value: history });
-
-    try {
-      expect(restoreGhPagesSpaFallbackPath('/mioframe/pr-86/')).toBe('/mioframe/pr-86/pr-123/home');
-      expect(history.replaceState).toHaveBeenCalledWith(null, '', '/mioframe/pr-86/pr-123/home');
-    } finally {
-      Object.defineProperty(window, 'sessionStorage', {
-        configurable: true,
-        value: originalSessionStorage,
-      });
-      Object.defineProperty(window, 'history', { configurable: true, value: originalHistory });
-    }
+  it('allows PR-preview-base routes whose next segment happens to look like a branch/pr root', () => {
+    const { replaceState } = withMockedWindow('/pr/86/branch/pr/home', () => {
+      expect(restoreGhPagesSpaFallbackPath('/pr/86/')).toBe('/pr/86/branch/pr/home');
+    });
+    expect(replaceState).toHaveBeenCalledWith(null, '', '/pr/86/branch/pr/home');
   });
 
   it('preserves the query string', () => {
-    const sessionStorage = {
-      getItem: vi.fn(() => '/mioframe/settings/documents?tab=recent'),
-      removeItem: vi.fn(),
-    };
-    const history = { replaceState: vi.fn() };
-
-    const originalSessionStorage = window.sessionStorage;
-    const originalHistory = window.history;
-
-    Object.defineProperty(window, 'sessionStorage', { configurable: true, value: sessionStorage });
-    Object.defineProperty(window, 'history', { configurable: true, value: history });
-
-    try {
-      expect(restoreGhPagesSpaFallbackPath('/mioframe/')).toBe(
-        '/mioframe/settings/documents?tab=recent',
-      );
-      expect(history.replaceState).toHaveBeenCalledWith(
-        null,
-        '',
-        '/mioframe/settings/documents?tab=recent',
-      );
-    } finally {
-      Object.defineProperty(window, 'sessionStorage', {
-        configurable: true,
-        value: originalSessionStorage,
-      });
-      Object.defineProperty(window, 'history', { configurable: true, value: originalHistory });
-    }
+    const { replaceState } = withMockedWindow('/settings/documents?tab=recent', () => {
+      expect(restoreGhPagesSpaFallbackPath('/')).toBe('/settings/documents?tab=recent');
+    });
+    expect(replaceState).toHaveBeenCalledWith(null, '', '/settings/documents?tab=recent');
   });
 
   it('does not throw if sessionStorage is unavailable', () => {
@@ -204,7 +118,7 @@ describe('restoreGhPagesSpaFallbackPath', () => {
     });
 
     try {
-      expect(() => restoreGhPagesSpaFallbackPath('/mioframe/')).not.toThrow();
+      expect(() => restoreGhPagesSpaFallbackPath('/')).not.toThrow();
     } finally {
       Object.defineProperty(window, 'sessionStorage', {
         configurable: true,
@@ -214,49 +128,32 @@ describe('restoreGhPagesSpaFallbackPath', () => {
   });
 
   it('returns null without rewriting when no fallback value is stored', () => {
-    const sessionStorage = {
-      getItem: vi.fn(() => null),
-      removeItem: vi.fn(),
-    };
-    const history = { replaceState: vi.fn() };
-
-    const originalSessionStorage = window.sessionStorage;
-    const originalHistory = window.history;
-
-    Object.defineProperty(window, 'sessionStorage', { configurable: true, value: sessionStorage });
-    Object.defineProperty(window, 'history', { configurable: true, value: history });
-
-    try {
-      expect(restoreGhPagesSpaFallbackPath('/mioframe/')).toBeNull();
-      expect(sessionStorage.removeItem).not.toHaveBeenCalled();
-      expect(history.replaceState).not.toHaveBeenCalled();
-    } finally {
-      Object.defineProperty(window, 'sessionStorage', {
-        configurable: true,
-        value: originalSessionStorage,
-      });
-      Object.defineProperty(window, 'history', { configurable: true, value: originalHistory });
-    }
+    const { removeItem, replaceState } = withMockedWindow(null, () => {
+      expect(restoreGhPagesSpaFallbackPath('/')).toBeNull();
+    });
+    expect(removeItem).not.toHaveBeenCalled();
+    expect(replaceState).not.toHaveBeenCalled();
   });
 
   it('continues restoring when fallback cleanup throws', () => {
-    const sessionStorage = {
-      getItem: vi.fn(() => '/mioframe/home'),
-      removeItem: vi.fn(() => {
-        throw new Error('blocked cleanup');
-      }),
-    };
-    const history = { replaceState: vi.fn() };
+    const getItem = vi.fn(() => '/home');
+    const removeItem = vi.fn(() => {
+      throw new Error('blocked cleanup');
+    });
+    const replaceState = vi.fn();
 
     const originalSessionStorage = window.sessionStorage;
     const originalHistory = window.history;
 
-    Object.defineProperty(window, 'sessionStorage', { configurable: true, value: sessionStorage });
-    Object.defineProperty(window, 'history', { configurable: true, value: history });
+    Object.defineProperty(window, 'sessionStorage', {
+      configurable: true,
+      value: { getItem, removeItem },
+    });
+    Object.defineProperty(window, 'history', { configurable: true, value: { replaceState } });
 
     try {
-      expect(restoreGhPagesSpaFallbackPath('/mioframe/')).toBe('/mioframe/home');
-      expect(history.replaceState).toHaveBeenCalledWith(null, '', '/mioframe/home');
+      expect(restoreGhPagesSpaFallbackPath('/')).toBe('/home');
+      expect(replaceState).toHaveBeenCalledWith(null, '', '/home');
     } finally {
       Object.defineProperty(window, 'sessionStorage', {
         configurable: true,
@@ -267,52 +164,16 @@ describe('restoreGhPagesSpaFallbackPath', () => {
   });
 
   it('does not restore malformed values', () => {
-    const sessionStorage = {
-      getItem: vi.fn(() => 'javascript:alert(1)'),
-      removeItem: vi.fn(),
-    };
-    const history = { replaceState: vi.fn() };
-
-    const originalSessionStorage = window.sessionStorage;
-    const originalHistory = window.history;
-
-    Object.defineProperty(window, 'sessionStorage', { configurable: true, value: sessionStorage });
-    Object.defineProperty(window, 'history', { configurable: true, value: history });
-
-    try {
-      expect(restoreGhPagesSpaFallbackPath('/mioframe/')).toBeNull();
-      expect(history.replaceState).not.toHaveBeenCalled();
-    } finally {
-      Object.defineProperty(window, 'sessionStorage', {
-        configurable: true,
-        value: originalSessionStorage,
-      });
-      Object.defineProperty(window, 'history', { configurable: true, value: originalHistory });
-    }
+    const { replaceState } = withMockedWindow('javascript:alert(1)', () => {
+      expect(restoreGhPagesSpaFallbackPath('/')).toBeNull();
+    });
+    expect(replaceState).not.toHaveBeenCalled();
   });
 
   it('does not restore protocol-relative values', () => {
-    const sessionStorage = {
-      getItem: vi.fn(() => '//evil.example/mioframe/home'),
-      removeItem: vi.fn(),
-    };
-    const history = { replaceState: vi.fn() };
-
-    const originalSessionStorage = window.sessionStorage;
-    const originalHistory = window.history;
-
-    Object.defineProperty(window, 'sessionStorage', { configurable: true, value: sessionStorage });
-    Object.defineProperty(window, 'history', { configurable: true, value: history });
-
-    try {
-      expect(restoreGhPagesSpaFallbackPath('/mioframe/')).toBeNull();
-      expect(history.replaceState).not.toHaveBeenCalled();
-    } finally {
-      Object.defineProperty(window, 'sessionStorage', {
-        configurable: true,
-        value: originalSessionStorage,
-      });
-      Object.defineProperty(window, 'history', { configurable: true, value: originalHistory });
-    }
+    const { replaceState } = withMockedWindow('//evil.example/home', () => {
+      expect(restoreGhPagesSpaFallbackPath('/')).toBeNull();
+    });
+    expect(replaceState).not.toHaveBeenCalled();
   });
 });

--- a/src/app/ghPagesSpaFallback.ts
+++ b/src/app/ghPagesSpaFallback.ts
@@ -1,6 +1,7 @@
 export const GH_PAGES_SPA_FALLBACK_KEY = 'ghPagesSpaFallback';
 
-const GH_PAGES_PREVIEW_SEGMENT_RE = /^pr-\d+$/;
+const CHANNEL_SCOPED_BASE_RE = /^\/(?:branch\/[^/]+|pr\/\d+)\/$/;
+const FOREIGN_CHANNEL_SEGMENT_RE = /^(?:branch|pr)$/;
 const GH_PAGES_DUMMY_ORIGIN = 'https://mioframe.invalid';
 
 function getValidatedFallbackPath(value: string, base: string): string | null {
@@ -20,13 +21,21 @@ function getValidatedFallbackPath(value: string, base: string): string | null {
     return null;
   }
 
-  const previewBaseMatch = base.match(/^(.*\/)(pr-\d+)\/$/);
-  if (previewBaseMatch) {
-    return url.pathname.startsWith(base) ? `${url.pathname}${url.search}${url.hash}` : null;
+  // When this deployment's own base is already a channel-scoped base (a
+  // branch or PR preview), any deep path under it is fine — the browser's
+  // service worker scope (and the base-prefix check above) already
+  // guarantee a value stored for this base can only belong to this exact
+  // channel.
+  if (CHANNEL_SCOPED_BASE_RE.test(base)) {
+    return `${url.pathname}${url.search}${url.hash}`;
   }
 
+  // Otherwise (the stable base `/`), reject a stored path whose first
+  // segment is a foreign channel root (`branch` or `pr`): the org-root
+  // 404.html is shared by every channel, so a value captured for a branch
+  // or PR preview must not be restored into the stable deployment.
   const firstSegment = url.pathname.slice(base.length).split('/', 1)[0] ?? '';
-  if (GH_PAGES_PREVIEW_SEGMENT_RE.test(firstSegment)) {
+  if (FOREIGN_CHANNEL_SEGMENT_RE.test(firstSegment)) {
     return null;
   }
 
@@ -36,8 +45,8 @@ function getValidatedFallbackPath(value: string, base: string): string | null {
 /**
  * Restores a GitHub Pages deep link captured by the root SPA fallback before
  * router creation for the current deployment base.
- * @param base - Current deployment base path, for example `/mioframe/` or
- *   `/mioframe/pr-86/`.
+ * @param base - Current deployment base path, for example `/`,
+ *   `/branch/develop/`, or `/pr/86/`.
  * @returns The restored relative URL when applied, otherwise `null`.
  */
 export function restoreGhPagesSpaFallbackPath(base: string): string | null {

--- a/src/pages/DataStoragePrivacyPane/DataStoragePrivacyPane.test.ts
+++ b/src/pages/DataStoragePrivacyPane/DataStoragePrivacyPane.test.ts
@@ -83,8 +83,8 @@ it('renders the local-first and privacy help content in-app', async () => {
   expect(root.textContent).toContain(
     'Mioframe 0.1 does not use Sentry Session Replay or Sentry performance tracing, and does not use product analytics.',
   );
-  expect(root.textContent).toContain('https://github.com/Vyachean/mioframe/discussions');
-  expect(root.textContent).toContain('https://github.com/Vyachean/mioframe/issues');
+  expect(root.textContent).toContain('https://github.com/Mioframe/mioframe/discussions');
+  expect(root.textContent).toContain('https://github.com/Mioframe/mioframe/issues');
 
   app.unmount();
   root.remove();
@@ -113,10 +113,10 @@ it('renders privacy markdown structure and safe external links', async () => {
 
   const links = Array.from(root.querySelectorAll('a'));
   expect(links).toHaveLength(2);
-  expect(links[0]?.getAttribute('href')).toBe('https://github.com/Vyachean/mioframe/discussions');
+  expect(links[0]?.getAttribute('href')).toBe('https://github.com/Mioframe/mioframe/discussions');
   expect(links[0]?.getAttribute('target')).toBe('_blank');
   expect(links[0]?.getAttribute('rel')).toBe('noopener noreferrer');
-  expect(links[1]?.getAttribute('href')).toBe('https://github.com/Vyachean/mioframe/issues');
+  expect(links[1]?.getAttribute('href')).toBe('https://github.com/Mioframe/mioframe/issues');
   expect(links[1]?.getAttribute('target')).toBe('_blank');
   expect(links[1]?.getAttribute('rel')).toBe('noopener noreferrer');
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,6 +18,8 @@ export default defineConfig(({ mode, isPreview }) => {
   const isStorybookBuild = process.env.APP_STORYBOOK === '1';
   const isDisablePwa = env.VITE_DISABLE_PWA === '1' || process.env.VITE_DISABLE_PWA === '1';
   const buildId = env.VITE_BUILD_ID || process.env.VITE_BUILD_ID || process.env.GITHUB_SHA || '';
+  const releaseChannel = env.VITE_RELEASE_CHANNEL === 'branch' ? 'branch' : 'stable';
+  const releaseChannelId = env.VITE_RELEASE_CHANNEL_ID || undefined;
   const sslPlugins = isStorybookBuild ? [] : getSslPlugins({ mode, isPreview: isPreviewBuild });
   const pwaPlugins = isStorybookBuild
     ? []
@@ -26,6 +28,8 @@ export default defineConfig(({ mode, isPreview }) => {
         mode,
         isPreview: isPreviewBuild,
         disablePwa: isDisablePwa,
+        channel: releaseChannel,
+        channelId: releaseChannelId,
       });
   const sentryPlugins = isStorybookBuild
     ? []


### PR DESCRIPTION
## Summary

- Move Mioframe publishing from the old project-site `/mioframe/` model to the organization Pages repository `Mioframe/mioframe.github.io`.
- Add release-channel deployment paths: stable `/`, develop `/branch/develop/`, manual branches `/branch/<branch-slug>/`, and PR previews `/pr/<number>/`.
- Publish generated static files to `Mioframe/mioframe.github.io:gh-pages` using the configured GitHub App credentials.
- Keep PR previews PWA-disabled, while stable/develop/manual branch deployments are PWA-enabled and isolated by base URL, manifest identity, service worker scope, and cache namespace.
- Add branch tombstones and 14-day cleanup for deleted branch deployments.
- Update release config, release artifact validation, SPA fallback handling, README links, and release docs for the organization-root deployment model.

## Architecture Decision

Release channels are separate deployed builds, not runtime modes inside one SPA.

`Mioframe/mioframe` owns source code, CI, verification, and trusted deployment tooling. `Mioframe/mioframe.github.io` owns only generated static deployment output.

For PR previews and manual branch deployments, application source may come from the PR head or selected branch, but publishing code must run from trusted tooling, not from the untrusted app-source checkout.

## Ownership Matrix

- feature: N/A; no product feature or release-channel switch UI in this PR.
- entity: N/A.
- widget: N/A.
- page/pane: N/A.
- shared: build/release metadata and SPA fallback support only.
- service/worker: PWA channel scope, manifest identity, runtime cache namespace, tombstone service worker cache cleanup.
- workflow/tooling: GitHub Actions, Pages publish scripts, branch slugging, deployment metadata, release config validation, tombstone cleanup.

## Source of Truth

- `.github/workflows/release.yml`
- `.github/workflows/verify.yml`
- `.github/workflows/deploy-branch.yml`
- `.github/workflows/deploy-cleanup.yml`
- `.github/workflows/deploy-branch-tombstone.yml`
- `.github/workflows/deploy-branch-tombstone-cleanup.yml`
- `config/tooling.json`
- `config/plugins/pwa.ts`
- `scripts/pages/*`
- `scripts/release/*`
- `docs/release.md`

## State Shape / API Contract

Every deployment writes `deployment.json` with channel metadata: channel, channel id, source ref/branch/slug, commit SHA, build date, app version, base URL, and tombstone flag when applicable.

Canonical deployment paths:

- stable: `https://mioframe.github.io/`
- develop: `https://mioframe.github.io/branch/develop/`
- manual branch: `https://mioframe.github.io/branch/<branch-slug>/`
- PR preview: `https://mioframe.github.io/pr/<number>/`

## User Scenarios Preserved

- Public stable app opens at the organization root URL.
- Develop build is available independently from stable.
- Selected branches can be deployed manually without auto-publishing every branch.
- PR previews remain short-lived manual verification builds and do not register PWA service workers.
- Deleted branch PWAs receive a tombstone before cleanup, so installed branch PWAs do not keep running stale app code indefinitely.

## Shared UI / Blast Radius

No shared UI component changes are intended in this PR.

The main blast radius is deployment infrastructure, service worker scope, Cache Storage names, and GitHub Pages fallback behavior.

## Verification

Expected verification before merge:

- `pnpm verify`
- release-scoped checks affected by the root base path:
  - `pnpm verify --full --only build`
  - `pnpm verify --full --only artifact`
  - `pnpm verify --full --only release-smoke`
  - `pnpm verify --full --only release-config`
- focused tests for slugging, publish path preservation, PR preview path migration, PWA path matching/cache namespace, release config, SPA fallback, tombstone creation, and tombstone cleanup.
- GitHub CI must be green.

## Known Risks

- Root stable service worker has `/` scope, so it must never serve or cache `/branch/*` or `/pr/*`.
- Cache Storage is origin-wide, so stable and branch cache names must remain channel-namespaced.
- The first PR that introduces trusted publishing tooling needs a bootstrap-safe preview deployment path, because base `develop` does not yet contain the new publish scripts.
- Branch tombstone cleanup must remove only expired tombstones, never live branch deployments.

## Reviewer Notes

This PR is intentionally infrastructure-focused. It does not add a version switch UI.
