### PR TITLE
fix(verify): skip visual for package version-only changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mioframe",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/scripts/lib/packageJsonImpact.mjs
+++ b/scripts/lib/packageJsonImpact.mjs
@@ -1,0 +1,117 @@
+import { readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+
+/**
+ * Determine whether two `package.json` contents differ only in the
+ * top-level "version" field.
+ * @param oldContent Raw package.json content before the change.
+ * @param newContent Raw package.json content after the change.
+ * @returns `true` when every field except "version" is unchanged; `false`
+ * when another field differs, or when either content cannot be parsed as a
+ * JSON object.
+ */
+export function isPackageJsonVersionOnlyChange(oldContent, newContent) {
+  const oldJson = parseJsonObject(oldContent);
+  const newJson = parseJsonObject(newContent);
+
+  if (oldJson === null || newJson === null) {
+    return false;
+  }
+
+  const { version: _oldVersion, ...oldRest } = oldJson;
+  const { version: _newVersion, ...newRest } = newJson;
+
+  return deepEqual(oldRest, newRest);
+}
+
+/**
+ * Determine whether a `package.json` change is visual-relevant. The change
+ * is treated as visual-relevant unless it can be positively confirmed as a
+ * version-only change; any failure to resolve a comparison fails closed
+ * (visual-relevant), so unknown `package.json` impact never skips visual
+ * checks.
+ * @param [options] Comparison inputs.
+ * @param [options.oldRef] Git ref to read the prior `package.json` content
+ * from, or `null` when no reliable base ref is known for the current verify
+ * scope.
+ * @param [options.packageJsonPath] Path to `package.json`, relative to the
+ * repository root.
+ * @param [options.spawn] Injectable `spawnSync`, for tests.
+ * @param [options.readFile] Injectable file reader, for tests.
+ * @returns `true` when visual checks should still run for this change.
+ */
+export function isVisualRelevantPackageJsonChange({
+  oldRef = null,
+  packageJsonPath = 'package.json',
+  spawn = spawnSync,
+  readFile = readFileSync,
+} = {}) {
+  if (typeof oldRef !== 'string' || oldRef.length === 0) {
+    return true;
+  }
+
+  const oldContent = readGitFileAtRef(oldRef, packageJsonPath, spawn);
+
+  if (oldContent === null) {
+    return true;
+  }
+
+  let newContent;
+
+  try {
+    newContent = readFile(packageJsonPath, 'utf8');
+  } catch {
+    return true;
+  }
+
+  return !isPackageJsonVersionOnlyChange(oldContent, newContent);
+}
+
+function readGitFileAtRef(ref, filePath, spawn) {
+  const result = spawn('git', ['show', `${ref}:${filePath}`], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  if (result.status !== 0 || typeof result.stdout !== 'string') {
+    return null;
+  }
+
+  return result.stdout;
+}
+
+function parseJsonObject(content) {
+  if (typeof content !== 'string') {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(content);
+    return parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function deepEqual(left, right) {
+  if (left === right) {
+    return true;
+  }
+
+  if (typeof left !== 'object' || typeof right !== 'object' || left === null || right === null) {
+    return false;
+  }
+
+  if (Array.isArray(left) !== Array.isArray(right)) {
+    return false;
+  }
+
+  const leftKeys = Object.keys(left);
+  const rightKeys = Object.keys(right);
+
+  if (leftKeys.length !== rightKeys.length) {
+    return false;
+  }
+
+  return leftKeys.every((key) => Object.hasOwn(right, key) && deepEqual(left[key], right[key]));
+}

--- a/scripts/lib/packageJsonImpact.test.mjs
+++ b/scripts/lib/packageJsonImpact.test.mjs
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  isPackageJsonVersionOnlyChange,
+  isVisualRelevantPackageJsonChange,
+} from './packageJsonImpact.mjs';
+
+describe('isPackageJsonVersionOnlyChange', () => {
+  it('returns true when only the version field changed', () => {
+    const oldContent = JSON.stringify({ name: 'mioframe', version: '0.1.0', scripts: { a: '1' } });
+    const newContent = JSON.stringify({ name: 'mioframe', version: '0.1.1', scripts: { a: '1' } });
+
+    expect(isPackageJsonVersionOnlyChange(oldContent, newContent)).toBe(true);
+  });
+
+  it('returns true when nothing changed at all', () => {
+    const content = JSON.stringify({ name: 'mioframe', version: '0.1.0' });
+
+    expect(isPackageJsonVersionOnlyChange(content, content)).toBe(true);
+  });
+
+  it('is unaffected by key ordering or whitespace differences', () => {
+    const oldContent = '{\n  "version": "0.1.0",\n  "name": "mioframe"\n}\n';
+    const newContent = '{"name":"mioframe","version":"0.1.1"}';
+
+    expect(isPackageJsonVersionOnlyChange(oldContent, newContent)).toBe(true);
+  });
+
+  it('returns false when a dependency changed', () => {
+    const oldContent = JSON.stringify({
+      version: '0.1.0',
+      dependencies: { vue: '1.0.0' },
+    });
+    const newContent = JSON.stringify({
+      version: '0.1.1',
+      dependencies: { vue: '1.0.1' },
+    });
+
+    expect(isPackageJsonVersionOnlyChange(oldContent, newContent)).toBe(false);
+  });
+
+  it('returns false when scripts changed', () => {
+    const oldContent = JSON.stringify({ version: '0.1.0', scripts: { build: 'vite build' } });
+    const newContent = JSON.stringify({ version: '0.1.0', scripts: { build: 'vite build --x' } });
+
+    expect(isPackageJsonVersionOnlyChange(oldContent, newContent)).toBe(false);
+  });
+
+  it('returns false when packageManager changed', () => {
+    const oldContent = JSON.stringify({ version: '0.1.0', packageManager: 'pnpm@9.0.0' });
+    const newContent = JSON.stringify({ version: '0.1.0', packageManager: 'pnpm@9.1.0' });
+
+    expect(isPackageJsonVersionOnlyChange(oldContent, newContent)).toBe(false);
+  });
+
+  it('returns false when either content is invalid JSON', () => {
+    const validContent = JSON.stringify({ version: '0.1.0' });
+
+    expect(isPackageJsonVersionOnlyChange('not json', validContent)).toBe(false);
+    expect(isPackageJsonVersionOnlyChange(validContent, 'not json')).toBe(false);
+  });
+
+  it('returns false when either content is not a JSON object', () => {
+    const validContent = JSON.stringify({ version: '0.1.0' });
+
+    expect(isPackageJsonVersionOnlyChange('[1,2,3]', validContent)).toBe(false);
+    expect(isPackageJsonVersionOnlyChange(validContent, 'null')).toBe(false);
+  });
+});
+
+describe('isVisualRelevantPackageJsonChange', () => {
+  it('fails closed (visual-relevant) when no base ref is known', () => {
+    const spawn = vi.fn();
+    const readFile = vi.fn();
+
+    expect(isVisualRelevantPackageJsonChange({ oldRef: null, spawn, readFile })).toBe(true);
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('fails closed (visual-relevant) when git show fails', () => {
+    const spawn = vi.fn().mockReturnValue({ status: 1, stdout: '' });
+    const readFile = vi.fn().mockReturnValue(JSON.stringify({ version: '0.1.0' }));
+
+    expect(isVisualRelevantPackageJsonChange({ oldRef: 'origin/develop', spawn, readFile })).toBe(
+      true,
+    );
+  });
+
+  it('fails closed (visual-relevant) when the current file cannot be read', () => {
+    const spawn = vi.fn().mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify({ version: '0.1.0' }),
+    });
+    const readFile = vi.fn().mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+
+    expect(isVisualRelevantPackageJsonChange({ oldRef: 'HEAD~1', spawn, readFile })).toBe(true);
+  });
+
+  it('is not visual-relevant for a confirmed version-only change', () => {
+    const spawn = vi.fn().mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify({ name: 'mioframe', version: '0.1.0' }),
+    });
+    const readFile = vi
+      .fn()
+      .mockReturnValue(JSON.stringify({ name: 'mioframe', version: '0.1.1' }));
+
+    expect(isVisualRelevantPackageJsonChange({ oldRef: 'HEAD~1', spawn, readFile })).toBe(false);
+    expect(spawn).toHaveBeenCalledWith('git', ['show', 'HEAD~1:package.json'], expect.any(Object));
+    expect(readFile).toHaveBeenCalledWith('package.json', 'utf8');
+  });
+
+  it('is visual-relevant when dependencies changed alongside version', () => {
+    const spawn = vi.fn().mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify({ version: '0.1.0', dependencies: { vue: '1.0.0' } }),
+    });
+    const readFile = vi
+      .fn()
+      .mockReturnValue(JSON.stringify({ version: '0.1.1', dependencies: { vue: '1.0.1' } }));
+
+    expect(isVisualRelevantPackageJsonChange({ oldRef: 'HEAD~1', spawn, readFile })).toBe(true);
+  });
+});

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -9,6 +9,7 @@ import { applyProcessResult } from './lib/processResult.mjs';
 import { classifyCommandWeight, resolveEslintConcurrency } from './lib/commandWeight.mjs';
 import { createChildSignalForwarder } from './lib/signalForward.mjs';
 import { resolveAppE2EPlan } from './lib/e2eRisk.mjs';
+import { isVisualRelevantPackageJsonChange } from './lib/packageJsonImpact.mjs';
 
 applyProjectEnv();
 
@@ -348,6 +349,8 @@ function getChangedFiles() {
     return {
       changedFiles: uniqSorted(cliFilesOverride),
       scope: 'explicit-files',
+      // No reliable single base ref for an explicit --files list.
+      packageJsonOldRef: null,
     };
   }
 
@@ -355,6 +358,7 @@ function getChangedFiles() {
   const envBaseRef = getVerifyBaseRef();
   let changedFiles = [];
   let scope = 'local-changes';
+  let packageJsonOldRef = 'HEAD';
 
   if (githubBaseRef) {
     const mergeBase = runGitCommand(['merge-base', 'HEAD', `origin/${githubBaseRef}`], {
@@ -369,6 +373,7 @@ function getChangedFiles() {
       '--',
     ]);
     scope = `github-base origin/${githubBaseRef}`;
+    packageJsonOldRef = mergeBase;
   } else if (cliBaseRef || envBaseRef) {
     const baseRef = cliBaseRef ?? envBaseRef;
     ensureBaseRefExists(baseRef);
@@ -382,6 +387,7 @@ function getChangedFiles() {
       ...runGitCommand(['ls-files', '--others', '--exclude-standard']),
     ];
     scope = `local-base ${baseRef}`;
+    packageJsonOldRef = forkPoint;
   } else {
     changedFiles = [
       ...runGitCommand(['diff', '--name-only', '--diff-filter=ACMR', 'HEAD', '--']),
@@ -398,6 +404,7 @@ function getChangedFiles() {
         '--',
       ]);
       scope = 'local-last-commit';
+      packageJsonOldRef = 'HEAD~1';
     }
   }
 
@@ -406,6 +413,7 @@ function getChangedFiles() {
       changedFiles.map(toPosixPath).filter((filePath) => !isIgnored(filePath)),
     ),
     scope,
+    packageJsonOldRef,
   };
 }
 
@@ -558,12 +566,14 @@ function isSharedUiFile(filePath) {
   return filePath.startsWith('src/shared/ui/');
 }
 
+// `package.json` is deliberately excluded here: its visual relevance
+// depends on which fields changed, so it is classified separately by
+// isVisualRelevantPackageJsonChange (see buildCommands).
 function isVisualRelevantFile(filePath) {
   return (
     filePath === 'config/tooling.json' ||
     filePath === 'playwright.visual.config.ts' ||
     filePath === 'vite.config.ts' ||
-    filePath === 'package.json' ||
     filePath === 'tsconfig.storybook.json' ||
     filePath === 'scripts/storybook.mjs' ||
     filePath === 'src/app/styles/styles.css' ||
@@ -1157,9 +1167,16 @@ function addReleaseOnlyCommands(commands) {
  * @param changedFiles Sorted unique list of repository-relative changed file paths.
  * @param [options] Build options.
  * @param [options.fullMode] Full-project release mode; defaults to the `--full` CLI flag.
+ * @param [options.packageJsonOldRef] Git ref to compare the current
+ * `package.json` against, for the version-only visual impact refinement.
+ * Pass `null` when no reliable base ref is known; that fails closed to
+ * visual-relevant.
  * @returns Command entries in run order.
  */
-export function buildCommands(changedFiles, { fullMode = isFullMode } = {}) {
+export function buildCommands(
+  changedFiles,
+  { fullMode = isFullMode, packageJsonOldRef = null } = {},
+) {
   const existingChangedFiles = changedFiles.filter(fileExists);
   const formatLintFiles = existingChangedFiles.filter((filePath) => !isFormatLintIgnored(filePath));
   const formattableFiles = formatLintFiles.filter((filePath) =>
@@ -1173,7 +1190,12 @@ export function buildCommands(changedFiles, { fullMode = isFullMode } = {}) {
     (filePath) =>
       filePath.startsWith('tests/e2e/visual/') && filePath.endsWith('.ts') && fileExists(filePath),
   );
-  const hasVisualRelevantChanges = changedFiles.some(isVisualRelevantFile);
+  const isPackageJsonVisualRelevant =
+    !fullMode &&
+    changedFiles.includes('package.json') &&
+    isVisualRelevantPackageJsonChange({ oldRef: packageJsonOldRef });
+  const hasVisualRelevantChanges =
+    changedFiles.some(isVisualRelevantFile) || isPackageJsonVisualRelevant;
   const appE2EPlan = resolveAppE2EPlan(changedFiles);
   const mutationScope = getMutationScope(changedFiles);
   const commands = [];
@@ -1505,8 +1527,8 @@ async function main(verifyLockEnv = {}, verifyLockController = { updateMetadata:
     throw new Error('Use either --fix or --fix-only, not both.');
   }
 
-  const { changedFiles, scope } = getChangedFiles();
-  const commands = selectOnlyCommands(buildCommands(changedFiles));
+  const { changedFiles, scope, packageJsonOldRef } = getChangedFiles();
+  const commands = selectOnlyCommands(buildCommands(changedFiles, { packageJsonOldRef }));
   const results = [];
   let hasFailed = false;
   const runnableCommands = commands.filter((entry) => entry.kind === 'run');

--- a/scripts/verify.test.mjs
+++ b/scripts/verify.test.mjs
@@ -1,5 +1,10 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+vi.mock('./lib/packageJsonImpact.mjs', () => ({
+  isVisualRelevantPackageJsonChange: vi.fn(),
+}));
+
+import { isVisualRelevantPackageJsonChange } from './lib/packageJsonImpact.mjs';
 import {
   buildCommands,
   getCliFilesOverride,
@@ -161,6 +166,53 @@ describe('buildCommands mutation scope', () => {
     const mutationEntry = commands.find((entry) => entry.label === 'mutation');
 
     expect(mutationEntry.kind).toBe('skipped');
+  });
+});
+
+describe('buildCommands package.json visual relevance', () => {
+  beforeEach(() => {
+    isVisualRelevantPackageJsonChange.mockReset();
+  });
+
+  it('skips visual when the package.json impact check confirms a version-only change', () => {
+    isVisualRelevantPackageJsonChange.mockReturnValue(false);
+
+    const commands = buildCommands(['package.json'], {
+      fullMode: false,
+      packageJsonOldRef: 'HEAD~1',
+    });
+    const visualEntry = commands.find((entry) => entry.label === 'visual');
+
+    expect(visualEntry.kind).toBe('skipped');
+    expect(isVisualRelevantPackageJsonChange).toHaveBeenCalledWith({ oldRef: 'HEAD~1' });
+  });
+
+  it('runs visual when the package.json impact check is not version-only', () => {
+    isVisualRelevantPackageJsonChange.mockReturnValue(true);
+
+    const commands = buildCommands(['package.json'], {
+      fullMode: false,
+      packageJsonOldRef: 'HEAD~1',
+    });
+    const visualEntry = commands.find((entry) => entry.label === 'visual');
+
+    expect(visualEntry.kind).toBe('run');
+  });
+
+  it('does not consult the package.json impact check in full mode', () => {
+    isVisualRelevantPackageJsonChange.mockReturnValue(false);
+
+    const commands = buildCommands(['package.json'], { fullMode: true });
+    const visualEntry = commands.find((entry) => entry.label === 'visual');
+
+    expect(visualEntry.kind).toBe('run');
+    expect(isVisualRelevantPackageJsonChange).not.toHaveBeenCalled();
+  });
+
+  it('does not consult the package.json impact check when package.json did not change', () => {
+    buildCommands(['src/app/main.ts'], { fullMode: false });
+
+    expect(isVisualRelevantPackageJsonChange).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds semantic `package.json` impact detection for `verify` visual scope.
- Keeps version-only `package.json` changes from triggering focused visual tests.
- Keeps non-version `package.json` changes fail-closed as visual-relevant.
- Adds regression tests for helper behavior and `buildCommands` visual command selection.

## Architecture Decision

`verify` remains the owner of scope decisions. GitHub Actions continues to call focused checks such as `pnpm verify --verbose --only visual`; the workflow does not decide file impact.

The change is intentionally inside `scripts/verify.mjs` and a small local helper under `scripts/lib/`. `package.json` is removed from static visual relevance and classified separately by comparing the previous Git content with the current file.

## Ownership Matrix

- feature/entity/widget/page/shared/service-worker: N/A.
- verify tooling: owns changed-file scope, package impact classification, and command selection.
- GitHub workflows: unchanged; no new ownership.
- release/deploy scripts: unchanged; no ownership in this PR.

## Source of Truth

- `scripts/verify.mjs`
- `scripts/lib/packageJsonImpact.mjs`
- `scripts/verify.test.mjs`
- `scripts/lib/packageJsonImpact.test.mjs`

## State Shape / API Contract

No runtime state or public app API changes.

Internal tooling API change: `buildCommands(changedFiles, { packageJsonOldRef })` can receive a Git ref used only for package.json visual impact refinement.

## User Scenarios Preserved

- PR verification still runs visual tests for actual visual-relevant changes.
- Push/merge verification no longer wastes visual CI time for version-only `package.json` bumps.
- Full release verification still runs visual tests.

## Shared UI / Blast Radius

No shared UI changes. No runtime UI blast radius.

## Verification

Focused:
- package impact helper tests
- `buildCommands` visual selection tests
- expected local `pnpm verify --verbose --only unit-tests`

Full:
- full release behavior remains unchanged because full mode still always runs visual.

## Known Risks

- Local staged-vs-working-tree edge cases still depend on the current `verify` model, which executes against the working tree. This PR primarily fixes the CI/PR/push semantic scope case.

## Reviewer Notes

Check that `.github/workflows/*`, `scripts/pages/*`, runtime app code, and package dependency versions are untouched.