### PR TITLE
fix(verify): report profile risk in verification summary

### DIFF
--- a/.agents/skills/verification/SKILL.md
+++ b/.agents/skills/verification/SKILL.md
@@ -59,7 +59,10 @@ pnpm verify --only e2e --files tests/e2e/relevant-flow.spec.ts
 - passed checks print concise status lines;
 - failed checks print the check label, exact command, exit code, relevant output tail, and log path;
 - warning-only checks print a warning summary and log path;
+- the final summary reports active profile/environment and whether unresolved CI-profile risk remains after a local pass;
 - full command logs are written per check under `.verify/logs/`.
+
+Report that summary directly. Do not collapse `passed with CI-profile risk` to a plain `passed`.
 
 Use `pnpm verify --verbose` when you need full streamed command output in the terminal. It is a diagnostic mode, not a separate quality gate.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,11 +22,12 @@ pnpm verify
 
 Do not replace the final read-only check with manually selected checks. The final verification must not use `--fix`.
 
-If `pnpm verify` fails, fix failures caused by the change. Otherwise report the exact failing command and output, and do not claim the task is complete.
+If `pnpm verify` fails, fix failures caused by the change. Otherwise report the exact failing command and output, and do not claim the task is complete. After `pnpm verify`, report the verify summary itself, including active profile/environment and whether unresolved CI-profile risk remains. Do not collapse a pass-with-risk result to just "verify passed".
 
 For local verification safety, agents may run focused checks for limited files, but must not start multiple expensive checks in parallel. Use `pnpm verify --only <label> --files ...` for focused local feedback, keep full `pnpm verify` as the completion gate, and if an expensive command is already running, inspect its logs or wait instead of starting another heavy command.
 
 If `pnpm verify` exits because another local verification or a standalone expensive command is already active, do not rerun `pnpm verify` immediately. Run `pnpm verify:status`, inspect `.verify/logs`, and report `VERIFY RESULT: blocked by active local verification` when the final read-only gate could not start. `pnpm verify:status` reports both the verify lock and the expensive-command lock so agents can distinguish which lock is blocking.
+If local Playwright-backed checks need CI-equivalent confidence, rerun the relevant verify step with `--profile github-actions` or `MIOFRAME_VERIFY_PROFILE=github-actions`; plain `pnpm verify` remains the default local workflow.
 
 Do not start manual e2e, visual, mutation, full lint, or full type-check commands while the local verify lock is active. `CI=true` in a local shell or container does not bypass local verification safety; only `GITHUB_ACTIONS=true` counts as GitHub Actions.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mioframe",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/scripts/lib/e2eRisk.mjs
+++ b/scripts/lib/e2eRisk.mjs
@@ -12,6 +12,7 @@ const LOW_LEVEL_E2E_EXACT_FILES = new Set([
   'scripts/e2eContainer.mjs',
   'scripts/e2eHost.mjs',
   'scripts/lib/e2eRisk.mjs',
+  'scripts/playwrightContainer.mjs',
   'scripts/verify.mjs',
   'vite.config.ts',
   'package.json',

--- a/scripts/lib/e2eRisk.test.mjs
+++ b/scripts/lib/e2eRisk.test.mjs
@@ -35,6 +35,7 @@ describe('isAppE2ESpecPath and isAppE2ESupportPath exclude release specs', () =>
 describe('isLowLevelE2EPath', () => {
   it('flags playwright config and verify tooling', () => {
     expect(isLowLevelE2EPath('playwright.config.ts')).toBe(true);
+    expect(isLowLevelE2EPath('scripts/playwrightContainer.mjs')).toBe(true);
     expect(isLowLevelE2EPath('scripts/verify.mjs')).toBe(true);
     expect(isLowLevelE2EPath('scripts/lib/e2eRisk.mjs')).toBe(true);
     expect(isLowLevelE2EPath('package.json')).toBe(true);
@@ -177,6 +178,13 @@ describe('resolveAppE2EPlan', () => {
 
     expect(plan.mode).toBe('full');
     expect(plan.reasons[0]).toContain('low-level path scripts/lib/e2eRisk.mjs');
+  });
+
+  it('runs full app e2e when playwrightContainer.mjs changes', () => {
+    const plan = resolveAppE2EPlan(['scripts/playwrightContainer.mjs']);
+
+    expect(plan.mode).toBe('full');
+    expect(plan.reasons[0]).toContain('low-level path scripts/playwrightContainer.mjs');
   });
 
   it('runs full app e2e for shared service changes', () => {

--- a/scripts/playwrightContainer.mjs
+++ b/scripts/playwrightContainer.mjs
@@ -64,6 +64,11 @@ const defaultDeps = {
   spawnSync,
 };
 
+const PLAYWRIGHT_CONTAINER_PROFILE_KEYS = PLAYWRIGHT_CONTAINER_LIMITS.map(({ key, label }) => ({
+  key,
+  label: label ?? key,
+}));
+
 /**
  * Run Playwright tests inside the repo's Podman wrapper with local safety limits.
  * @param options Container runner options.
@@ -333,6 +338,32 @@ export function resolvePlaywrightContainerProfile(processEnv = process.env) {
       getFirstDefinedEnvValue([envName], processEnv) ?? String(profileDefaults[key]),
     ]),
   ]);
+}
+
+/**
+ * Compare two resolved Playwright container profiles using the canonical
+ * comparable fields owned by this module.
+ * @param left Active Playwright container profile.
+ * @param right Target Playwright container profile.
+ * @returns Structured profile differences with printable labels.
+ */
+export function comparePlaywrightContainerProfiles(left, right) {
+  const differences = [];
+
+  for (const { key, label } of PLAYWRIGHT_CONTAINER_PROFILE_KEYS) {
+    if (left[key] === right[key]) {
+      continue;
+    }
+
+    differences.push({
+      key,
+      label,
+      left: left[key],
+      right: right[key],
+    });
+  }
+
+  return differences;
 }
 
 function printPlaywrightContainerFailureDiagnostic({

--- a/scripts/playwrightContainer.mjs
+++ b/scripts/playwrightContainer.mjs
@@ -17,6 +17,7 @@ const GENERIC_MEMORY_SWAP_ENV = 'PLAYWRIGHT_CONTAINER_MEMORY_SWAP';
 const GENERIC_PIDS_LIMIT_ENV = 'PLAYWRIGHT_CONTAINER_PIDS_LIMIT';
 const GENERIC_TIMEOUT_ENV = 'PLAYWRIGHT_CONTAINER_TIMEOUT';
 const GENERIC_WORKERS_ENV = 'PLAYWRIGHT_CONTAINER_WORKERS';
+export const VERIFY_PROFILE_ENV = 'MIOFRAME_VERIFY_PROFILE';
 const containerProfiles = toolingConfig.verification.playwrightContainer;
 const PLAYWRIGHT_CONTAINER_LIMITS = [
   {
@@ -300,12 +301,33 @@ function getInstalledPlaywrightVersion(repositoryRoot, missingMetadataMessage) {
  * @returns Effective profile name and resource limits.
  */
 export function resolvePlaywrightContainerProfile(processEnv = process.env) {
-  const profileName = processEnv.GITHUB_ACTIONS === 'true' ? 'github-actions' : 'local';
+  const requestedProfile = processEnv[VERIFY_PROFILE_ENV]?.trim();
+  let profileName;
+
+  if (requestedProfile) {
+    if (requestedProfile !== 'local' && requestedProfile !== 'github-actions') {
+      throw new Error(
+        `Unsupported ${VERIFY_PROFILE_ENV} value: ${requestedProfile}. Expected one of: local, github-actions.`,
+      );
+    }
+
+    profileName = requestedProfile;
+  } else {
+    profileName = processEnv.GITHUB_ACTIONS === 'true' ? 'github-actions' : 'local';
+  }
+
   const profileDefaults =
     profileName === 'github-actions' ? containerProfiles.githubActions : containerProfiles.local;
+  const source =
+    requestedProfile !== undefined && requestedProfile !== ''
+      ? VERIFY_PROFILE_ENV
+      : processEnv.GITHUB_ACTIONS === 'true'
+        ? 'GITHUB_ACTIONS'
+        : 'default-local';
 
   return Object.fromEntries([
     ['name', profileName],
+    ['source', source],
     ...PLAYWRIGHT_CONTAINER_LIMITS.map(({ envName, key }) => [
       key,
       getFirstDefinedEnvValue([envName], processEnv) ?? String(profileDefaults[key]),

--- a/scripts/playwrightContainer.test.mjs
+++ b/scripts/playwrightContainer.test.mjs
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   resolvePlaywrightContainerProfile,
   runPlaywrightInContainer,
+  VERIFY_PROFILE_ENV,
 } from './playwrightContainer.mjs';
 import { runGuardedExpensiveLocalCommand } from './lib/localCommandGuard.mjs';
 import { applyProcessResult } from './lib/processResult.mjs';
@@ -94,6 +95,27 @@ describe('runPlaywrightInContainer', () => {
     expect(profile.memorySwap).toBe('8g');
     expect(profile.pidsLimit).toBe('512');
     expect(profile.workers).toBe('2');
+  });
+
+  it('prefers the explicit verify profile override over the host environment', () => {
+    const profile = resolvePlaywrightContainerProfile({
+      GITHUB_ACTIONS: 'false',
+      [VERIFY_PROFILE_ENV]: 'github-actions',
+    });
+
+    expect(profile.name).toBe('github-actions');
+    expect(profile.source).toBe(VERIFY_PROFILE_ENV);
+    expect(profile.workers).toBe('2');
+  });
+
+  it('rejects unsupported explicit verify profile overrides', () => {
+    expect(() =>
+      resolvePlaywrightContainerProfile({
+        [VERIFY_PROFILE_ENV]: 'ci-like',
+      }),
+    ).toThrow(
+      `Unsupported ${VERIFY_PROFILE_ENV} value: ci-like. Expected one of: local, github-actions.`,
+    );
   });
 
   it('applies the final process result only after the lock callback returns', async () => {

--- a/scripts/playwrightContainer.test.mjs
+++ b/scripts/playwrightContainer.test.mjs
@@ -2,6 +2,7 @@ import process from 'node:process';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  comparePlaywrightContainerProfiles,
   resolvePlaywrightContainerProfile,
   runPlaywrightInContainer,
   VERIFY_PROFILE_ENV,
@@ -72,6 +73,22 @@ describe('applyProcessResult', () => {
 });
 
 describe('runPlaywrightInContainer', () => {
+  it('formats profile differences from the owned comparable field list', () => {
+    const localProfile = resolvePlaywrightContainerProfile({
+      GITHUB_ACTIONS: 'false',
+    });
+    const githubActionsProfile = resolvePlaywrightContainerProfile({
+      [VERIFY_PROFILE_ENV]: 'github-actions',
+    });
+
+    expect(comparePlaywrightContainerProfiles(localProfile, githubActionsProfile)).toEqual([
+      { key: 'memory', label: 'memory', left: '4g', right: '6g' },
+      { key: 'memorySwap', label: 'memory-swap', left: '4g', right: '8g' },
+      { key: 'pidsLimit', label: 'pids-limit', left: '384', right: '512' },
+      { key: 'workers', label: 'workers', left: '1', right: '2' },
+    ]);
+  });
+
   it('resolves conservative local resource limits outside GitHub Actions', () => {
     const profile = resolvePlaywrightContainerProfile({
       GITHUB_ACTIONS: 'false',

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -10,7 +10,11 @@ import { classifyCommandWeight, resolveEslintConcurrency } from './lib/commandWe
 import { createChildSignalForwarder } from './lib/signalForward.mjs';
 import { resolveAppE2EPlan } from './lib/e2eRisk.mjs';
 import { isVisualRelevantPackageJsonChange } from './lib/packageJsonImpact.mjs';
-import { resolvePlaywrightContainerProfile, VERIFY_PROFILE_ENV } from './playwrightContainer.mjs';
+import {
+  comparePlaywrightContainerProfiles,
+  resolvePlaywrightContainerProfile,
+  VERIFY_PROFILE_ENV,
+} from './playwrightContainer.mjs';
 
 applyProjectEnv();
 
@@ -967,14 +971,20 @@ function printHelp() {
   }
 }
 
-function getVerifyProcessEnv(baseEnv = process.env) {
-  if (cliProfile === null) {
+/**
+ * Merge verify-level environment overrides into a child-process environment.
+ * @param [baseEnv] Base environment passed to verify child commands.
+ * @param [profileOverride] Explicit verify profile override, usually from `--profile`.
+ * @returns Environment with verify-owned overrides applied.
+ */
+export function getVerifyProcessEnv(baseEnv = process.env, profileOverride = cliProfile) {
+  if (profileOverride === null) {
     return baseEnv;
   }
 
   return {
     ...baseEnv,
-    [VERIFY_PROFILE_ENV]: cliProfile,
+    [VERIFY_PROFILE_ENV]: profileOverride,
   };
 }
 
@@ -992,15 +1002,6 @@ function getHeavyCheckTriggerLines(results) {
     .filter((result) => result.status !== 'skipped' && result.triggerReason)
     .map((result) => `${result.label}: ${result.triggerReason}`);
 }
-
-const PLAYWRIGHT_RISK_KEYS = [
-  'cpus',
-  'memory',
-  'memorySwap',
-  'pidsLimit',
-  'workers',
-  'timeoutSeconds',
-];
 
 /**
  * Detect unresolved GitHub Actions Playwright profile risk after a local pass.
@@ -1029,23 +1030,9 @@ export function getCiProfileRisk(results, processEnv = process.env) {
     GITHUB_ACTIONS: 'true',
     [VERIFY_PROFILE_ENV]: 'github-actions',
   });
-  const differences = [];
-
-  for (const key of PLAYWRIGHT_RISK_KEYS) {
-    if (activeProfile[key] === githubActionsProfile[key]) {
-      continue;
-    }
-
-    const label =
-      key === 'memorySwap'
-        ? 'memory-swap'
-        : key === 'pidsLimit'
-          ? 'pids-limit'
-          : key === 'timeoutSeconds'
-            ? 'timeout'
-            : key;
-    differences.push(`${label}: ${activeProfile[key]} -> ${githubActionsProfile[key]}`);
-  }
+  const differences = comparePlaywrightContainerProfiles(activeProfile, githubActionsProfile).map(
+    ({ label, left, right }) => `${label}: ${left} -> ${right}`,
+  );
 
   if (differences.length === 0) {
     return null;
@@ -1836,6 +1823,34 @@ export function getExtraEnvForEntry(entry, priorResults) {
   return buildResult?.status === 'passed' ? { RELEASE_ARTIFACT_SKIP_BUILD: '1' } : {};
 }
 
+/**
+ * Build the child command environment for a verify entry.
+ * @param entry Command entry about to run.
+ * @param priorResults Results already collected earlier in this run.
+ * @param [options] Environment inputs for the child command.
+ * @param [options.verifyLockEnv] Env inherited from the verify lock.
+ * @param [options.verifyProcessEnv] Env carrying verify-level overrides such as profile selection.
+ * @param [options.expensiveLockEnv] Env added only for expensive-command lock ownership.
+ * @returns Environment passed to the child process.
+ */
+export function buildCommandEnv(entry, priorResults, options = {}) {
+  const { verifyLockEnv = {}, verifyProcessEnv = process.env, expensiveLockEnv = {} } = options;
+  const extraEnv = getExtraEnvForEntry(entry, priorResults);
+
+  return entry.weight === 'expensive'
+    ? {
+        ...verifyLockEnv,
+        ...verifyProcessEnv,
+        ...expensiveLockEnv,
+        ...extraEnv,
+      }
+    : {
+        ...verifyLockEnv,
+        ...verifyProcessEnv,
+        ...extraEnv,
+      };
+}
+
 async function main(verifyLockEnv = {}, verifyLockController = { updateMetadata: () => {} }) {
   if (isFixMode && isFixOnlyMode) {
     throw new Error('Use either --fix or --fix-only, not both.');
@@ -1885,7 +1900,6 @@ async function main(verifyLockEnv = {}, verifyLockController = { updateMetadata:
 
     // oxlint-disable-next-line no-await-in-loop -- verify checks run sequentially for deterministic logs and fail-fast expensive gates.
     let result;
-    const extraEnv = getExtraEnvForEntry(entry, results);
 
     if (entry.weight === 'expensive') {
       // oxlint-disable-next-line no-await-in-loop -- verify checks run sequentially for deterministic logs and fail-fast expensive gates.
@@ -1895,12 +1909,16 @@ async function main(verifyLockEnv = {}, verifyLockController = { updateMetadata:
           command: formatCommand(entry.command, entry.args),
         },
         async (lockEnv) =>
-          runCommand(entry.label, entry.command, entry.args, {
-            ...verifyLockEnv,
-            ...verifyProcessEnv,
-            ...lockEnv,
-            ...extraEnv,
-          }),
+          runCommand(
+            entry.label,
+            entry.command,
+            entry.args,
+            buildCommandEnv(entry, results, {
+              expensiveLockEnv: lockEnv,
+              verifyLockEnv,
+              verifyProcessEnv,
+            }),
+          ),
       );
 
       // Signal propagation must happen after withExpensiveCommandLock cleanup,
@@ -1911,11 +1929,15 @@ async function main(verifyLockEnv = {}, verifyLockController = { updateMetadata:
       }
     } else {
       // oxlint-disable-next-line no-await-in-loop -- verify checks run sequentially for deterministic logs and fail-fast expensive gates.
-      result = await runCommand(entry.label, entry.command, entry.args, {
-        ...verifyLockEnv,
-        ...verifyProcessEnv,
-        ...extraEnv,
-      });
+      result = await runCommand(
+        entry.label,
+        entry.command,
+        entry.args,
+        buildCommandEnv(entry, results, {
+          verifyLockEnv,
+          verifyProcessEnv,
+        }),
+      );
 
       if (result.terminatedBySignal) {
         applyProcessResult({ signal: result.terminatedBySignal });

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -10,6 +10,7 @@ import { classifyCommandWeight, resolveEslintConcurrency } from './lib/commandWe
 import { createChildSignalForwarder } from './lib/signalForward.mjs';
 import { resolveAppE2EPlan } from './lib/e2eRisk.mjs';
 import { isVisualRelevantPackageJsonChange } from './lib/packageJsonImpact.mjs';
+import { resolvePlaywrightContainerProfile, VERIFY_PROFILE_ENV } from './playwrightContainer.mjs';
 
 applyProjectEnv();
 
@@ -65,6 +66,7 @@ const COMMAND_TIMEOUT_MS_BY_LABEL = {
 };
 const cliBaseRef = isHelpMode ? null : getCliBaseRef(cliArgs);
 const cliOnlyLabel = isHelpMode ? null : getCliOnlyLabel(cliArgs);
+const cliProfile = isHelpMode ? null : getCliProfile(cliArgs);
 
 if (cliOnlyLabel !== null && FULL_ONLY_LABELS.has(cliOnlyLabel) && !isFullMode) {
   throw new Error(
@@ -220,6 +222,48 @@ function getCliOnlyLabel(argv) {
   return null;
 }
 
+function getCliProfile(argv) {
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+
+    if (argument === '--profile') {
+      const value = argv[index + 1];
+
+      if (!value || value.startsWith('--')) {
+        throw new Error('Missing value for --profile. Accepted profiles: local, github-actions');
+      }
+
+      validateProfile(value);
+      return value;
+    }
+
+    if (argument.startsWith('--profile=')) {
+      const value = argument.slice('--profile='.length);
+
+      if (value.length === 0) {
+        throw new Error('Missing value for --profile. Accepted profiles: local, github-actions');
+      }
+
+      validateProfile(value);
+      return value;
+    }
+  }
+
+  return null;
+}
+
+function validateProfile(profile) {
+  if (profile === 'local' || profile === 'github-actions') {
+    return;
+  }
+
+  throw new Error(
+    [`Invalid value for --profile: ${profile}`, 'Accepted profiles: local, github-actions'].join(
+      '\n',
+    ),
+  );
+}
+
 /**
  * Parse explicit file overrides from the verify CLI.
  * @param argv Raw CLI arguments after the script name.
@@ -349,6 +393,7 @@ function getChangedFiles() {
     return {
       changedFiles: uniqSorted(cliFilesOverride),
       scope: 'explicit-files',
+      baseRef: null,
       // No reliable single base ref for an explicit --files list.
       packageJsonOldRef: null,
     };
@@ -372,8 +417,14 @@ function getChangedFiles() {
       `${mergeBase}...HEAD`,
       '--',
     ]);
-    scope = `github-base origin/${githubBaseRef}`;
-    packageJsonOldRef = mergeBase;
+    return {
+      changedFiles: uniqSorted(
+        changedFiles.map(toPosixPath).filter((filePath) => !isIgnored(filePath)),
+      ),
+      scope: `github-base origin/${githubBaseRef}`,
+      baseRef: `origin/${githubBaseRef}`,
+      packageJsonOldRef: mergeBase,
+    };
   } else if (cliBaseRef || envBaseRef) {
     const baseRef = cliBaseRef ?? envBaseRef;
     ensureBaseRefExists(baseRef);
@@ -386,8 +437,14 @@ function getChangedFiles() {
       ...runGitCommand(['diff', '--cached', '--name-only', '--diff-filter=ACMR', '--']),
       ...runGitCommand(['ls-files', '--others', '--exclude-standard']),
     ];
-    scope = `local-base ${baseRef}`;
-    packageJsonOldRef = forkPoint;
+    return {
+      changedFiles: uniqSorted(
+        changedFiles.map(toPosixPath).filter((filePath) => !isIgnored(filePath)),
+      ),
+      scope: `local-base ${baseRef}`,
+      baseRef,
+      packageJsonOldRef: forkPoint,
+    };
   } else {
     changedFiles = [
       ...runGitCommand(['diff', '--name-only', '--diff-filter=ACMR', 'HEAD', '--']),
@@ -413,6 +470,7 @@ function getChangedFiles() {
       changedFiles.map(toPosixPath).filter((filePath) => !isIgnored(filePath)),
     ),
     scope,
+    baseRef: null,
     packageJsonOldRef,
   };
 }
@@ -858,6 +916,8 @@ function printHelp() {
   console.log('  --fix-only          Apply supported format/lint fixes only.');
   console.log('  --base <ref>        Verify changes against a local base ref.');
   console.log('                      Local-only default: set VERIFY_BASE in .env.local.');
+  console.log('  --profile <name>    Override the verify runtime profile.');
+  console.log(`                      Env alternative: ${VERIFY_PROFILE_ENV}=local|github-actions.`);
   console.log('  --only <label>      Run one focused verification check.');
   console.log('  --files <paths...>  Override changed-file detection with an explicit file list.');
   console.log(
@@ -879,7 +939,9 @@ function printHelp() {
   console.log('  pnpm verify');
   console.log('  pnpm verify --verbose');
   console.log('  pnpm verify --base origin/develop');
+  console.log('  pnpm verify --profile github-actions --only e2e');
   console.log('  .env.local: VERIFY_BASE=origin/develop');
+  console.log(`  ${VERIFY_PROFILE_ENV}=github-actions pnpm verify --only visual`);
   console.log('  pnpm verify --verbose --only type-check');
   console.log('  pnpm verify --only eslint --files src/foo.ts src/bar.vue');
   console.log('  pnpm verify --fix');
@@ -903,6 +965,98 @@ function printHelp() {
 
     console.log(`    - ${label}: ${formatHelpTimeout(timeoutMs)}`);
   }
+}
+
+function getVerifyProcessEnv(baseEnv = process.env) {
+  if (cliProfile === null) {
+    return baseEnv;
+  }
+
+  return {
+    ...baseEnv,
+    [VERIFY_PROFILE_ENV]: cliProfile,
+  };
+}
+
+function getProfileSummary(processEnv) {
+  const profile = resolvePlaywrightContainerProfile(processEnv);
+
+  return {
+    environment: processEnv.GITHUB_ACTIONS === 'true' ? 'github-actions' : 'local',
+    profile,
+  };
+}
+
+function getHeavyCheckTriggerLines(results) {
+  return results
+    .filter((result) => result.status !== 'skipped' && result.triggerReason)
+    .map((result) => `${result.label}: ${result.triggerReason}`);
+}
+
+const PLAYWRIGHT_RISK_KEYS = [
+  'cpus',
+  'memory',
+  'memorySwap',
+  'pidsLimit',
+  'workers',
+  'timeoutSeconds',
+];
+
+/**
+ * Detect unresolved GitHub Actions Playwright profile risk after a local pass.
+ * @param results Collected command results in run order.
+ * @param [processEnv] Environment object used for profile resolution.
+ * @returns Risk details when local Playwright settings differ from GitHub Actions.
+ */
+export function getCiProfileRisk(results, processEnv = process.env) {
+  const relevantLabels = new Set(['e2e', 'visual']);
+  const affectedChecks = results
+    .filter((result) => result.status === 'passed' && relevantLabels.has(result.label))
+    .map((result) => result.label);
+
+  if (affectedChecks.length === 0) {
+    return null;
+  }
+
+  const activeProfile = resolvePlaywrightContainerProfile(processEnv);
+
+  if (activeProfile.name === 'github-actions') {
+    return null;
+  }
+
+  const githubActionsProfile = resolvePlaywrightContainerProfile({
+    ...processEnv,
+    GITHUB_ACTIONS: 'true',
+    [VERIFY_PROFILE_ENV]: 'github-actions',
+  });
+  const differences = [];
+
+  for (const key of PLAYWRIGHT_RISK_KEYS) {
+    if (activeProfile[key] === githubActionsProfile[key]) {
+      continue;
+    }
+
+    const label =
+      key === 'memorySwap'
+        ? 'memory-swap'
+        : key === 'pidsLimit'
+          ? 'pids-limit'
+          : key === 'timeoutSeconds'
+            ? 'timeout'
+            : key;
+    differences.push(`${label}: ${activeProfile[key]} -> ${githubActionsProfile[key]}`);
+  }
+
+  if (differences.length === 0) {
+    return null;
+  }
+
+  return {
+    affectedChecks,
+    activeProfile,
+    githubActionsProfile,
+    differences,
+  };
 }
 
 async function runCommand(label, command, args, extraEnv = {}) {
@@ -1120,6 +1274,7 @@ async function runCommand(label, command, args, extraEnv = {}) {
     hasWarnings: warningSummary.length > 0,
     warningSummary,
     blockingLogIssue,
+    triggerReason: null,
     terminatedBySignal: forwarder.terminatedBySignal,
     // Populated for expensive commands to support applyProcessResult.
     signal: forwarder.terminatedBySignal,
@@ -1138,6 +1293,7 @@ function createSkippedResult(entry, reason = entry.reason) {
     hasWarnings: false,
     warningSummary: '',
     blockingLogIssue: null,
+    triggerReason: entry.triggerReason ?? null,
   };
 }
 
@@ -1155,6 +1311,7 @@ function createFailedResult(entry, reason = entry.reason) {
     hasWarnings: false,
     warningSummary: '',
     blockingLogIssue: null,
+    triggerReason: entry.triggerReason ?? null,
   };
 }
 
@@ -1180,6 +1337,7 @@ function createE2ECommand(extraArgs = [], note = null) {
     args: ['e2e:container', ...extraArgs],
     weight: classifyCommandWeight({ label: 'e2e' }),
     note,
+    triggerReason: note,
   };
 }
 
@@ -1434,12 +1592,18 @@ export function buildCommands(
   }
 
   if (fullMode || hasVisualRelevantChanges || changedVisualSpecs.length > 0) {
+    const triggerReason = fullMode
+      ? 'full-project release verification'
+      : changedVisualSpecs.length > 0
+        ? `changed visual specs: ${changedVisualSpecs.join(', ')}`
+        : 'visual-relevant files changed';
     commands.push({
       kind: 'run',
       label: 'visual',
       command: 'pnpm',
       args: ['test:visual'],
       weight: classifyCommandWeight({ label: 'visual' }),
+      triggerReason,
     });
   } else {
     commands.push({
@@ -1460,6 +1624,7 @@ export function buildCommands(
       command: 'pnpm',
       args: ['exec', 'stryker', 'run', '-m', mutationScope.join(',')],
       weight: classifyCommandWeight({ label: 'mutation' }),
+      triggerReason: `mutation scope: ${mutationScope.join(', ')}`,
     });
   } else if (!fullMode) {
     commands.push({
@@ -1498,9 +1663,12 @@ function selectOnlyCommands(commands) {
 /**
  * Build the `action required` lines for the verify summary.
  * @param results Collected command results in run order.
+ * @param [options] Summary options.
+ * @param [options.ciProfileRisk] Pending GitHub Actions profile risk details.
  * @returns Action lines; `['None.']` when nothing failed or warned.
  */
-export function getActionRequired(results) {
+export function getActionRequired(results, options = {}) {
+  const { ciProfileRisk = null } = options;
   const actions = [];
   const failedResults = results.filter((result) => result.status === 'failed');
   const warningResults = results.filter(
@@ -1529,6 +1697,16 @@ export function getActionRequired(results) {
     actions.push(`Reason: ${result.warningSummary}`);
   }
 
+  if (ciProfileRisk !== null) {
+    const rerunChecks = ciProfileRisk.affectedChecks
+      .map((label) => `pnpm verify --profile github-actions --only ${label}`)
+      .join(' ; ');
+    actions.push(
+      `CI-profile risk remains for ${ciProfileRisk.affectedChecks.join(', ')} because local Playwright used profile ${ciProfileRisk.activeProfile.name}.`,
+    );
+    actions.push(`For CI-equivalent Playwright confidence locally, rerun: ${rerunChecks}`);
+  }
+
   if (actions.length === 0) {
     actions.push('None.');
   }
@@ -1543,38 +1721,81 @@ export function getActionRequired(results) {
  * @param changedFiles Changed files the run was scoped to.
  * @param scope Human-readable changed-file scope description.
  * @param results Collected command results in run order.
+ * @param [options] Summary overrides for tests and caller-provided context.
+ * @param [options.baseRef] Changed-file base ref used by this run, when known.
+ * @param [options.processEnv] Environment object used for profile resolution.
+ * @param [options.ciProfileRisk] Precomputed GitHub Actions profile risk details.
+ * @param [options.profileSummary] Precomputed verify profile summary details.
+ * @param [options.heavyCheckTriggers] Precomputed heavy-check trigger lines.
  * @returns Overall run status derived from the results.
  */
-export function printSummary(changedFiles, scope, results) {
+export function printSummary(changedFiles, scope, results, options = {}) {
   const hasFailed = results.some((result) => result.status === 'failed');
+  const processEnv = options.processEnv ?? getVerifyProcessEnv(process.env);
+  const ciProfileRisk = options.ciProfileRisk ?? getCiProfileRisk(results, processEnv);
+  const { environment, profile } = options.profileSummary ?? getProfileSummary(processEnv);
   const status = hasFailed ? 'failed' : 'passed';
-  const displayStatus = hasFailed ? 'failed ❌' : 'passed ✅';
-  const actionRequired = getActionRequired(results);
+  const displayStatus = hasFailed
+    ? 'failed ❌'
+    : ciProfileRisk === null
+      ? 'passed ✅'
+      : 'passed with CI-profile risk ⚠️';
+  const actionRequired = getActionRequired(results, { ciProfileRisk });
   const mode = isFixOnlyMode ? 'fix-only' : isFixMode ? 'fix' : 'check';
+  const heavyCheckTriggers = options.heavyCheckTriggers ?? getHeavyCheckTriggerLines(results);
+  const baseRef = options.baseRef ?? null;
+  const runnableResults = results.filter((result) => result.status !== 'skipped');
+  const skippedResults = results.filter((result) => result.status === 'skipped');
 
   console.log('\nVERIFY RESULT');
   console.log(`mode: ${mode}`);
+  console.log(`environment: ${environment}`);
+  console.log(`profile: ${profile.name} (source: ${profile.source})`);
   console.log(`release: ${isFullMode ? 'full-project (pnpm verify --full)' : 'off'}`);
   console.log(`verbose: ${isVerboseMode ? 'on' : 'off'}`);
   console.log(`only: ${cliOnlyLabel ?? 'all'}`);
   console.log(`scope: ${isFullMode ? 'full-project (changed-file scope ignored)' : scope}`);
+  console.log(`base ref: ${baseRef ?? 'n/a'}`);
   console.log(`changed files: ${changedFiles.length}`);
   console.log(`status: ${displayStatus}`);
   console.log(`logs: ${VERIFY_LOG_DIR}`);
-  console.log('commands:');
+  console.log(`checks run: ${runnableResults.length}`);
 
-  for (const result of results) {
-    if (result.status === 'skipped') {
-      console.log(`- ${result.label}: skipped (${result.reason})`);
-      continue;
-    }
-
+  for (const result of runnableResults) {
     const warningSuffix = result.hasWarnings ? ' (warnings found)' : '';
     console.log(`- ${result.label}: ${result.status}${warningSuffix} (${result.displayCommand})`);
 
-    if (result.label === 'e2e' && result.note) {
-      console.log(`  e2e triggered by: ${result.note}`);
+    if (result.triggerReason) {
+      console.log(`  trigger: ${result.triggerReason}`);
     }
+  }
+
+  console.log(`checks skipped: ${skippedResults.length}`);
+
+  for (const result of skippedResults) {
+    console.log(`- ${result.label}: skipped (${result.reason})`);
+  }
+
+  console.log('heavy-check triggers:');
+
+  if (heavyCheckTriggers.length === 0) {
+    console.log('- none');
+  } else {
+    for (const triggerLine of heavyCheckTriggers) {
+      console.log(`- ${triggerLine}`);
+    }
+  }
+
+  console.log('ci profile risk:');
+
+  if (ciProfileRisk === null) {
+    console.log('- none');
+  } else {
+    console.log(
+      `- Local Playwright checks ran under ${ciProfileRisk.activeProfile.name}; GitHub Actions uses ${ciProfileRisk.githubActionsProfile.name}.`,
+    );
+    console.log(`- Affected checks: ${ciProfileRisk.affectedChecks.join(', ')}`);
+    console.log(`- Differences: ${ciProfileRisk.differences.join('; ')}`);
   }
 
   console.log('action required:');
@@ -1586,6 +1807,7 @@ export function printSummary(changedFiles, scope, results) {
   return {
     status,
     hasFailed,
+    hasCiProfileRisk: ciProfileRisk !== null,
   };
 }
 
@@ -1619,7 +1841,8 @@ async function main(verifyLockEnv = {}, verifyLockController = { updateMetadata:
     throw new Error('Use either --fix or --fix-only, not both.');
   }
 
-  const { changedFiles, scope, packageJsonOldRef } = getChangedFiles();
+  const verifyProcessEnv = getVerifyProcessEnv(process.env);
+  const { changedFiles, scope, baseRef, packageJsonOldRef } = getChangedFiles();
   const commands = selectOnlyCommands(buildCommands(changedFiles, { packageJsonOldRef }));
   const results = [];
   let hasFailed = false;
@@ -1674,6 +1897,7 @@ async function main(verifyLockEnv = {}, verifyLockController = { updateMetadata:
         async (lockEnv) =>
           runCommand(entry.label, entry.command, entry.args, {
             ...verifyLockEnv,
+            ...verifyProcessEnv,
             ...lockEnv,
             ...extraEnv,
           }),
@@ -1689,6 +1913,7 @@ async function main(verifyLockEnv = {}, verifyLockController = { updateMetadata:
       // oxlint-disable-next-line no-await-in-loop -- verify checks run sequentially for deterministic logs and fail-fast expensive gates.
       result = await runCommand(entry.label, entry.command, entry.args, {
         ...verifyLockEnv,
+        ...verifyProcessEnv,
         ...extraEnv,
       });
 
@@ -1699,6 +1924,7 @@ async function main(verifyLockEnv = {}, verifyLockController = { updateMetadata:
     if (entry.note) {
       result.note = entry.note;
     }
+    result.triggerReason = entry.triggerReason ?? null;
 
     results.push(result);
     completedRunnableChecks += 1;
@@ -1708,7 +1934,10 @@ async function main(verifyLockEnv = {}, verifyLockController = { updateMetadata:
     }
   }
 
-  const summary = printSummary(changedFiles, scope, results);
+  const summary = printSummary(changedFiles, scope, results, {
+    baseRef,
+    processEnv: verifyProcessEnv,
+  });
   process.exitCode = summary.hasFailed ? 1 : 0;
 }
 

--- a/scripts/verify.test.mjs
+++ b/scripts/verify.test.mjs
@@ -6,11 +6,13 @@ vi.mock('./lib/packageJsonImpact.mjs', () => ({
 
 import { isVisualRelevantPackageJsonChange } from './lib/packageJsonImpact.mjs';
 import {
+  buildCommandEnv,
   buildCommands,
   getCiProfileRisk,
   getActionRequired,
   getBlockingLogIssue,
   getCliFilesOverride,
+  getVerifyProcessEnv,
   getAllSiblingTestFiles,
   getExtraEnvForEntry,
   getVerifyBaseRef,
@@ -18,6 +20,7 @@ import {
   resolveCommandStatus,
   runVerifyCli,
 } from './verify.mjs';
+import { resolvePlaywrightContainerProfile, VERIFY_PROFILE_ENV } from './playwrightContainer.mjs';
 
 describe('getAllSiblingTestFiles', () => {
   it('maps scripts production .mjs files to sibling .test.mjs', () => {
@@ -83,6 +86,15 @@ describe('getCliFilesOverride', () => {
 describe('getVerifyBaseRef', () => {
   it('reads VERIFY_BASE from process env', () => {
     expect(getVerifyBaseRef({ VERIFY_BASE: 'origin/develop' })).toBe('origin/develop');
+  });
+});
+
+describe('getVerifyProcessEnv', () => {
+  it('applies an explicit verify profile override to the process env', () => {
+    expect(getVerifyProcessEnv({ GITHUB_ACTIONS: 'false' }, 'github-actions')).toMatchObject({
+      GITHUB_ACTIONS: 'false',
+      [VERIFY_PROFILE_ENV]: 'github-actions',
+    });
   });
 });
 
@@ -247,6 +259,27 @@ describe('getExtraEnvForEntry', () => {
     expect(getExtraEnvForEntry({ label: 'release-smoke' }, priorResults)).toEqual({
       RELEASE_ARTIFACT_SKIP_BUILD: '1',
     });
+  });
+});
+
+describe('buildCommandEnv', () => {
+  it('propagates a github-actions profile override into expensive child command env', () => {
+    const childEnv = buildCommandEnv(
+      {
+        label: 'e2e',
+        weight: 'expensive',
+      },
+      [],
+      {
+        expensiveLockEnv: { MIOFRAME_EXPENSIVE_COMMAND_LOCK_HELD: '1' },
+        verifyLockEnv: { MIOFRAME_VERIFY_LOCK_HELD: '1' },
+        verifyProcessEnv: getVerifyProcessEnv({ GITHUB_ACTIONS: 'false' }, 'github-actions'),
+      },
+    );
+
+    expect(childEnv[VERIFY_PROFILE_ENV]).toBe('github-actions');
+    expect(childEnv.MIOFRAME_EXPENSIVE_COMMAND_LOCK_HELD).toBe('1');
+    expect(resolvePlaywrightContainerProfile(childEnv).name).toBe('github-actions');
   });
 });
 

--- a/scripts/verify.test.mjs
+++ b/scripts/verify.test.mjs
@@ -7,6 +7,7 @@ vi.mock('./lib/packageJsonImpact.mjs', () => ({
 import { isVisualRelevantPackageJsonChange } from './lib/packageJsonImpact.mjs';
 import {
   buildCommands,
+  getCiProfileRisk,
   getActionRequired,
   getBlockingLogIssue,
   getCliFilesOverride,
@@ -376,13 +377,44 @@ describe('getActionRequired', () => {
     expect(actions).toEqual(['None.']);
   });
 
+  it('adds a CI-profile rerun action when local Playwright risk remains', () => {
+    const actions = getActionRequired(
+      [
+        {
+          label: 'e2e',
+          command: 'pnpm e2e:container',
+          status: 'passed',
+          exitCode: 0,
+          hasWarnings: false,
+          warningSummary: '',
+          blockingLogIssue: null,
+        },
+      ],
+      {
+        ciProfileRisk: {
+          affectedChecks: ['e2e'],
+          activeProfile: { name: 'local' },
+        },
+      },
+    );
+
+    expect(actions).toContainEqual(
+      expect.stringContaining(
+        'CI-profile risk remains for e2e because local Playwright used profile local.',
+      ),
+    );
+    expect(actions).toContainEqual(
+      expect.stringContaining('pnpm verify --profile github-actions --only e2e'),
+    );
+  });
+
   it('reports a zero-exit blocked unit-tests result through the normal VERIFY RESULT summary', () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
     try {
       const summary = printSummary([], 'local-changes', [blockedUnitTestsResult]);
 
-      expect(summary).toEqual({ status: 'failed', hasFailed: true });
+      expect(summary).toEqual({ status: 'failed', hasFailed: true, hasCiProfileRisk: false });
 
       const output = logSpy.mock.calls.map((call) => call.join(' ')).join('\n');
 
@@ -394,6 +426,83 @@ describe('getActionRequired', () => {
     } finally {
       logSpy.mockRestore();
     }
+  });
+
+  it('reports CI-profile risk in the summary when local e2e passed under the local profile', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      const summary = printSummary(
+        ['scripts/verify.mjs'],
+        'local-base origin/develop',
+        [
+          {
+            label: 'e2e',
+            command: 'pnpm e2e:container',
+            displayCommand: 'pnpm e2e:container',
+            status: 'passed',
+            exitCode: 0,
+            hasWarnings: false,
+            warningSummary: '',
+            triggerReason: 'low-level path scripts/verify.mjs -> full app e2e',
+          },
+          {
+            label: 'e2e-install',
+            status: 'skipped',
+            reason: 'browser install is not required; Playwright container provides browsers',
+          },
+        ],
+        {
+          baseRef: 'origin/develop',
+          processEnv: {
+            GITHUB_ACTIONS: 'false',
+          },
+        },
+      );
+
+      expect(summary).toEqual({ status: 'passed', hasFailed: false, hasCiProfileRisk: true });
+
+      const output = logSpy.mock.calls.map((call) => call.join(' ')).join('\n');
+      expect(output).toContain('profile: local (source: default-local)');
+      expect(output).toContain('base ref: origin/develop');
+      expect(output).toContain('status: passed with CI-profile risk');
+      expect(output).toContain('heavy-check triggers:');
+      expect(output).toContain('e2e: low-level path scripts/verify.mjs -> full app e2e');
+      expect(output).toContain('ci profile risk:');
+      expect(output).toContain('Affected checks: e2e');
+      expect(output).toContain('workers: 1 -> 2');
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+});
+
+describe('getCiProfileRisk', () => {
+  it('omits CI-profile risk when Playwright checks did not run', () => {
+    expect(
+      getCiProfileRisk([
+        {
+          label: 'type-check',
+          status: 'passed',
+        },
+      ]),
+    ).toBeNull();
+  });
+
+  it('omits CI-profile risk when the GitHub Actions profile is already active', () => {
+    expect(
+      getCiProfileRisk(
+        [
+          {
+            label: 'visual',
+            status: 'passed',
+          },
+        ],
+        {
+          GITHUB_ACTIONS: 'true',
+        },
+      ),
+    ).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

Improves `pnpm verify` reporting so agents and CI can see when a local pass still has unresolved CI-profile risk.

- Report active environment/profile in the final verify summary.
- Add explicit verify profile override via `--profile` / `MIOFRAME_VERIFY_PROFILE`.
- Detect local Playwright e2e/visual passes that differ from the GitHub Actions Playwright container profile.
- Show run/skipped checks, heavy-check triggers, CI-profile risk, and action-required lines in the summary.
- Keep Playwright profile comparison metadata owned by the Playwright container tooling.
- Treat `scripts/playwrightContainer.mjs` changes as low-level app e2e risk.
- Update agent guidance to require reporting the verify summary instead of collapsing pass-with-risk to plain `verify passed`.

## Architecture Decision

Keep `pnpm verify` as the single quality-gate orchestrator. Local verification remains focused and summary-first; CI keeps step-level verbose logs but must not duplicate check-selection logic outside `verify`.

The profile override is a project-owned verification interface, not a recommendation to spoof GitHub Actions with `GITHUB_ACTIONS=true`.

## Ownership Matrix

- feature: N/A.
- entity: N/A.
- widget: N/A.
- page/pane: N/A.
- shared: N/A.
- service/worker: N/A.
- tooling / verify: check orchestration, summary shape, pass/fail status, profile-risk decision, action-required output.
- tooling / Playwright container: profile resolution, profile override source, resource-limit metadata, profile comparison output.
- tooling / e2e risk: changed-file classification for app e2e scope.
- documentation/rules: agent-facing verification reporting rules.

## Source of Truth

- `scripts/verify.mjs` for verification orchestration and summary output.
- `scripts/playwrightContainer.mjs` and `config/tooling.json` for Playwright container profile resolution/comparison.
- `scripts/lib/e2eRisk.mjs` for e2e scope risk classification.
- `.agents/skills/verification/SKILL.md` and `AGENTS.md` for agent reporting rules.
- `.github/workflows/verify.yml` remains CI grouping only.

## State Shape / API Contract

Adds:

- `pnpm verify --profile local|github-actions`
- `MIOFRAME_VERIFY_PROFILE=local|github-actions`
- verify summary fields for environment, profile, base ref, run/skipped checks, heavy-check triggers, CI-profile risk, and action-required output.

## User Scenarios Preserved

- Agents can keep using plain `pnpm verify` as the default completion gate.
- Local verification remains focused and low-noise.
- CI keeps verbose step logs and artifacts.
- A local pass with unresolved CI-profile risk is visible as `passed with CI-profile risk`, not silently reported as a clean pass.

## Shared UI / Blast Radius

N/A. Tooling and documentation only.

## Verification

- Focused script tests added/updated for profile override, child env propagation, Playwright profile comparison, CI-profile risk summary, and e2e-risk classification.
- CI for the latest head is currently in progress.

## Known Risks

- Need to inspect the final `VERIFY RESULT` output after CI completes to confirm the summary remains useful and not too noisy.
- `passed with CI-profile risk` intentionally remains zero-exit for local focused verification; it must be treated as not PR-ready by agent/reporting rules.

## Reviewer Notes

Review should focus on whether `verify` remains a single orchestrator, whether the summary is useful to agents without becoming noisy, and whether profile override/risk reporting avoids making full CI-equivalent verification mandatory for every local run.