### PR TITLE
fix(pages): update environment variable usage for Pages repository

### DIFF
--- a/.github/workflows/deploy-branch-tombstone-cleanup.yml
+++ b/.github/workflows/deploy-branch-tombstone-cleanup.yml
@@ -42,9 +42,10 @@ jobs:
           private-key: ${{ secrets.MIOFRAME_PAGES_APP_PRIVATE_KEY }}
           owner: Mioframe
           repositories: mioframe.github.io
+          permission-contents: write
 
       - name: Remove expired branch tombstones
         env:
           GITHUB_TOKEN: ${{ steps.pages-app-token.outputs.token }}
-          GITHUB_REPOSITORY: Mioframe/mioframe.github.io
+          PAGES_REPOSITORY: Mioframe/mioframe.github.io
         run: node scripts/pages/cleanupExpiredTombstones.mjs

--- a/.github/workflows/deploy-branch-tombstone.yml
+++ b/.github/workflows/deploy-branch-tombstone.yml
@@ -57,10 +57,11 @@ jobs:
           private-key: ${{ secrets.MIOFRAME_PAGES_APP_PRIVATE_KEY }}
           owner: Mioframe
           repositories: mioframe.github.io
+          permission-contents: write
 
       - name: Tombstone removed branch deployment
         if: steps.slug.outputs.slug != ''
         env:
           GITHUB_TOKEN: ${{ steps.pages-app-token.outputs.token }}
-          GITHUB_REPOSITORY: Mioframe/mioframe.github.io
+          PAGES_REPOSITORY: Mioframe/mioframe.github.io
         run: node scripts/pages/publishBranchTombstone.mjs --slug ${{ steps.slug.outputs.slug }}

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -64,6 +64,8 @@ jobs:
           path: app-source
 
       - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: app-source/package.json
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -113,9 +113,10 @@ jobs:
           private-key: ${{ secrets.MIOFRAME_PAGES_APP_PRIVATE_KEY }}
           owner: Mioframe
           repositories: mioframe.github.io
+          permission-contents: write
 
       - name: Publish branch build to Mioframe/mioframe.github.io
         env:
           GITHUB_TOKEN: ${{ steps.pages-app-token.outputs.token }}
-          GITHUB_REPOSITORY: Mioframe/mioframe.github.io
+          PAGES_REPOSITORY: Mioframe/mioframe.github.io
         run: node tooling/scripts/pages/publishBranch.mjs --dist app-source/dist --slug ${{ steps.slug.outputs.slug }}

--- a/.github/workflows/deploy-cleanup.yml
+++ b/.github/workflows/deploy-cleanup.yml
@@ -46,9 +46,10 @@ jobs:
           private-key: ${{ secrets.MIOFRAME_PAGES_APP_PRIVATE_KEY }}
           owner: Mioframe
           repositories: mioframe.github.io
+          permission-contents: write
 
       - name: Remove PR preview from Mioframe/mioframe.github.io
         env:
           GITHUB_TOKEN: ${{ steps.pages-app-token.outputs.token }}
-          GITHUB_REPOSITORY: Mioframe/mioframe.github.io
+          PAGES_REPOSITORY: Mioframe/mioframe.github.io
         run: node scripts/pages/cleanupPreview.mjs --pr ${{ github.event.number }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,9 +129,10 @@ jobs:
           private-key: ${{ secrets.MIOFRAME_PAGES_APP_PRIVATE_KEY }}
           owner: Mioframe
           repositories: mioframe.github.io
+          permission-contents: write
 
       - name: Publish stable build to Mioframe/mioframe.github.io
         env:
           GITHUB_TOKEN: ${{ steps.pages-app-token.outputs.token }}
-          GITHUB_REPOSITORY: Mioframe/mioframe.github.io
+          PAGES_REPOSITORY: Mioframe/mioframe.github.io
         run: node scripts/pages/publishStable.mjs --dist dist

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -188,6 +188,18 @@ jobs:
     # write credential. Remove this line once this branch merges to develop;
     # do not add further branch/PR exclusions here for ordinary PRs. See
     # docs/release.md#pr-preview-deployment.
+    #
+    # The `fix/pages-target-repository-env` exclusion below is a second,
+    # equally scoped one-time bootstrap exception for PR #122. That PR
+    # changes the trusted Pages publish tooling contract from the reserved
+    # GITHUB_REPOSITORY variable to the explicit PAGES_REPOSITORY variable.
+    # `tooling/` is checked out from the PR's base ref (develop), whose
+    # publishPreview.mjs still expects GITHUB_REPOSITORY, so it cannot
+    # publish this PR's preview correctly; running PR-head publish tooling
+    # instead would execute untrusted code with the Pages write token, which
+    # is forbidden. Remove this line once PR #122 merges into develop and
+    # base-ref tooling expects PAGES_REPOSITORY; do not add further
+    # branch/PR exclusions here for ordinary PRs.
     if: >-
       !cancelled() &&
       needs.verify.result == 'success' &&
@@ -195,7 +207,8 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       !(startsWith(github.event.pull_request.head.ref, 'sync/main-') &&
         endsWith(github.event.pull_request.head.ref, '-back-to-develop')) &&
-      github.event.pull_request.head.ref != 'infra/org-pages-release-channels'
+      github.event.pull_request.head.ref != 'infra/org-pages-release-channels' &&
+      github.event.pull_request.head.ref != 'fix/pages-target-repository-env'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -216,6 +216,8 @@ jobs:
           path: app-source
 
       - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: app-source/package.json
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -269,11 +269,12 @@ jobs:
           private-key: ${{ secrets.MIOFRAME_PAGES_APP_PRIVATE_KEY }}
           owner: Mioframe
           repositories: mioframe.github.io
+          permission-contents: write
 
       - name: Publish PR preview to Mioframe/mioframe.github.io
         env:
           GITHUB_TOKEN: ${{ steps.pages-app-token.outputs.token }}
-          GITHUB_REPOSITORY: Mioframe/mioframe.github.io
+          PAGES_REPOSITORY: Mioframe/mioframe.github.io
         run: node tooling/scripts/pages/publishPreview.mjs --dist app-source/dist --pr ${{ github.event.number }}
 
       - name: Post or update preview comment
@@ -344,9 +345,10 @@ jobs:
           private-key: ${{ secrets.MIOFRAME_PAGES_APP_PRIVATE_KEY }}
           owner: Mioframe
           repositories: mioframe.github.io
+          permission-contents: write
 
       - name: Publish develop build to Mioframe/mioframe.github.io
         env:
           GITHUB_TOKEN: ${{ steps.pages-app-token.outputs.token }}
-          GITHUB_REPOSITORY: Mioframe/mioframe.github.io
+          PAGES_REPOSITORY: Mioframe/mioframe.github.io
         run: node scripts/pages/publishBranch.mjs --dist dist --slug develop

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mioframe",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/scripts/pages/cleanupExpiredTombstones.mjs
+++ b/scripts/pages/cleanupExpiredTombstones.mjs
@@ -11,7 +11,8 @@
  *
  * Required env:
  *   GITHUB_TOKEN      - token with contents:write on the target Pages repository
- *   GITHUB_REPOSITORY - OWNER/REPO of the target Pages repository
+ *   PAGES_REPOSITORY  - OWNER/REPO of the target Pages repository (never GITHUB_REPOSITORY,
+ *                        which is the reserved Actions default pointing at the source repository)
  */
 
 import { appendFileSync } from 'node:fs';
@@ -40,15 +41,15 @@ export async function cleanupExpiredTombstones(argv = process.argv.slice(2), env
   const outputIndex = argv.indexOf('--output-dir');
   const outputDir = outputIndex !== -1 ? argv[outputIndex + 1] : undefined;
 
-  const { GITHUB_TOKEN, GITHUB_REPOSITORY, GITHUB_OUTPUT } = env;
+  const { GITHUB_TOKEN, PAGES_REPOSITORY, GITHUB_OUTPUT } = env;
   if (!GITHUB_TOKEN) throw new Error('GITHUB_TOKEN is required');
-  if (!GITHUB_REPOSITORY) throw new Error('GITHUB_REPOSITORY is required');
+  if (!PAGES_REPOSITORY) throw new Error('PAGES_REPOSITORY is required');
 
   const removedSlugs = [];
 
   await withGhPagesBranch({
     token: GITHUB_TOKEN,
-    repository: GITHUB_REPOSITORY,
+    repository: PAGES_REPOSITORY,
     commitMessage: 'chore(pages): remove expired branch tombstones',
     outputDir,
     fn(workDir) {

--- a/scripts/pages/cleanupExpiredTombstones.test.mjs
+++ b/scripts/pages/cleanupExpiredTombstones.test.mjs
@@ -9,6 +9,7 @@ vi.mock('./lib/ghPagesBranch.mjs', () => ({
   }),
 }));
 
+const { withGhPagesBranch } = await import('./lib/ghPagesBranch.mjs');
 const { cleanupExpiredTombstones } = await import('./cleanupExpiredTombstones.mjs');
 
 let workDir = '';
@@ -25,6 +26,7 @@ function writeDeploymentJson(slug, metadata) {
 beforeEach(() => {
   workDir = mkdtempSync(join(tmpdir(), 'pages-work-'));
   outputFile = join(mkdtempSync(join(tmpdir(), 'pages-output-')), 'github-output.txt');
+  vi.mocked(withGhPagesBranch).mockClear();
 });
 
 afterEach(() => {
@@ -34,14 +36,14 @@ afterEach(() => {
 
 describe('cleanupExpiredTombstones argument validation', () => {
   it('throws when GITHUB_TOKEN is missing', async () => {
-    await expect(cleanupExpiredTombstones([], { GITHUB_REPOSITORY: 'owner/repo' })).rejects.toThrow(
-      'GITHUB_TOKEN is required',
-    );
+    await expect(
+      cleanupExpiredTombstones([], { PAGES_REPOSITORY: 'owner/pages-repo' }),
+    ).rejects.toThrow('GITHUB_TOKEN is required');
   });
 
-  it('throws when GITHUB_REPOSITORY is missing', async () => {
+  it('throws when PAGES_REPOSITORY is missing', async () => {
     await expect(cleanupExpiredTombstones([], { GITHUB_TOKEN: 'token' })).rejects.toThrow(
-      'GITHUB_REPOSITORY is required',
+      'PAGES_REPOSITORY is required',
     );
   });
 
@@ -51,11 +53,27 @@ describe('cleanupExpiredTombstones argument validation', () => {
       await expect(
         cleanupExpiredTombstones(['--retention-days', value], {
           GITHUB_TOKEN: 'token',
-          GITHUB_REPOSITORY: 'owner/repo',
+          PAGES_REPOSITORY: 'owner/pages-repo',
         }),
       ).rejects.toThrow('Invalid retention days from --retention-days');
     },
   );
+});
+
+describe('cleanupExpiredTombstones target repository', () => {
+  it('cleans up on PAGES_REPOSITORY and ignores GITHUB_REPOSITORY', async () => {
+    await cleanupExpiredTombstones(['--retention-days', '14'], {
+      GITHUB_TOKEN: 'token',
+      PAGES_REPOSITORY: 'Mioframe/mioframe.github.io',
+      // The reserved Actions default env var; must never be used as the
+      // target Pages repository even when set to the source repository.
+      GITHUB_REPOSITORY: 'Mioframe/mioframe',
+    });
+
+    expect(withGhPagesBranch).toHaveBeenCalledWith(
+      expect.objectContaining({ repository: 'Mioframe/mioframe.github.io' }),
+    );
+  });
 });
 
 describe('cleanupExpiredTombstones behavior', () => {
@@ -76,7 +94,7 @@ describe('cleanupExpiredTombstones behavior', () => {
 
     const removed = await cleanupExpiredTombstones(['--retention-days', '14'], {
       GITHUB_TOKEN: 'token',
-      GITHUB_REPOSITORY: 'owner/repo',
+      PAGES_REPOSITORY: 'owner/pages-repo',
       GITHUB_OUTPUT: outputFile,
     });
 
@@ -108,7 +126,7 @@ describe('cleanupExpiredTombstones behavior', () => {
 
     const removed = await cleanupExpiredTombstones(['--retention-days', '14'], {
       GITHUB_TOKEN: 'token',
-      GITHUB_REPOSITORY: 'owner/repo',
+      PAGES_REPOSITORY: 'owner/pages-repo',
       GITHUB_OUTPUT: outputFile,
     });
 
@@ -124,7 +142,7 @@ describe('cleanupExpiredTombstones behavior', () => {
 
     const removed = await cleanupExpiredTombstones([], {
       GITHUB_TOKEN: 'token',
-      GITHUB_REPOSITORY: 'owner/repo',
+      PAGES_REPOSITORY: 'owner/pages-repo',
     });
 
     expect(removed).toEqual([]);

--- a/scripts/pages/cleanupPreview.mjs
+++ b/scripts/pages/cleanupPreview.mjs
@@ -15,7 +15,8 @@
  *
  * Required env:
  *   GITHUB_TOKEN      - token with contents:write on the target Pages repository
- *   GITHUB_REPOSITORY - OWNER/REPO of the target Pages repository
+ *   PAGES_REPOSITORY  - OWNER/REPO of the target Pages repository (never GITHUB_REPOSITORY,
+ *                        which is the reserved Actions default pointing at the source repository)
  */
 
 import { appendFileSync } from 'node:fs';
@@ -41,15 +42,15 @@ export async function cleanupPreview(argv = process.argv.slice(2), env = process
   const outputIndex = argv.indexOf('--output-dir');
   const outputDir = outputIndex !== -1 ? argv[outputIndex + 1] : undefined;
 
-  const { GITHUB_TOKEN, GITHUB_REPOSITORY, GITHUB_OUTPUT } = env;
+  const { GITHUB_TOKEN, PAGES_REPOSITORY, GITHUB_OUTPUT } = env;
   if (!GITHUB_TOKEN) throw new Error('GITHUB_TOKEN is required');
-  if (!GITHUB_REPOSITORY) throw new Error('GITHUB_REPOSITORY is required');
+  if (!PAGES_REPOSITORY) throw new Error('PAGES_REPOSITORY is required');
 
   let removed = false;
 
   await withGhPagesBranch({
     token: GITHUB_TOKEN,
-    repository: GITHUB_REPOSITORY,
+    repository: PAGES_REPOSITORY,
     commitMessage: `chore(pages): remove preview for PR #${prNumber}`,
     outputDir,
     fn(workDir) {

--- a/scripts/pages/cleanupPreview.test.mjs
+++ b/scripts/pages/cleanupPreview.test.mjs
@@ -9,6 +9,7 @@ vi.mock('./lib/ghPagesBranch.mjs', () => ({
   }),
 }));
 
+const { withGhPagesBranch } = await import('./lib/ghPagesBranch.mjs');
 const { cleanupPreview } = await import('./cleanupPreview.mjs');
 
 let workDir = '';
@@ -17,6 +18,7 @@ let outputFile = '';
 beforeEach(() => {
   workDir = mkdtempSync(join(tmpdir(), 'pages-work-'));
   outputFile = join(mkdtempSync(join(tmpdir(), 'pages-output-')), 'github-output.txt');
+  vi.mocked(withGhPagesBranch).mockClear();
 });
 
 afterEach(() => {
@@ -29,7 +31,7 @@ describe('cleanupPreview argument validation', () => {
     await expect(
       cleanupPreview([], {
         GITHUB_TOKEN: 'token',
-        GITHUB_REPOSITORY: 'owner/repo',
+        PAGES_REPOSITORY: 'owner/pages-repo',
       }),
     ).rejects.toThrow('Usage:');
   });
@@ -37,17 +39,33 @@ describe('cleanupPreview argument validation', () => {
   it('throws when GITHUB_TOKEN is missing', async () => {
     await expect(
       cleanupPreview(['--pr', '42'], {
-        GITHUB_REPOSITORY: 'owner/repo',
+        PAGES_REPOSITORY: 'owner/pages-repo',
       }),
     ).rejects.toThrow('GITHUB_TOKEN is required');
   });
 
-  it('throws when GITHUB_REPOSITORY is missing', async () => {
+  it('throws when PAGES_REPOSITORY is missing', async () => {
     await expect(
       cleanupPreview(['--pr', '42'], {
         GITHUB_TOKEN: 'token',
       }),
-    ).rejects.toThrow('GITHUB_REPOSITORY is required');
+    ).rejects.toThrow('PAGES_REPOSITORY is required');
+  });
+});
+
+describe('cleanupPreview target repository', () => {
+  it('cleans up on PAGES_REPOSITORY and ignores GITHUB_REPOSITORY', async () => {
+    await cleanupPreview(['--pr', '42'], {
+      GITHUB_TOKEN: 'token',
+      PAGES_REPOSITORY: 'Mioframe/mioframe.github.io',
+      // The reserved Actions default env var; must never be used as the
+      // target Pages repository even when set to the source repository.
+      GITHUB_REPOSITORY: 'Mioframe/mioframe',
+    });
+
+    expect(withGhPagesBranch).toHaveBeenCalledWith(
+      expect.objectContaining({ repository: 'Mioframe/mioframe.github.io' }),
+    );
   });
 });
 
@@ -58,7 +76,7 @@ describe('cleanupPreview changed output', () => {
 
     const removed = await cleanupPreview(['--pr', '42'], {
       GITHUB_TOKEN: 'token',
-      GITHUB_REPOSITORY: 'owner/repo',
+      PAGES_REPOSITORY: 'owner/pages-repo',
       GITHUB_OUTPUT: outputFile,
     });
 
@@ -69,7 +87,7 @@ describe('cleanupPreview changed output', () => {
   it('resolves false and writes changed=false when the preview slot did not exist', async () => {
     const removed = await cleanupPreview(['--pr', '99'], {
       GITHUB_TOKEN: 'token',
-      GITHUB_REPOSITORY: 'owner/repo',
+      PAGES_REPOSITORY: 'owner/pages-repo',
       GITHUB_OUTPUT: outputFile,
     });
 
@@ -81,7 +99,7 @@ describe('cleanupPreview changed output', () => {
     await expect(
       cleanupPreview(['--pr', '99'], {
         GITHUB_TOKEN: 'token',
-        GITHUB_REPOSITORY: 'owner/repo',
+        PAGES_REPOSITORY: 'owner/pages-repo',
       }),
     ).resolves.toBe(false);
   });

--- a/scripts/pages/publishBranch.mjs
+++ b/scripts/pages/publishBranch.mjs
@@ -13,7 +13,8 @@
  *
  * Required env:
  *   GITHUB_TOKEN      - token with contents:write on the target Pages repository
- *   GITHUB_REPOSITORY - OWNER/REPO of the target Pages repository
+ *   PAGES_REPOSITORY  - OWNER/REPO of the target Pages repository (never GITHUB_REPOSITORY,
+ *                        which is the reserved Actions default pointing at the source repository)
  */
 
 import { existsSync } from 'node:fs';
@@ -47,13 +48,13 @@ export async function publishBranch(argv = process.argv.slice(2), env = process.
   const outputIndex = argv.indexOf('--output-dir');
   const outputDir = outputIndex !== -1 ? argv[outputIndex + 1] : undefined;
 
-  const { GITHUB_TOKEN, GITHUB_REPOSITORY } = env;
+  const { GITHUB_TOKEN, PAGES_REPOSITORY } = env;
   if (!GITHUB_TOKEN) throw new Error('GITHUB_TOKEN is required');
-  if (!GITHUB_REPOSITORY) throw new Error('GITHUB_REPOSITORY is required');
+  if (!PAGES_REPOSITORY) throw new Error('PAGES_REPOSITORY is required');
 
   await withGhPagesBranch({
     token: GITHUB_TOKEN,
-    repository: GITHUB_REPOSITORY,
+    repository: PAGES_REPOSITORY,
     commitMessage: `chore(pages): deploy branch ${slug}`,
     outputDir,
     fn(workDir) {

--- a/scripts/pages/publishBranch.test.mjs
+++ b/scripts/pages/publishBranch.test.mjs
@@ -1,14 +1,20 @@
 import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { publishBranch } from './publishBranch.mjs';
+vi.mock('./lib/ghPagesBranch.mjs', () => ({
+  withGhPagesBranch: vi.fn(async () => {}),
+}));
+
+const { withGhPagesBranch } = await import('./lib/ghPagesBranch.mjs');
+const { publishBranch } = await import('./publishBranch.mjs');
 
 let distDir = '';
 
 beforeEach(() => {
   distDir = mkdtempSync(join(tmpdir(), 'pages-dist-'));
+  vi.mocked(withGhPagesBranch).mockClear();
 });
 
 afterEach(() => {
@@ -20,7 +26,7 @@ describe('publishBranch validation', () => {
     await expect(
       publishBranch(['--dist', '/nonexistent/dist-12345', '--slug', 'develop'], {
         GITHUB_TOKEN: 'token',
-        GITHUB_REPOSITORY: 'owner/repo',
+        PAGES_REPOSITORY: 'owner/pages-repo',
       }),
     ).rejects.toThrow('dist directory does not exist');
   });
@@ -29,7 +35,7 @@ describe('publishBranch validation', () => {
     await expect(
       publishBranch(['--slug', 'develop'], {
         GITHUB_TOKEN: 'token',
-        GITHUB_REPOSITORY: 'owner/repo',
+        PAGES_REPOSITORY: 'owner/pages-repo',
       }),
     ).rejects.toThrow('Usage:');
   });
@@ -38,7 +44,7 @@ describe('publishBranch validation', () => {
     await expect(
       publishBranch(['--dist', distDir], {
         GITHUB_TOKEN: 'token',
-        GITHUB_REPOSITORY: 'owner/repo',
+        PAGES_REPOSITORY: 'owner/pages-repo',
       }),
     ).rejects.toThrow('Usage:');
   });
@@ -47,7 +53,7 @@ describe('publishBranch validation', () => {
     await expect(
       publishBranch(['--dist', distDir, '--slug', '../etc'], {
         GITHUB_TOKEN: 'token',
-        GITHUB_REPOSITORY: 'owner/repo',
+        PAGES_REPOSITORY: 'owner/pages-repo',
       }),
     ).rejects.toThrow('Invalid branch slug');
   });
@@ -56,7 +62,7 @@ describe('publishBranch validation', () => {
     await expect(
       publishBranch(['--dist', distDir, '--slug', 'pr'], {
         GITHUB_TOKEN: 'token',
-        GITHUB_REPOSITORY: 'owner/repo',
+        PAGES_REPOSITORY: 'owner/pages-repo',
       }),
     ).rejects.toThrow('is reserved');
   });
@@ -64,8 +70,32 @@ describe('publishBranch validation', () => {
   it('throws when GITHUB_TOKEN is missing', async () => {
     await expect(
       publishBranch(['--dist', distDir, '--slug', 'develop'], {
-        GITHUB_REPOSITORY: 'owner/repo',
+        PAGES_REPOSITORY: 'owner/pages-repo',
       }),
     ).rejects.toThrow('GITHUB_TOKEN is required');
+  });
+
+  it('throws when PAGES_REPOSITORY is missing', async () => {
+    await expect(
+      publishBranch(['--dist', distDir, '--slug', 'develop'], {
+        GITHUB_TOKEN: 'token',
+      }),
+    ).rejects.toThrow('PAGES_REPOSITORY is required');
+  });
+});
+
+describe('publishBranch target repository', () => {
+  it('publishes to PAGES_REPOSITORY and ignores GITHUB_REPOSITORY', async () => {
+    await publishBranch(['--dist', distDir, '--slug', 'develop'], {
+      GITHUB_TOKEN: 'token',
+      PAGES_REPOSITORY: 'Mioframe/mioframe.github.io',
+      // The reserved Actions default env var; must never be used as the
+      // target Pages repository even when set to the source repository.
+      GITHUB_REPOSITORY: 'Mioframe/mioframe',
+    });
+
+    expect(withGhPagesBranch).toHaveBeenCalledWith(
+      expect.objectContaining({ repository: 'Mioframe/mioframe.github.io' }),
+    );
   });
 });

--- a/scripts/pages/publishBranchTombstone.mjs
+++ b/scripts/pages/publishBranchTombstone.mjs
@@ -19,7 +19,8 @@
  *
  * Required env:
  *   GITHUB_TOKEN      - token with contents:write on the target Pages repository
- *   GITHUB_REPOSITORY - OWNER/REPO of the target Pages repository
+ *   PAGES_REPOSITORY  - OWNER/REPO of the target Pages repository (never GITHUB_REPOSITORY,
+ *                        which is the reserved Actions default pointing at the source repository)
  */
 
 import { appendFileSync, existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
@@ -64,9 +65,9 @@ export async function publishBranchTombstone(argv = process.argv.slice(2), env =
   const outputIndex = argv.indexOf('--output-dir');
   const outputDir = outputIndex !== -1 ? argv[outputIndex + 1] : undefined;
 
-  const { GITHUB_TOKEN, GITHUB_REPOSITORY, GITHUB_OUTPUT } = env;
+  const { GITHUB_TOKEN, PAGES_REPOSITORY, GITHUB_OUTPUT } = env;
   if (!GITHUB_TOKEN) throw new Error('GITHUB_TOKEN is required');
-  if (!GITHUB_REPOSITORY) throw new Error('GITHUB_REPOSITORY is required');
+  if (!PAGES_REPOSITORY) throw new Error('PAGES_REPOSITORY is required');
 
   let tombstoned = false;
   let tombstoneDistDir;
@@ -74,7 +75,7 @@ export async function publishBranchTombstone(argv = process.argv.slice(2), env =
   try {
     await withGhPagesBranch({
       token: GITHUB_TOKEN,
-      repository: GITHUB_REPOSITORY,
+      repository: PAGES_REPOSITORY,
       commitMessage: `chore(pages): tombstone removed branch ${slug}`,
       outputDir,
       fn(workDir) {

--- a/scripts/pages/publishBranchTombstone.test.mjs
+++ b/scripts/pages/publishBranchTombstone.test.mjs
@@ -18,6 +18,7 @@ let outputFile = '';
 beforeEach(() => {
   workDir = mkdtempSync(join(tmpdir(), 'pages-work-'));
   outputFile = join(mkdtempSync(join(tmpdir(), 'pages-output-')), 'github-output.txt');
+  vi.mocked(withGhPagesBranch).mockClear();
 });
 
 afterEach(() => {
@@ -28,7 +29,7 @@ afterEach(() => {
 describe('publishBranchTombstone argument validation', () => {
   it('throws when --slug argument is missing', async () => {
     await expect(
-      publishBranchTombstone([], { GITHUB_TOKEN: 'token', GITHUB_REPOSITORY: 'owner/repo' }),
+      publishBranchTombstone([], { GITHUB_TOKEN: 'token', PAGES_REPOSITORY: 'owner/pages-repo' }),
     ).rejects.toThrow('Usage:');
   });
 
@@ -36,15 +37,37 @@ describe('publishBranchTombstone argument validation', () => {
     await expect(
       publishBranchTombstone(['--slug', '../etc'], {
         GITHUB_TOKEN: 'token',
-        GITHUB_REPOSITORY: 'owner/repo',
+        PAGES_REPOSITORY: 'owner/pages-repo',
       }),
     ).rejects.toThrow('Invalid branch slug');
   });
 
   it('throws when GITHUB_TOKEN is missing', async () => {
     await expect(
-      publishBranchTombstone(['--slug', 'develop'], { GITHUB_REPOSITORY: 'owner/repo' }),
+      publishBranchTombstone(['--slug', 'develop'], { PAGES_REPOSITORY: 'owner/pages-repo' }),
     ).rejects.toThrow('GITHUB_TOKEN is required');
+  });
+
+  it('throws when PAGES_REPOSITORY is missing', async () => {
+    await expect(
+      publishBranchTombstone(['--slug', 'develop'], { GITHUB_TOKEN: 'token' }),
+    ).rejects.toThrow('PAGES_REPOSITORY is required');
+  });
+});
+
+describe('publishBranchTombstone target repository', () => {
+  it('tombstones on PAGES_REPOSITORY and ignores GITHUB_REPOSITORY', async () => {
+    await publishBranchTombstone(['--slug', 'develop'], {
+      GITHUB_TOKEN: 'token',
+      PAGES_REPOSITORY: 'Mioframe/mioframe.github.io',
+      // The reserved Actions default env var; must never be used as the
+      // target Pages repository even when set to the source repository.
+      GITHUB_REPOSITORY: 'Mioframe/mioframe',
+    });
+
+    expect(withGhPagesBranch).toHaveBeenCalledWith(
+      expect.objectContaining({ repository: 'Mioframe/mioframe.github.io' }),
+    );
   });
 });
 
@@ -52,7 +75,7 @@ describe('publishBranchTombstone behavior', () => {
   it('is a no-op when the branch slot does not exist', async () => {
     const tombstoned = await publishBranchTombstone(['--slug', 'develop'], {
       GITHUB_TOKEN: 'token',
-      GITHUB_REPOSITORY: 'owner/repo',
+      PAGES_REPOSITORY: 'owner/pages-repo',
       GITHUB_OUTPUT: outputFile,
     });
 
@@ -67,7 +90,7 @@ describe('publishBranchTombstone behavior', () => {
 
     const tombstoned = await publishBranchTombstone(['--slug', 'develop'], {
       GITHUB_TOKEN: 'token',
-      GITHUB_REPOSITORY: 'owner/repo',
+      PAGES_REPOSITORY: 'owner/pages-repo',
       GITHUB_OUTPUT: outputFile,
     });
 
@@ -102,7 +125,7 @@ describe('publishBranchTombstone behavior', () => {
 
     await publishBranchTombstone(['--slug', 'develop'], {
       GITHUB_TOKEN: 'token',
-      GITHUB_REPOSITORY: 'owner/repo',
+      PAGES_REPOSITORY: 'owner/pages-repo',
     });
 
     expect(readFileSync(join(workDir, 'branch', 'other', 'index.html'), 'utf8')).toBe('<other/>');
@@ -119,7 +142,7 @@ describe('publishBranchTombstone behavior', () => {
 
     await publishBranchTombstone(['--slug', 'develop'], {
       GITHUB_TOKEN: 'token',
-      GITHUB_REPOSITORY: 'owner/repo',
+      PAGES_REPOSITORY: 'owner/pages-repo',
     });
 
     const tmpEntriesAfter = readdirSync(tmpdir()).filter((name) =>
@@ -147,7 +170,7 @@ describe('publishBranchTombstone behavior', () => {
     await expect(
       publishBranchTombstone(['--slug', 'develop'], {
         GITHUB_TOKEN: 'token',
-        GITHUB_REPOSITORY: 'owner/repo',
+        PAGES_REPOSITORY: 'owner/pages-repo',
       }),
     ).rejects.toThrow('simulated publish failure after temp dir creation');
 

--- a/scripts/pages/publishPreview.mjs
+++ b/scripts/pages/publishPreview.mjs
@@ -12,7 +12,8 @@
  *
  * Required env:
  *   GITHUB_TOKEN      - token with contents:write on the target Pages repository
- *   GITHUB_REPOSITORY - OWNER/REPO of the target Pages repository
+ *   PAGES_REPOSITORY  - OWNER/REPO of the target Pages repository (never GITHUB_REPOSITORY,
+ *                        which is the reserved Actions default pointing at the source repository)
  */
 
 import { existsSync } from 'node:fs';
@@ -46,13 +47,13 @@ export async function publishPreview(argv = process.argv.slice(2), env = process
   const outputIndex = argv.indexOf('--output-dir');
   const outputDir = outputIndex !== -1 ? argv[outputIndex + 1] : undefined;
 
-  const { GITHUB_TOKEN, GITHUB_REPOSITORY } = env;
+  const { GITHUB_TOKEN, PAGES_REPOSITORY } = env;
   if (!GITHUB_TOKEN) throw new Error('GITHUB_TOKEN is required');
-  if (!GITHUB_REPOSITORY) throw new Error('GITHUB_REPOSITORY is required');
+  if (!PAGES_REPOSITORY) throw new Error('PAGES_REPOSITORY is required');
 
   await withGhPagesBranch({
     token: GITHUB_TOKEN,
-    repository: GITHUB_REPOSITORY,
+    repository: PAGES_REPOSITORY,
     commitMessage: `chore(pages): deploy preview for PR #${prNumber}`,
     outputDir,
     fn(workDir) {

--- a/scripts/pages/publishPreview.test.mjs
+++ b/scripts/pages/publishPreview.test.mjs
@@ -1,14 +1,20 @@
 import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { publishPreview } from './publishPreview.mjs';
+vi.mock('./lib/ghPagesBranch.mjs', () => ({
+  withGhPagesBranch: vi.fn(async () => {}),
+}));
+
+const { withGhPagesBranch } = await import('./lib/ghPagesBranch.mjs');
+const { publishPreview } = await import('./publishPreview.mjs');
 
 let distDir = '';
 
 beforeEach(() => {
   distDir = mkdtempSync(join(tmpdir(), 'pages-dist-'));
+  vi.mocked(withGhPagesBranch).mockClear();
 });
 
 afterEach(() => {
@@ -20,7 +26,7 @@ describe('publishPreview distDir validation', () => {
     await expect(
       publishPreview(['--dist', '/nonexistent/dist-12345', '--pr', '42'], {
         GITHUB_TOKEN: 'token',
-        GITHUB_REPOSITORY: 'owner/repo',
+        PAGES_REPOSITORY: 'owner/pages-repo',
       }),
     ).rejects.toThrow('dist directory does not exist');
   });
@@ -29,7 +35,7 @@ describe('publishPreview distDir validation', () => {
     await expect(
       publishPreview(['--pr', '42'], {
         GITHUB_TOKEN: 'token',
-        GITHUB_REPOSITORY: 'owner/repo',
+        PAGES_REPOSITORY: 'owner/pages-repo',
       }),
     ).rejects.toThrow('Usage:');
   });
@@ -37,8 +43,32 @@ describe('publishPreview distDir validation', () => {
   it('throws when GITHUB_TOKEN is missing', async () => {
     await expect(
       publishPreview(['--dist', distDir, '--pr', '42'], {
-        GITHUB_REPOSITORY: 'owner/repo',
+        PAGES_REPOSITORY: 'owner/pages-repo',
       }),
     ).rejects.toThrow('GITHUB_TOKEN is required');
+  });
+
+  it('throws when PAGES_REPOSITORY is missing', async () => {
+    await expect(
+      publishPreview(['--dist', distDir, '--pr', '42'], {
+        GITHUB_TOKEN: 'token',
+      }),
+    ).rejects.toThrow('PAGES_REPOSITORY is required');
+  });
+});
+
+describe('publishPreview target repository', () => {
+  it('publishes to PAGES_REPOSITORY and ignores GITHUB_REPOSITORY', async () => {
+    await publishPreview(['--dist', distDir, '--pr', '42'], {
+      GITHUB_TOKEN: 'token',
+      PAGES_REPOSITORY: 'Mioframe/mioframe.github.io',
+      // The reserved Actions default env var; must never be used as the
+      // target Pages repository even when set to the source repository.
+      GITHUB_REPOSITORY: 'Mioframe/mioframe',
+    });
+
+    expect(withGhPagesBranch).toHaveBeenCalledWith(
+      expect.objectContaining({ repository: 'Mioframe/mioframe.github.io' }),
+    );
   });
 });

--- a/scripts/pages/publishStable.mjs
+++ b/scripts/pages/publishStable.mjs
@@ -12,8 +12,9 @@
  *   node scripts/pages/publishStable.mjs --dist ./dist [--output-dir ./pages-staging]
  *
  * Required env:
- *   GITHUB_TOKEN      - token with contents:write
- *   GITHUB_REPOSITORY - OWNER/REPO
+ *   GITHUB_TOKEN      - token with contents:write on the target Pages repository
+ *   PAGES_REPOSITORY  - OWNER/REPO of the target Pages repository (never GITHUB_REPOSITORY,
+ *                        which is the reserved Actions default pointing at the source repository)
  */
 
 import { existsSync } from 'node:fs';
@@ -39,13 +40,13 @@ export async function publishStable(argv = process.argv.slice(2), env = process.
   const outputIndex = argv.indexOf('--output-dir');
   const outputDir = outputIndex !== -1 ? argv[outputIndex + 1] : undefined;
 
-  const { GITHUB_TOKEN, GITHUB_REPOSITORY } = env;
+  const { GITHUB_TOKEN, PAGES_REPOSITORY } = env;
   if (!GITHUB_TOKEN) throw new Error('GITHUB_TOKEN is required');
-  if (!GITHUB_REPOSITORY) throw new Error('GITHUB_REPOSITORY is required');
+  if (!PAGES_REPOSITORY) throw new Error('PAGES_REPOSITORY is required');
 
   await withGhPagesBranch({
     token: GITHUB_TOKEN,
-    repository: GITHUB_REPOSITORY,
+    repository: PAGES_REPOSITORY,
     commitMessage: 'chore(pages): deploy stable build',
     outputDir,
     fn(workDir) {

--- a/scripts/pages/publishStable.test.mjs
+++ b/scripts/pages/publishStable.test.mjs
@@ -1,14 +1,20 @@
 import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { publishStable } from './publishStable.mjs';
+vi.mock('./lib/ghPagesBranch.mjs', () => ({
+  withGhPagesBranch: vi.fn(async () => {}),
+}));
+
+const { withGhPagesBranch } = await import('./lib/ghPagesBranch.mjs');
+const { publishStable } = await import('./publishStable.mjs');
 
 let distDir = '';
 
 beforeEach(() => {
   distDir = mkdtempSync(join(tmpdir(), 'pages-dist-'));
+  vi.mocked(withGhPagesBranch).mockClear();
 });
 
 afterEach(() => {
@@ -20,7 +26,7 @@ describe('publishStable distDir validation', () => {
     await expect(
       publishStable(['--dist', '/nonexistent/dist-12345'], {
         GITHUB_TOKEN: 'token',
-        GITHUB_REPOSITORY: 'owner/repo',
+        PAGES_REPOSITORY: 'owner/pages-repo',
       }),
     ).rejects.toThrow('dist directory does not exist');
   });
@@ -29,7 +35,7 @@ describe('publishStable distDir validation', () => {
     await expect(
       publishStable([], {
         GITHUB_TOKEN: 'token',
-        GITHUB_REPOSITORY: 'owner/repo',
+        PAGES_REPOSITORY: 'owner/pages-repo',
       }),
     ).rejects.toThrow('Usage:');
   });
@@ -37,8 +43,32 @@ describe('publishStable distDir validation', () => {
   it('throws when GITHUB_TOKEN is missing', async () => {
     await expect(
       publishStable(['--dist', distDir], {
-        GITHUB_REPOSITORY: 'owner/repo',
+        PAGES_REPOSITORY: 'owner/pages-repo',
       }),
     ).rejects.toThrow('GITHUB_TOKEN is required');
+  });
+
+  it('throws when PAGES_REPOSITORY is missing', async () => {
+    await expect(
+      publishStable(['--dist', distDir], {
+        GITHUB_TOKEN: 'token',
+      }),
+    ).rejects.toThrow('PAGES_REPOSITORY is required');
+  });
+});
+
+describe('publishStable target repository', () => {
+  it('publishes to PAGES_REPOSITORY and ignores GITHUB_REPOSITORY', async () => {
+    await publishStable(['--dist', distDir], {
+      GITHUB_TOKEN: 'token',
+      PAGES_REPOSITORY: 'Mioframe/mioframe.github.io',
+      // The reserved Actions default env var; must never be used as the
+      // target Pages repository even when set to the source repository.
+      GITHUB_REPOSITORY: 'Mioframe/mioframe',
+    });
+
+    expect(withGhPagesBranch).toHaveBeenCalledWith(
+      expect.objectContaining({ repository: 'Mioframe/mioframe.github.io' }),
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Replace reserved `GITHUB_REPOSITORY` target repository wiring with explicit `PAGES_REPOSITORY` for Pages publish/cleanup/tombstone scripts and workflows.
- Request explicit `permission-contents: write` for GitHub App deploy tokens that mutate `Mioframe/mioframe.github.io`.
- Fix nested `app-source/` pnpm setup for preview/manual branch deployment jobs.
- Add a scoped one-time `deploy-preview` bootstrap skip for this PR because base `develop` trusted tooling still expects `GITHUB_REPOSITORY` while this PR transitions it to `PAGES_REPOSITORY`.
- Add regression tests for the Pages target repository environment contract.

## Architecture Decision

GitHub Actions owns the source repository context through reserved `GITHUB_*` variables. Cross-repository Pages publishing must not overload `GITHUB_REPOSITORY`; Pages mutation scripts now require the explicit `PAGES_REPOSITORY` target repository variable while keeping `GITHUB_TOKEN` as the deploy token.

Trusted publishing remains split: PR application code may be built from `app-source/`, but publish scripts that run with the Pages write token must come from trusted base-branch tooling. Because PR #122 changes that trusted tooling contract, this PR cannot safely self-preview its publish step until merged into `develop`; the preview skip is branch-scoped and temporary.

## Ownership Matrix

- feature: N/A
- entity: N/A
- widget: N/A
- page/pane: N/A
- shared: N/A
- service/worker: N/A
- workflow: checkout layout, Pages token creation, env wiring, bootstrap preview skip
- `scripts/pages/*`: target Pages repository validation and gh-pages mutation through `PAGES_REPOSITORY`
- `verify`: unchanged; remains the owner of verification scope and `--only` checks
- app runtime/PWA/cache: unchanged

## Source of Truth

- Source repo: `Mioframe/mioframe`
- Target Pages repo: `Mioframe/mioframe.github.io`
- Target repository env variable: `PAGES_REPOSITORY`
- Deploy token env variable: `GITHUB_TOKEN`

## State Shape / API Contract

Pages mutation scripts require:

- `GITHUB_TOKEN`: token with write access to the target Pages repository
- `PAGES_REPOSITORY`: `OWNER/REPO` for the target Pages repository

They must not treat `GITHUB_REPOSITORY` as the target Pages repository.

## User Scenarios Preserved

- PR previews continue to publish under `/pr/<number>/` for normal future PRs.
- Develop deployment continues to publish under `/branch/develop/` after push to `develop`.
- Manual branch deployment continues to publish under `/branch/<slug>/`.
- Stable deployment continues to publish to the org Pages root from `main`.

## Shared UI / Blast Radius

N/A. No app runtime, UI, shared component, pane, feature, entity, PWA, or cache behavior changes.

## Verification

- `pnpm verify --verbose --only format`
- `pnpm verify --verbose --only oxlint`
- `pnpm verify --verbose --only unit-tests`
- CI `verify` workflow for PR #122

## Known Risks

- PR #122 intentionally skips only its own `deploy-preview` publish step because base `develop` trusted tooling cannot consume this PR's new `PAGES_REPOSITORY` contract yet.
- Actual cross-repository publish validation must happen in the post-merge `deploy-develop` run after this tooling lands in `develop`.
- The old PR #121 bootstrap preview exclusion remains and should be removed in a follow-up cleanup PR.

## Reviewer Notes

This PR fixes the post-merge Pages publish failure where deployment attempted to push to `Mioframe/mioframe.git` instead of `Mioframe/mioframe.github.io.git` due to misuse of the reserved `GITHUB_REPOSITORY` GitHub Actions variable.