### PR TITLE
fix(ci): remove one-time bootstrap exceptions for deploy-preview step

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -179,36 +179,13 @@ jobs:
 
   deploy-preview:
     needs: [verify]
-    # The `infra/org-pages-release-channels` exclusion below is a one-time
-    # bootstrap exception: `tooling/` is checked out from the PR's base ref
-    # (develop), which does not yet have the scripts/pages/* tooling this PR
-    # itself introduces (writeDeploymentMetadata.mjs, the updated
-    # publishPreview.mjs, slug/deployment-metadata helpers). Skipping preview
-    # publish here avoids running untrusted PR-head tooling with the Pages
-    # write credential. Remove this line once this branch merges to develop;
-    # do not add further branch/PR exclusions here for ordinary PRs. See
-    # docs/release.md#pr-preview-deployment.
-    #
-    # The `fix/pages-target-repository-env` exclusion below is a second,
-    # equally scoped one-time bootstrap exception for PR #122. That PR
-    # changes the trusted Pages publish tooling contract from the reserved
-    # GITHUB_REPOSITORY variable to the explicit PAGES_REPOSITORY variable.
-    # `tooling/` is checked out from the PR's base ref (develop), whose
-    # publishPreview.mjs still expects GITHUB_REPOSITORY, so it cannot
-    # publish this PR's preview correctly; running PR-head publish tooling
-    # instead would execute untrusted code with the Pages write token, which
-    # is forbidden. Remove this line once PR #122 merges into develop and
-    # base-ref tooling expects PAGES_REPOSITORY; do not add further
-    # branch/PR exclusions here for ordinary PRs.
     if: >-
       !cancelled() &&
       needs.verify.result == 'success' &&
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       !(startsWith(github.event.pull_request.head.ref, 'sync/main-') &&
-        endsWith(github.event.pull_request.head.ref, '-back-to-develop')) &&
-      github.event.pull_request.head.ref != 'infra/org-pages-release-channels' &&
-      github.event.pull_request.head.ref != 'fix/pages-target-repository-env'
+        endsWith(github.event.pull_request.head.ref, '-back-to-develop'))
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:

--- a/docs/release.md
+++ b/docs/release.md
@@ -365,29 +365,11 @@ previews for release sync-back branches remain skipped, as before (see
 `Release sync-back` above). PR preview cleanup on PR close removes only
 that PR's `pr/<number>/` slot.
 
-#### One-time bootstrap exception (`infra/org-pages-release-channels`)
-
 `deploy-preview` checks out trusted tooling from the PR's **base** ref (see
 `Trusted publishing boundary` above), never from the PR head, so that
 publish scripts never run untrusted PR-head code with the Pages write
-credential. This is the correct model for every ordinary PR, but it cannot
-bootstrap the PR that first introduces this org-Pages deployment tooling
-(release-channels PR, branch `infra/org-pages-release-channels`): that PR's
-base (`develop`) does not yet contain
-`scripts/pages/writeDeploymentMetadata.mjs`, the updated
-`scripts/pages/publishPreview.mjs`, or the slug/deployment-metadata helpers
-the trusted-tooling checkout expects.
-
-`deploy-preview`'s `if:` condition therefore excludes
-`github.event.pull_request.head.ref == 'infra/org-pages-release-channels'`
-in addition to the existing sync-back exclusion, so this one PR's preview
-publish step does not run. `verify` (format/lint/type-check/tests/e2e) still
-runs and gates the PR as normal — only preview publishing is skipped. This
-is a one-time exception for this specific branch, not a general fallback:
-once `infra/org-pages-release-channels` merges to `develop`, the tooling
-exists on `develop` for every subsequent PR, the exclusion is dead code, and
-it should be deleted rather than left in place or copied for future
-bootstrap-shaped problems.
+credential. `develop` now carries this tooling for every PR, so no
+branch-specific bootstrap exclusion is needed.
 
 ### Branch deletion tombstone
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mioframe",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "author": {


### PR DESCRIPTION
## Summary

- Remove completed one-time deploy-preview bootstrap exclusions from `.github/workflows/verify.yml`.
- Keep the sync-back PR preview skip, same-repository guard, verify dependency, and trusted tooling boundary unchanged.
- Update release documentation so it describes the current steady-state trusted preview model instead of the completed bootstrap exception.

## Architecture Decision

The org Pages deployment tooling now exists on `develop`, so `deploy-preview` can use trusted base-branch tooling for ordinary PRs without branch-specific bootstrap bypasses.

Temporary bootstrap exclusions must not remain as workflow policy. `deploy-preview` stays guarded by successful verification, same-repository PRs, sync-back exclusion, and trusted publish scripts checked out from the PR base branch.

## Ownership Matrix

- workflow: owns deploy-preview conditions, trusted tooling checkout boundary, Pages token generation, and preview publish sequencing
- `scripts/pages/*`: unchanged; owns Pages publish behavior and `PAGES_REPOSITORY` target contract
- `verify`: unchanged; owns validation scope and focused `--only` checks
- docs: removes stale bootstrap-exception wording and describes current steady-state preview behavior
- feature/entity/widget/page-pane/shared/service-worker/app runtime: N/A

## Source of Truth

- `.github/workflows/verify.yml` for deploy-preview workflow guards
- `docs/release.md` for release-channel workflow documentation
- `develop` now contains the trusted Pages publishing tooling used by preview jobs

## State Shape / API Contract

N/A. No runtime state or app API changes.

## User Scenarios Preserved

- Normal same-repository PRs can publish previews after `verify` succeeds.
- Release sync-back PRs remain excluded from preview publishing.
- Preview publishing continues to use trusted tooling from the PR base branch, not PR-head publish scripts.
- Pages target repository wiring through `PAGES_REPOSITORY` remains unchanged.

## Shared UI / Blast Radius

N/A. No UI, shared component, pane, feature, entity, PWA, cache, or runtime behavior changes.

## Verification

- `pnpm verify --verbose --only format`
- `pnpm verify --verbose --only oxlint`
- CI `verify` workflow for PR #123

## Known Risks

- The PR intentionally touches CI policy. Merge readiness depends on GitHub Actions confirming that `deploy-preview` is no longer skipped by stale bootstrap branch exclusions and still uses trusted base-branch tooling.

## Reviewer Notes

This is cleanup after the org Pages release-channel bootstrap and PR #122. It removes dead branch-specific bypasses rather than changing the deployment architecture.