### PR TITLE
chore(deps): automate browserslist database update process

### DIFF
--- a/.github/workflows/update-browserslist-db.yml
+++ b/.github/workflows/update-browserslist-db.yml
@@ -1,0 +1,73 @@
+name: update-browserslist-db
+
+# Refresh the Browserslist DB snapshot used by the lockfile without changing
+# normal build/verify behavior. The workflow only opens a PR when the refresh
+# changes pnpm-lock.yaml, and never pushes directly to develop.
+
+on:
+  schedule:
+    - cron: '17 4 1 * *'
+  workflow_dispatch:
+
+jobs:
+  update-browserslist-db:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: develop
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Update Browserslist DB snapshot
+        run: pnpm deps:update-browsers
+
+      - name: Detect lockfile changes
+        id: lockfile_changes
+        run: |
+          if git diff --quiet --exit-code -- pnpm-lock.yaml; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Bump patch version for develop PR policy
+        if: steps.lockfile_changes.outputs.changed == 'true'
+        run: npm version patch --no-git-tag-version
+
+      - name: Create pull request
+        if: steps.lockfile_changes.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: automation/update-browserslist-db
+          delete-branch: true
+          base: develop
+          add-paths: |
+            package.json
+            pnpm-lock.yaml
+          commit-message: 'chore(deps): update browserslist database'
+          title: 'chore(deps): update browserslist database'
+          body: |
+            This automated PR refreshes the Browserslist DB snapshot used by the lockfile.
+
+            - `.browserslistrc` is unchanged.
+            - Browser support policy is unchanged.
+            - The lockfile/browser DB snapshot was refreshed.
+            - `package.json` was patch-bumped to satisfy the existing PR-into-`develop` version policy.
+            - Normal CI verification is required before merge.

--- a/.github/workflows/update-browserslist-db.yml
+++ b/.github/workflows/update-browserslist-db.yml
@@ -9,6 +9,10 @@ on:
     - cron: '17 4 1 * *'
   workflow_dispatch:
 
+concurrency:
+  group: update-browserslist-db
+  cancel-in-progress: true
+
 jobs:
   update-browserslist-db:
     runs-on: ubuntu-24.04

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "test:mutate": "node scripts/mutate.mjs",
     "release:build-artifact": "node scripts/release/buildArtifact.mjs",
     "release:validate-version": "node scripts/release/validateVersion.mjs",
-    "release:validate-config": "node scripts/release/validateReleaseConfig.mjs"
+    "release:validate-config": "node scripts/release/validateReleaseConfig.mjs",
+    "deps:update-browsers": "pnpm dlx update-browserslist-db@latest"
   },
   "dependencies": {
     "@automerge/automerge": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mioframe",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "author": {


### PR DESCRIPTION
## Architecture Decision

Add a controlled scheduled/manual maintenance workflow for refreshing the Browserslist DB snapshot used by the project lockfile.

The workflow runs separately from normal build, preview, deploy, e2e webServer startup, and `pnpm verify`. It updates Browserslist data only inside a generated PR, preserving reproducible builds and reviewable lockfile changes.

The automation:

- runs monthly and via `workflow_dispatch`;
- checks out `develop`;
- installs dependencies with `pnpm install --frozen-lockfile`;
- runs `pnpm deps:update-browsers`;
- creates a PR only when `pnpm-lock.yaml` changes;
- never pushes directly to `develop`;
- uses workflow-level concurrency because it writes to a fixed automation branch.

## Ownership Matrix

- feature: N/A.
- entity: N/A.
- widget: N/A.
- page/pane: N/A.
- shared: N/A.
- service/worker: N/A.
- tooling: `package.json` script and `.github/workflows/update-browserslist-db.yml`.
- CI/automation: scheduled/manual Browserslist DB refresh PR creation.

## Source of Truth

- `.browserslistrc` remains the browser support policy source of truth.
- `pnpm-lock.yaml` remains the reproducible dependency/browser DB snapshot.
- Generated maintenance PRs are the review boundary for browser DB refreshes.

## State Shape / API Contract

No runtime state, user-facing API, storage model, worker API, routing, diagnostics, or shared UI contract changes.

## User Scenarios Preserved

- Normal app build stays reproducible.
- Normal `pnpm verify` does not fetch or update Browserslist data.
- Preview/deploy/e2e webServer startup do not mutate dependency data.
- Browser DB updates are surfaced as reviewable PRs against `develop`.

## Shared UI / Blast Radius

N/A. No shared UI files or visual contracts changed.

## Verification

- CI `verify` run #926: passed.
- CI steps passed: version bump, format, oxlint, eslint, type-check, unit tests, e2e, visual, mutation.
- CI preview deployment: passed.

## Known Risks

- The generated maintenance PR uses a third-party PR creation action. This is isolated to the maintenance workflow and requires review like other workflow dependencies.
- The workflow uses `pnpm dlx update-browserslist-db@latest` intentionally, because the purpose is to refresh browser DB data. The resulting changes are still locked and reviewed through PR.
- Generated PRs patch-bump `package.json` to satisfy the existing PR-into-`develop` version policy.

## Reviewer Notes

This PR is intentionally limited to dependency-maintenance automation. It does not change `.browserslistrc`, Vite, TypeScript, application runtime behavior, existing verify jobs, product code, or shared UI.