### PR TITLE
fix(export): make JSON export work in Browser Storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mioframe",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/scripts/lib/e2eRisk.mjs
+++ b/scripts/lib/e2eRisk.mjs
@@ -146,6 +146,11 @@ export const E2E_SCENARIO_SCOPES = [
     ],
     specs: ['tests/e2e/repositoryFlows.spec.ts'],
   },
+  {
+    name: 'document export',
+    sourcePrefixes: ['src/features/exportDocument/'],
+    specs: ['tests/e2e/exportDocumentBrowserStorage.spec.ts'],
+  },
 ];
 
 function uniqSorted(values) {

--- a/src/features/exportDocument/useExportDocument.test.ts
+++ b/src/features/exportDocument/useExportDocument.test.ts
@@ -3,9 +3,9 @@ import { DomainError } from '@shared/lib/error';
 import { zodDocumentId } from '@shared/lib/automerge';
 import { useExportDocument } from './useExportDocument';
 
-const { fetchMock, fileSaveMock } = vi.hoisted(() => ({
+const { fetchMock, saveFileWithPickerMock } = vi.hoisted(() => ({
   fetchMock: vi.fn(),
-  fileSaveMock: vi.fn(),
+  saveFileWithPickerMock: vi.fn(),
 }));
 
 const documentId = zodDocumentId.parse('4Z1fFANPScpDsLXmC1KsBCn4mWYu');
@@ -20,21 +20,59 @@ vi.mock('@shared/service', () => ({
   }),
 }));
 
-vi.mock('browser-fs-access', () => ({
-  fileSave: fileSaveMock,
-}));
+vi.mock('@shared/lib/fileSystem', async () => {
+  const actual =
+    await vi.importActual<typeof import('@shared/lib/fileSystem')>('@shared/lib/fileSystem');
+
+  return {
+    ...actual,
+    saveFileWithPicker: saveFileWithPickerMock,
+  };
+});
 
 describe('useExportDocument', () => {
   beforeEach(() => {
     fetchMock.mockReset();
-    fileSaveMock.mockReset();
+    saveFileWithPickerMock.mockReset();
     fetchMock.mockResolvedValue({
       body: {},
       name: 'Doc',
       type: 'note',
       version: 1,
     });
-    fileSaveMock.mockResolvedValue(undefined);
+    saveFileWithPickerMock.mockImplementation(async (createBlob) => {
+      await createBlob();
+      return true;
+    });
+  });
+
+  it('starts save target acquisition before fetching document state', async () => {
+    const callOrder: string[] = [];
+    fetchMock.mockImplementation(() => {
+      callOrder.push('fetch');
+      return Promise.resolve({
+        body: {},
+        name: 'Doc',
+        type: 'note',
+        version: 1,
+      });
+    });
+    saveFileWithPickerMock.mockImplementation(async (createBlob) => {
+      callOrder.push('save-target');
+      const blob = await createBlob();
+      callOrder.push(`blob:${await blob.text()}`);
+      return true;
+    });
+
+    const { saveJsonFile } = useExportDocument();
+
+    await expect(saveJsonFile('/documents', documentId)).resolves.toBe(true);
+
+    expect(callOrder).toEqual([
+      'save-target',
+      'fetch',
+      'blob:{"body":{},"name":"Doc","type":"note","version":1}',
+    ]);
   });
 
   it('throws a user-facing DomainError when the document state is missing', async () => {
@@ -44,12 +82,12 @@ describe('useExportDocument', () => {
 
     await expect(saveJsonFile('/documents', documentId)).rejects.toMatchObject({
       message: 'The document is not available for export',
+      code: 'exportDocument.documentExportUnavailable',
     });
     expect(fetchMock).toHaveBeenCalledWith({
       path: '/documents',
       documentId,
     });
-    expect(fileSaveMock).not.toHaveBeenCalled();
   });
 
   it('preserves raw document load failure as cause when fetch fails', async () => {
@@ -73,7 +111,6 @@ describe('useExportDocument', () => {
     expect(error.cause).toBe(rawCause);
     expect(error.message).not.toContain('/Device files');
     expect(error.message).not.toContain('gd-');
-    expect(fileSaveMock).not.toHaveBeenCalled();
   });
 
   it('preserves an existing DomainError when fetching the document state fails', async () => {
@@ -83,24 +120,30 @@ describe('useExportDocument', () => {
     const { saveJsonFile } = useExportDocument();
 
     await expect(saveJsonFile('/documents', documentId)).rejects.toBe(cause);
-    expect(fileSaveMock).not.toHaveBeenCalled();
   });
 
   it('returns false when the user cancels the save dialog', async () => {
-    fileSaveMock.mockRejectedValueOnce(new DOMException('User cancelled', 'AbortError'));
+    saveFileWithPickerMock.mockResolvedValueOnce(false);
 
     const { saveJsonFile } = useExportDocument();
 
     await expect(saveJsonFile('/documents', documentId)).resolves.toBe(false);
-    expect(fileSaveMock).toHaveBeenCalledOnce();
-    expect(fileSaveMock.mock.calls[0]?.[1]).toEqual({
-      fileName: `${documentId}.json`,
-      extensions: ['.json'],
-      mimeTypes: ['application/json'],
-    });
+    expect(saveFileWithPickerMock).toHaveBeenCalledOnce();
   });
 
   it('returns true and saves the document JSON on success', async () => {
+    let savedBlobText = '';
+    saveFileWithPickerMock.mockImplementationOnce(async (createBlob, options) => {
+      const blob = await createBlob();
+      savedBlobText = await blob.text();
+      expect(options).toEqual({
+        fileName: `${documentId}.json`,
+        extensions: ['.json'],
+        mimeTypes: ['application/json'],
+      });
+      return true;
+    });
+
     const { saveJsonFile } = useExportDocument();
 
     await expect(saveJsonFile('/documents', documentId)).resolves.toBe(true);
@@ -109,16 +152,7 @@ describe('useExportDocument', () => {
       path: '/documents',
       documentId,
     });
-    expect(fileSaveMock).toHaveBeenCalledOnce();
-
-    const [blob, options] = fileSaveMock.mock.calls[0] ?? [];
-
-    expect(options).toEqual({
-      fileName: `${documentId}.json`,
-      extensions: ['.json'],
-      mimeTypes: ['application/json'],
-    });
-    await expect(blob.text()).resolves.toBe(
+    expect(savedBlobText).toBe(
       JSON.stringify({
         body: {},
         name: 'Doc',
@@ -128,12 +162,12 @@ describe('useExportDocument', () => {
     );
   });
 
-  it('preserves raw save failure as cause when file save fails with a non-cancel error', async () => {
+  it('preserves raw save failure as cause when save target writing fails', async () => {
     const rawCause = new DOMException(
       'Could not save /Device files/Private/Tax 2025/4Z1fFANPScpDsLXmC1KsBCn4mWYu.json',
       'NotAllowedError',
     );
-    fileSaveMock.mockRejectedValueOnce(rawCause);
+    saveFileWithPickerMock.mockRejectedValueOnce(rawCause);
 
     const { saveJsonFile } = useExportDocument();
 
@@ -153,7 +187,7 @@ describe('useExportDocument', () => {
 
   it('preserves an existing DomainError when saving fails', async () => {
     const cause = new DomainError('Could not export JSON');
-    fileSaveMock.mockRejectedValueOnce(cause);
+    saveFileWithPickerMock.mockRejectedValueOnce(cause);
 
     const { saveJsonFile } = useExportDocument();
 

--- a/src/features/exportDocument/useExportDocument.ts
+++ b/src/features/exportDocument/useExportDocument.ts
@@ -1,9 +1,8 @@
 import type { AMDocumentId } from '@shared/lib/automerge';
 import { DomainError } from '@shared/lib/error';
-import { isUserFileSelectionCancel } from '@shared/lib/fileSystem';
+import { saveFileWithPicker } from '@shared/lib/fileSystem';
 import { useMainServiceClient } from '@shared/service';
 import { stringify } from 'safe-stable-stringify';
-import { fileSave } from 'browser-fs-access';
 import { ExportDocumentErrorCode } from './exportDocumentErrorCode';
 
 /**
@@ -22,49 +21,45 @@ export const useExportDocument = () => {
    * @returns `true` when the export succeeds, or `false` when the user cancels the save dialog.
    */
   const saveJsonFile = async (path: string, documentId: AMDocumentId) => {
-    let documentState: Awaited<ReturnType<typeof cfrDocumentState.fetch>>;
-
-    try {
-      documentState = await cfrDocumentState.fetch({
-        path,
-        documentId,
-      });
-    } catch (error) {
-      if (error instanceof DomainError) {
-        throw error;
-      }
-
-      throw new DomainError('Could not export JSON', {
-        cause: error,
-        code: ExportDocumentErrorCode.documentExportFailed,
-      });
-    }
-
-    if (!documentState) {
-      throw new DomainError('The document is not available for export', {
-        code: ExportDocumentErrorCode.documentExportUnavailable,
-      });
-    }
-
-    const jsonString = stringify(documentState);
-
     const extension = 'json';
-
     const mimeType = `application/${extension}`;
 
     try {
-      await fileSave(new Blob([jsonString], { type: mimeType }), {
-        fileName: `${documentId}.${extension}`,
-        extensions: [`.${extension}`],
-        mimeTypes: [mimeType],
-      });
+      return await saveFileWithPicker(
+        async () => {
+          let documentState: Awaited<ReturnType<typeof cfrDocumentState.fetch>>;
 
-      return true;
+          try {
+            documentState = await cfrDocumentState.fetch({
+              path,
+              documentId,
+            });
+          } catch (error) {
+            if (error instanceof DomainError) {
+              throw error;
+            }
+
+            throw new DomainError('Could not export JSON', {
+              cause: error,
+              code: ExportDocumentErrorCode.documentExportFailed,
+            });
+          }
+
+          if (!documentState) {
+            throw new DomainError('The document is not available for export', {
+              code: ExportDocumentErrorCode.documentExportUnavailable,
+            });
+          }
+
+          return new Blob([stringify(documentState)], { type: mimeType });
+        },
+        {
+          fileName: `${documentId}.${extension}`,
+          extensions: [`.${extension}`],
+          mimeTypes: [mimeType],
+        },
+      );
     } catch (error) {
-      if (isUserFileSelectionCancel(error)) {
-        return false;
-      }
-
       if (error instanceof DomainError) {
         throw error;
       }

--- a/src/shared/lib/fileSystem/index.ts
+++ b/src/shared/lib/fileSystem/index.ts
@@ -7,6 +7,7 @@ export { isFileFSEntry } from './FileFSEntry';
 export type { FileFSEntry } from './FileFSEntry';
 export { FileSystemDomainErrorCode } from './fileSystemErrorCode';
 export { isEntryPath, isGeneralFSEntry } from './GeneralFSEntry';
+export { saveFileWithPicker, type SaveFileWithPickerOptions } from './saveFileWithPicker';
 export { isUserFileSelectionCancel } from './isUserFileSelectionCancel';
 export type {
   EntryPath,

--- a/src/shared/lib/fileSystem/saveFileWithPicker.test.ts
+++ b/src/shared/lib/fileSystem/saveFileWithPicker.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createFileHandleMock } from '@shared/lib/webFileSystemProvider/WebFileSystemProvider.testUtils';
+
+const { fileSaveMock } = vi.hoisted(() => ({
+  fileSaveMock: vi.fn(),
+}));
+
+vi.mock('browser-fs-access', () => ({
+  fileSave: fileSaveMock,
+}));
+
+describe('saveFileWithPicker', () => {
+  const hadOriginalShowSaveFilePicker = Reflect.has(globalThis, 'showSaveFilePicker');
+  const originalShowSaveFilePicker = globalThis.showSaveFilePicker;
+
+  beforeEach(() => {
+    fileSaveMock.mockReset();
+    Reflect.deleteProperty(globalThis, 'showSaveFilePicker');
+  });
+
+  afterEach(() => {
+    if (hadOriginalShowSaveFilePicker) {
+      Reflect.set(globalThis, 'showSaveFilePicker', originalShowSaveFilePicker);
+      return;
+    }
+
+    Reflect.deleteProperty(globalThis, 'showSaveFilePicker');
+  });
+
+  it('starts the native save picker before asynchronous content preparation', async () => {
+    const events: string[] = [];
+    let resolveContent!: (blob: Blob) => void;
+    const contentPromise = new Promise<Blob>((resolve) => {
+      resolveContent = resolve;
+    });
+    const writable = {
+      locked: false,
+      write: vi.fn(async (blob: Blob) => {
+        events.push(`write:${await blob.text()}`);
+      }),
+      close: vi.fn(() => {
+        events.push('close');
+        return Promise.resolve(undefined);
+      }),
+      abort: vi.fn(() => {
+        events.push('abort');
+        return Promise.resolve(undefined);
+      }),
+      seek: vi.fn(() => Promise.resolve(undefined)),
+      truncate: vi.fn(() => Promise.resolve(undefined)),
+      getWriter: () => new WritableStream().getWriter(),
+    } satisfies FileSystemWritableFileStream;
+    const showSaveFilePickerMock = vi.fn(() => {
+      events.push('picker');
+      const handle = createFileHandleMock({ name: 'doc.json' });
+      handle.createWritable = vi.fn(() => Promise.resolve(writable));
+      return Promise.resolve(handle);
+    });
+    Reflect.set(globalThis, 'showSaveFilePicker', showSaveFilePickerMock);
+
+    const { saveFileWithPicker } = await import('./saveFileWithPicker');
+
+    const savePromise = saveFileWithPicker(
+      async () => {
+        events.push('prepare');
+        return contentPromise;
+      },
+      {
+        fileName: 'doc.json',
+        extensions: ['.json'],
+        mimeTypes: ['application/json'],
+      },
+    );
+
+    await Promise.resolve();
+    expect(events).toEqual(['picker']);
+
+    resolveContent(new Blob(['{"name":"Doc"}'], { type: 'application/json' }));
+
+    await expect(savePromise).resolves.toBe(true);
+    expect(events).toEqual(['picker', 'prepare', 'write:{"name":"Doc"}', 'close']);
+    expect(writable.abort).not.toHaveBeenCalled();
+  });
+
+  it('uses browser-fs-access fallback when the native save picker is unavailable', async () => {
+    fileSaveMock.mockResolvedValueOnce(null);
+
+    const { saveFileWithPicker } = await import('./saveFileWithPicker');
+
+    await expect(
+      saveFileWithPicker(
+        () => Promise.resolve(new Blob(['fallback'], { type: 'application/json' })),
+        {
+          fileName: 'doc.json',
+          extensions: ['.json'],
+          mimeTypes: ['application/json'],
+        },
+      ),
+    ).resolves.toBe(true);
+
+    expect(fileSaveMock).toHaveBeenCalledOnce();
+    const [blobPromise, options] = fileSaveMock.mock.calls[0] ?? [];
+    expect(options).toEqual({
+      fileName: 'doc.json',
+      extensions: ['.json'],
+      mimeTypes: ['application/json'],
+    });
+    await expect((await blobPromise).text()).resolves.toBe('fallback');
+  });
+
+  it('returns false when the user cancels the native save picker', async () => {
+    Reflect.set(
+      globalThis,
+      'showSaveFilePicker',
+      vi.fn(() => Promise.reject(new DOMException('User cancelled', 'AbortError'))),
+    );
+
+    const { saveFileWithPicker } = await import('./saveFileWithPicker');
+
+    await expect(
+      saveFileWithPicker(() => Promise.resolve(new Blob(['{}'], { type: 'application/json' })), {
+        fileName: 'doc.json',
+        extensions: ['.json'],
+        mimeTypes: ['application/json'],
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it('aborts the writable and preserves the original content error on the native path', async () => {
+    const rawCause = new Error('document fetch failed');
+    const writable = {
+      locked: false,
+      write: vi.fn(),
+      close: vi.fn(),
+      abort: vi.fn(() => Promise.resolve(undefined)),
+      seek: vi.fn(() => Promise.resolve(undefined)),
+      truncate: vi.fn(() => Promise.resolve(undefined)),
+      getWriter: () => new WritableStream().getWriter(),
+    } satisfies FileSystemWritableFileStream;
+    Reflect.set(
+      globalThis,
+      'showSaveFilePicker',
+      vi.fn(() => {
+        const handle = createFileHandleMock({ name: 'doc.json' });
+        handle.createWritable = vi.fn(() => Promise.resolve(writable));
+        return Promise.resolve(handle);
+      }),
+    );
+
+    const { saveFileWithPicker } = await import('./saveFileWithPicker');
+
+    await expect(
+      saveFileWithPicker(() => Promise.reject(rawCause), {
+        fileName: 'doc.json',
+        extensions: ['.json'],
+        mimeTypes: ['application/json'],
+      }),
+    ).rejects.toBe(rawCause);
+
+    expect(writable.abort).toHaveBeenCalledOnce();
+    expect(writable.write).not.toHaveBeenCalled();
+    expect(writable.close).not.toHaveBeenCalled();
+  });
+});

--- a/src/shared/lib/fileSystem/saveFileWithPicker.ts
+++ b/src/shared/lib/fileSystem/saveFileWithPicker.ts
@@ -1,0 +1,97 @@
+import { fileSave } from 'browser-fs-access';
+import { isUserFileSelectionCancel } from './isUserFileSelectionCancel';
+
+type SaveFileExtension = `.${string}`;
+type SaveFileMimeType = `${string}/${string}`;
+
+/**
+ * Low-level save-picker options used by shared browser file save helpers.
+ */
+export interface SaveFileWithPickerOptions {
+  /** Suggested file name shown by the save picker. */
+  fileName: string;
+  /** Allowed file extensions for the chosen file type. */
+  extensions: SaveFileExtension[];
+  /** Allowed MIME types for the chosen file type. */
+  mimeTypes: SaveFileMimeType[];
+  /** Optional picker description for the file type filter. */
+  description?: string;
+}
+
+const toBlob = async (value: Blob | Response) => {
+  if (value instanceof Response) {
+    return await value.blob();
+  }
+
+  return value;
+};
+
+const buildAcceptMap = ({ extensions, mimeTypes }: SaveFileWithPickerOptions) => {
+  return mimeTypes.reduce<Record<SaveFileMimeType, SaveFileExtension[]>>((accept, mimeType) => {
+    accept[mimeType] = extensions;
+    return accept;
+  }, {});
+};
+
+/**
+ * Starts browser save target acquisition immediately, then writes asynchronously prepared content.
+ * Returns `false` when the user cancels the save flow.
+ * @param createBlob - Produces the file content after save target acquisition starts.
+ * @param options - Save picker options.
+ * @returns `true` when the file is written, or `false` when the user cancels the picker.
+ */
+export const saveFileWithPicker = async (
+  createBlob: () => Promise<Blob | Response>,
+  options: SaveFileWithPickerOptions,
+) => {
+  try {
+    if (typeof globalThis.showSaveFilePicker === 'function') {
+      const handle = await globalThis.showSaveFilePicker({
+        suggestedName: options.fileName,
+        types: [
+          {
+            description: options.description ?? '',
+            accept: buildAcceptMap(options),
+          },
+        ],
+      });
+      const writable = await handle.createWritable();
+
+      try {
+        await writable.write(await toBlob(await createBlob()));
+        await writable.close();
+      } catch (error) {
+        await writable.abort().catch(() => undefined);
+        throw error;
+      }
+
+      return true;
+    }
+
+    const contentPromise = Promise.resolve()
+      .then(() => createBlob())
+      .then((value) => toBlob(value));
+    const fallbackOptions = {
+      fileName: options.fileName,
+      extensions: options.extensions,
+      mimeTypes: options.mimeTypes,
+      ...(options.description === undefined ? {} : { description: options.description }),
+    };
+
+    try {
+      await fileSave(contentPromise, fallbackOptions);
+      await contentPromise;
+    } catch (error) {
+      void contentPromise.catch(() => undefined);
+      throw error;
+    }
+
+    return true;
+  } catch (error) {
+    if (isUserFileSelectionCancel(error)) {
+      return false;
+    }
+
+    throw error;
+  }
+};

--- a/src/shared/lib/sortable/useReorderSurface.helpers.test.ts
+++ b/src/shared/lib/sortable/useReorderSurface.helpers.test.ts
@@ -460,6 +460,27 @@ describe('useReorderSurface helpers', () => {
     ).toBe(false);
   });
 
+  it('prevents document selectstart while suppression is active', () => {
+    const release = acquireReorderDocumentSelectionSuppression();
+    const activeEvent = new Event('selectstart', {
+      bubbles: true,
+      cancelable: true,
+    });
+
+    document.dispatchEvent(activeEvent);
+    expect(activeEvent.defaultPrevented).toBe(true);
+
+    release();
+
+    const releasedEvent = new Event('selectstart', {
+      bubbles: true,
+      cancelable: true,
+    });
+
+    document.dispatchEvent(releasedEvent);
+    expect(releasedEvent.defaultPrevented).toBe(false);
+  });
+
   it('makes repeated token release harmless', () => {
     const release = acquireReorderDocumentSelectionSuppression();
 

--- a/src/shared/lib/sortable/useReorderSurface.helpers.ts
+++ b/src/shared/lib/sortable/useReorderSurface.helpers.ts
@@ -351,6 +351,12 @@ export const shouldUseBestEffortReorderHaptics = (input: ReorderInput): boolean 
 
 let reorderSelectionSuppressionDepth = 0;
 
+const preventReorderSelectionStart = (event: Event) => {
+  if (reorderSelectionSuppressionDepth > 0) {
+    event.preventDefault();
+  }
+};
+
 /**
  * Checks whether the event target belongs to a draggable reorder item.
  * @param target - Event target to inspect.
@@ -375,7 +381,10 @@ export const acquireReorderDocumentSelectionSuppression = (): (() => void) => {
   }
 
   reorderSelectionSuppressionDepth += 1;
-  rootEl.classList.add(REORDER_DOCUMENT_SELECTION_SUPPRESSED_CLASS);
+  if (reorderSelectionSuppressionDepth === 1) {
+    rootEl.classList.add(REORDER_DOCUMENT_SELECTION_SUPPRESSED_CLASS);
+    document.addEventListener('selectstart', preventReorderSelectionStart, true);
+  }
 
   let released = false;
 
@@ -389,6 +398,7 @@ export const acquireReorderDocumentSelectionSuppression = (): (() => void) => {
 
     if (reorderSelectionSuppressionDepth === 0) {
       rootEl.classList.remove(REORDER_DOCUMENT_SELECTION_SUPPRESSED_CLASS);
+      document.removeEventListener('selectstart', preventReorderSelectionStart, true);
     }
   };
 };

--- a/tests/e2e/exportDocumentBrowserStorage.spec.ts
+++ b/tests/e2e/exportDocumentBrowserStorage.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test } from '@playwright/test';
+import {
+  closeDocumentPane,
+  createDatabaseDocument,
+  createDirectory,
+  createUniqueName,
+  launchApp,
+  openDirectory,
+  openDocumentFromExplorer,
+  openOpfs,
+  renameOpenDocument,
+} from './helpers';
+
+const escapeRegex = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const savedExportsKey = 'savedJsonExportsForTest';
+
+test('exports the current Browser Storage document as non-empty JSON from the document menu', async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    const savedExports: string[] = [];
+    Reflect.set(globalThis, 'savedJsonExportsForTest', savedExports);
+    Reflect.set(globalThis, 'showSaveFilePicker', () =>
+      Promise.resolve({
+        createWritable: () =>
+          Promise.resolve({
+            write: async (blob: Blob) => {
+              savedExports.push(await blob.text());
+            },
+            close: () => Promise.resolve(undefined),
+            abort: () => Promise.resolve(undefined),
+          }),
+      }),
+    );
+  });
+
+  await launchApp(page);
+  await openOpfs(page);
+
+  const directoryName = await createDirectory(page, createUniqueName('records'));
+  await openDirectory(page, directoryName);
+
+  const originalDocumentName = await createDatabaseDocument(page, createUniqueName('catalog'));
+  await openDocumentFromExplorer(page, originalDocumentName);
+
+  const renamedDocumentName = createUniqueName('exported catalog');
+  await renameOpenDocument(page, renamedDocumentName);
+  await closeDocumentPane(page);
+
+  await page
+    .getByRole('button', {
+      name: new RegExp(`^options ${escapeRegex(renamedDocumentName)}$`, 'i'),
+    })
+    .click();
+  await page.getByRole('menuitem', { name: /^export json$/i }).click();
+
+  await expect(
+    page.getByText('JSON exported. It can be imported as a new document.', { exact: true }),
+  ).toBeVisible();
+
+  const savedExports = await page.evaluate((key) => {
+    const savedValue = Reflect.get(globalThis, key);
+
+    if (!Array.isArray(savedValue)) {
+      throw new Error('Expected saved exports array');
+    }
+
+    return savedValue;
+  }, savedExportsKey);
+
+  expect(savedExports).toHaveLength(1);
+  expect(savedExports[0]?.length ?? 0).toBeGreaterThan(0);
+
+  const exportedDocument = JSON.parse(savedExports[0] ?? 'null');
+  expect(exportedDocument.name).toBe(renamedDocumentName);
+  expect(exportedDocument).toHaveProperty('body');
+});


### PR DESCRIPTION
## Summary

Fixes document-level **Export JSON** in Browser Storage by opening the browser save target before asynchronous document preparation. This preserves Chromium/File System Access user activation and keeps JSON export as a document snapshot, separate from Mioframe internal storage chunks.

The PR also stabilizes the existing Mobile Chrome reorder smoke by preventing `selectstart` while reorder selection suppression is active. This is limited to the shared sortable primitive and keeps the no-text-selection product contract.

## Architecture Decision

Use a user-activation-safe save flow:

- `features/exportDocument` owns the Export JSON action, document fetch, JSON snapshot creation, and export-specific errors.
- `shared/lib/fileSystem` owns the low-level browser save helper that acquires the save target first, then writes asynchronously prepared content.
- Native `showSaveFilePicker` is used when available; `browser-fs-access` remains the fallback path.
- Browser picker logic stays on the main thread and does not move into service/worker.

For reorder stability:

- `shared/lib/sortable` owns document-level selection suppression during active reorder interactions.
- The fix extends the existing suppression lifecycle instead of weakening the e2e assertion or adding test-only cleanup.

## Ownership Matrix

- feature: Export JSON user action, document snapshot serialization, snackbar-facing result/error contract.
- entity: N/A.
- widget: N/A.
- page/pane: N/A.
- shared: low-level file save/picker/write/cancel handling; sortable reorder selection suppression.
- service/worker: document state remains the source of truth; no browser picker ownership.

## Source of Truth

The exported content comes from `documents.cfrDocumentState.fetch({ path, documentId })` via the existing service client boundary.

## State Shape / API Contract

`saveJsonFile(path, documentId)` still resolves `true` on successful export and `false` on user cancel. Missing documents and real load/write failures remain error paths with export-specific `DomainError` handling.

Reorder selection suppression remains reference-counted and is released after the final active suppression release.

## User Scenarios Preserved

- Browser Storage document can be exported as non-empty JSON from the existing document menu.
- Cancelled save is not treated as an error.
- Exported JSON remains compatible with the existing import-as-new-document model.
- Database view reorder does not leave visible text selection on Mobile Chrome.

## Shared UI / Blast Radius

No shared UI component visual changes. Shared changes are limited to low-level browser file saving and sortable selection suppression.

## Verification

- Focused: export feature unit tests, file save helper unit tests, sortable helper unit tests, Browser Storage export e2e coverage, reorder smoke e2e coverage.
- Full: GitHub `verify` check is the merge gate.

## Known Risks

- Native browser save behavior is covered with mocks/stubs in automated tests; final confidence still depends on the GitHub verify result and browser behavior in Chromium.

## Reviewer Notes

This PR intentionally does not add sharing, collaboration, full workspace backup, or internal storage format changes.