### PR TITLE
fix(sortable): clear document selection during reorder suppression

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mioframe",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/src/shared/lib/sortable/useReorderSurface.helpers.test.ts
+++ b/src/shared/lib/sortable/useReorderSurface.helpers.test.ts
@@ -519,7 +519,7 @@ describe('useReorderSurface helpers', () => {
     range.selectNode(document.body);
     selection.removeAllRanges();
     selection.addRange(range);
-    expect(selection.rangeCount).toBeGreaterThan(0);
+    expect(selection.rangeCount).toBe(0);
 
     const secondRelease = acquireReorderDocumentSelectionSuppression();
 
@@ -539,6 +539,70 @@ describe('useReorderSurface helpers', () => {
     expect(
       document.documentElement.classList.contains(REORDER_DOCUMENT_SELECTION_SUPPRESSED_CLASS),
     ).toBe(false);
+  });
+
+  it('clears a selection created after acquisition while suppression is active', () => {
+    const selection = document.getSelection();
+
+    if (!selection) {
+      throw new Error('Selection API is unavailable in the test environment');
+    }
+
+    const release = acquireReorderDocumentSelectionSuppression();
+
+    const range = document.createRange();
+    range.selectNode(document.body);
+    selection.addRange(range);
+
+    document.dispatchEvent(new Event('selectionchange'));
+
+    expect(selection.rangeCount).toBe(0);
+
+    release();
+  });
+
+  it('stops clearing selection on selectionchange once suppression is fully released', () => {
+    const selection = document.getSelection();
+
+    if (!selection) {
+      throw new Error('Selection API is unavailable in the test environment');
+    }
+
+    const release = acquireReorderDocumentSelectionSuppression();
+    release();
+
+    const range = document.createRange();
+    range.selectNode(document.body);
+    selection.addRange(range);
+
+    document.dispatchEvent(new Event('selectionchange'));
+
+    expect(selection.rangeCount).toBeGreaterThan(0);
+
+    selection.removeAllRanges();
+  });
+
+  it('keeps selectionchange cleanup active after the first release while nested acquisition holds', () => {
+    const selection = document.getSelection();
+
+    if (!selection) {
+      throw new Error('Selection API is unavailable in the test environment');
+    }
+
+    const firstRelease = acquireReorderDocumentSelectionSuppression();
+    const secondRelease = acquireReorderDocumentSelectionSuppression();
+
+    firstRelease();
+
+    const range = document.createRange();
+    range.selectNode(document.body);
+    selection.addRange(range);
+
+    document.dispatchEvent(new Event('selectionchange'));
+
+    expect(selection.rangeCount).toBe(0);
+
+    secondRelease();
   });
 
   it('makes repeated token release harmless', () => {

--- a/src/shared/lib/sortable/useReorderSurface.helpers.test.ts
+++ b/src/shared/lib/sortable/useReorderSurface.helpers.test.ts
@@ -481,6 +481,66 @@ describe('useReorderSurface helpers', () => {
     expect(releasedEvent.defaultPrevented).toBe(false);
   });
 
+  it('clears an existing document selection immediately when suppression is acquired', () => {
+    const selection = document.getSelection();
+
+    if (!selection) {
+      throw new Error('Selection API is unavailable in the test environment');
+    }
+
+    const range = document.createRange();
+    range.selectNode(document.body);
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    expect(selection.rangeCount).toBeGreaterThan(0);
+
+    const release = acquireReorderDocumentSelectionSuppression();
+
+    expect(selection.rangeCount).toBe(0);
+
+    release();
+  });
+
+  it('clears newly created selection on repeated/nested acquisition without losing reference counting', () => {
+    const selection = document.getSelection();
+
+    if (!selection) {
+      throw new Error('Selection API is unavailable in the test environment');
+    }
+
+    const firstRelease = acquireReorderDocumentSelectionSuppression();
+
+    expect(
+      document.documentElement.classList.contains(REORDER_DOCUMENT_SELECTION_SUPPRESSED_CLASS),
+    ).toBe(true);
+
+    const range = document.createRange();
+    range.selectNode(document.body);
+    selection.removeAllRanges();
+    selection.addRange(range);
+    expect(selection.rangeCount).toBeGreaterThan(0);
+
+    const secondRelease = acquireReorderDocumentSelectionSuppression();
+
+    expect(selection.rangeCount).toBe(0);
+    expect(
+      document.documentElement.classList.contains(REORDER_DOCUMENT_SELECTION_SUPPRESSED_CLASS),
+    ).toBe(true);
+
+    firstRelease();
+
+    expect(
+      document.documentElement.classList.contains(REORDER_DOCUMENT_SELECTION_SUPPRESSED_CLASS),
+    ).toBe(true);
+
+    secondRelease();
+
+    expect(
+      document.documentElement.classList.contains(REORDER_DOCUMENT_SELECTION_SUPPRESSED_CLASS),
+    ).toBe(false);
+  });
+
   it('makes repeated token release harmless', () => {
     const release = acquireReorderDocumentSelectionSuppression();
 

--- a/src/shared/lib/sortable/useReorderSurface.helpers.ts
+++ b/src/shared/lib/sortable/useReorderSurface.helpers.ts
@@ -373,6 +373,18 @@ const clearActiveDocumentSelection = () => {
 };
 
 /**
+ * Clears any document selection created while reorder suppression is still acquired.
+ * Native `selectionchange` can fire even when `selectstart` was prevented (e.g. selection
+ * extension via keyboard, find-in-page, or platform-specific touch handling), so suppression
+ * must keep clearing selection for its whole acquired lifetime, not only at acquire time.
+ */
+const clearSelectionWhileSuppressed = () => {
+  if (reorderSelectionSuppressionDepth > 0) {
+    clearActiveDocumentSelection();
+  }
+};
+
+/**
  * Checks whether the event target belongs to a draggable reorder item.
  * @param target - Event target to inspect.
  * @returns True when the target is inside a draggable reorder item.
@@ -405,6 +417,7 @@ export const acquireReorderDocumentSelectionSuppression = (): (() => void) => {
   if (reorderSelectionSuppressionDepth === 1) {
     rootEl.classList.add(REORDER_DOCUMENT_SELECTION_SUPPRESSED_CLASS);
     document.addEventListener('selectstart', preventReorderSelectionStart, true);
+    document.addEventListener('selectionchange', clearSelectionWhileSuppressed);
   }
 
   let released = false;
@@ -420,6 +433,7 @@ export const acquireReorderDocumentSelectionSuppression = (): (() => void) => {
     if (reorderSelectionSuppressionDepth === 0) {
       rootEl.classList.remove(REORDER_DOCUMENT_SELECTION_SUPPRESSED_CLASS);
       document.removeEventListener('selectstart', preventReorderSelectionStart, true);
+      document.removeEventListener('selectionchange', clearSelectionWhileSuppressed);
     }
   };
 };

--- a/src/shared/lib/sortable/useReorderSurface.helpers.ts
+++ b/src/shared/lib/sortable/useReorderSurface.helpers.ts
@@ -358,6 +358,21 @@ const preventReorderSelectionStart = (event: Event) => {
 };
 
 /**
+ * Removes any active document selection ranges, if the Selection API is available.
+ */
+const clearActiveDocumentSelection = () => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const selection = document.getSelection();
+
+  if (selection && selection.rangeCount > 0) {
+    selection.removeAllRanges();
+  }
+};
+
+/**
  * Checks whether the event target belongs to a draggable reorder item.
  * @param target - Event target to inspect.
  * @returns True when the target is inside a draggable reorder item.
@@ -367,6 +382,10 @@ export const isReorderItemTarget = (target: EventTarget | null): boolean =>
 
 /**
  * Acquires document-level text-selection suppression for an active reorder interaction.
+ *
+ * Clears any selection already present in the document immediately, since native
+ * selection can be created or extended in the window before this suppression takes
+ * effect (e.g. between pointerdown activation and SortableJS reporting drag start).
  * @returns Idempotent release function for the acquired suppression token.
  */
 export const acquireReorderDocumentSelectionSuppression = (): (() => void) => {
@@ -379,6 +398,8 @@ export const acquireReorderDocumentSelectionSuppression = (): (() => void) => {
   if (!(rootEl instanceof HTMLElement)) {
     return () => {};
   }
+
+  clearActiveDocumentSelection();
 
   reorderSelectionSuppressionDepth += 1;
   if (reorderSelectionSuppressionDepth === 1) {
@@ -414,11 +435,7 @@ export const cleanupPostDragInteraction = (
     return;
   }
 
-  const selection = document.getSelection();
-
-  if (selection && selection.rangeCount > 0) {
-    selection.removeAllRanges();
-  }
+  clearActiveDocumentSelection();
 
   const activeElement = document.activeElement;
 

--- a/src/shared/lib/sortable/useReorderSurface.test.ts
+++ b/src/shared/lib/sortable/useReorderSurface.test.ts
@@ -452,7 +452,6 @@ describe('useReorderSurface', () => {
     range.selectNode(document.body);
     selection.removeAllRanges();
     selection.addRange(range);
-    vi.spyOn(selection, 'rangeCount', 'get').mockReturnValue(1);
     const removeAllRangesSpy = vi.spyOn(selection, 'removeAllRanges');
     const blurSpy = vi.spyOn(child, 'blur');
     child.focus();
@@ -495,7 +494,8 @@ describe('useReorderSurface', () => {
     expect(preventDefault).toHaveBeenCalled();
     expect(stopPropagation).toHaveBeenCalled();
     expect(stopImmediatePropagation).toHaveBeenCalled();
-    expect(removeAllRangesSpy).toHaveBeenCalledTimes(3);
+    expect(removeAllRangesSpy).toHaveBeenCalled();
+    expect(selection.rangeCount).toBe(0);
     expect(rafMock).toHaveBeenCalledTimes(1);
     expect(blurSpy).toHaveBeenCalled();
     expect(api.suppressNextClick.value).toBe(false);

--- a/src/shared/lib/sortable/useReorderSurface.test.ts
+++ b/src/shared/lib/sortable/useReorderSurface.test.ts
@@ -452,10 +452,7 @@ describe('useReorderSurface', () => {
     range.selectNode(document.body);
     selection.removeAllRanges();
     selection.addRange(range);
-    Object.defineProperty(selection, 'rangeCount', {
-      configurable: true,
-      get: () => 1,
-    });
+    vi.spyOn(selection, 'rangeCount', 'get').mockReturnValue(1);
     const removeAllRangesSpy = vi.spyOn(selection, 'removeAllRanges');
     const blurSpy = vi.spyOn(child, 'blur');
     child.focus();
@@ -498,7 +495,7 @@ describe('useReorderSurface', () => {
     expect(preventDefault).toHaveBeenCalled();
     expect(stopPropagation).toHaveBeenCalled();
     expect(stopImmediatePropagation).toHaveBeenCalled();
-    expect(removeAllRangesSpy).toHaveBeenCalledTimes(2);
+    expect(removeAllRangesSpy).toHaveBeenCalledTimes(3);
     expect(rafMock).toHaveBeenCalledTimes(1);
     expect(blurSpy).toHaveBeenCalled();
     expect(api.suppressNextClick.value).toBe(false);
@@ -802,6 +799,44 @@ describe('useReorderSurface', () => {
     expect(
       document.documentElement.classList.contains(REORDER_DOCUMENT_SELECTION_SUPPRESSED_CLASS),
     ).toBe(false);
+  });
+
+  it('clears selection created between activation and drag start without relying on post-drag cleanup', async () => {
+    const selection = document.getSelection();
+
+    if (!selection) {
+      throw new Error('Selection API is unavailable in the test environment');
+    }
+
+    const itemIdList = ref<string[] | undefined>(['a', 'b', 'c']);
+    const { containerEl } = mountUseReorderSurface({
+      itemIdList,
+    });
+    const row = document.createElement('button');
+    row.setAttribute('data-sortable-id', 'a');
+    containerEl.appendChild(row);
+
+    row.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    await nextTick();
+
+    expect(containerEl.classList.contains(REORDER_SURFACE_ACTIVATING_CLASS)).toBe(true);
+
+    const range = document.createRange();
+    range.selectNode(row);
+    selection.removeAllRanges();
+    selection.addRange(range);
+    expect(selection.rangeCount).toBeGreaterThan(0);
+
+    sortableAdapterState.callbacks?.onStart?.({
+      itemId: 'a',
+      orderedIds: ['a', 'b', 'c'],
+      fromIndex: 0,
+      toIndex: 0,
+    });
+
+    expect(selection.rangeCount).toBe(0);
+
+    await nextTick();
   });
 
   it('applies activation suppression synchronously on valid reorder-item input', async () => {

--- a/src/shared/lib/sortable/useReorderSurface.test.ts
+++ b/src/shared/lib/sortable/useReorderSurface.test.ts
@@ -825,7 +825,7 @@ describe('useReorderSurface', () => {
     range.selectNode(row);
     selection.removeAllRanges();
     selection.addRange(range);
-    expect(selection.rangeCount).toBeGreaterThan(0);
+    expect(selection.rangeCount).toBe(0);
 
     sortableAdapterState.callbacks?.onStart?.({
       itemId: 'a',


### PR DESCRIPTION
## Summary

Fixes the post-merge `develop` e2e failure where `reorderSurfaceDragSmoke.spec.ts` could leak native text selection during active view reordering.

- Clear active document selection immediately when reorder document-level selection suppression is acquired.
- Keep selection suppression active for the whole reference-counted lifecycle by clearing new selections on `selectionchange` while suppression depth is greater than zero.
- Add/remove the `selectionchange` listener together with the existing document-level suppression lifecycle.
- Reuse the same selection-clearing helper in post-drag cleanup.
- Add focused sortable helper/composable tests for immediate selection clearing, active `selectionchange` cleanup, nested suppression, and release cleanup.
- Replace a brittle exact `removeAllRanges()` call-count assertion with behavior-level selection cleanup assertions.
- Keep the strict e2e assertion unchanged.
- Bump package version from `0.1.12` to `0.1.13` for the develop PR version policy.

## Architecture Decision

Selection suppression is part of the shared reorder surface contract. The fix belongs in `src/shared/lib/sortable`, not in database-view feature code, pane/widget composition, e2e workarounds, or CI retries.

The existing reference-counted document-level suppression remains the source of truth. The implementation strengthens it from a one-shot acquire cleanup into an active suppression mode for the full acquired lifetime:

- immediate clear on acquire;
- `selectstart` prevention remains;
- `selectionchange` cleanup clears selections created after acquisition;
- cleanup remains tied to the same depth-based release lifecycle.

## Ownership Matrix

- feature: N/A. Database views consume the shared reorder contract and do not own native selection suppression.
- entity: N/A.
- widget: N/A.
- page/pane: N/A.
- shared: `src/shared/lib/sortable` owns reorder activation, drag lifecycle, document-level selection suppression, active selection cleanup, post-drag cleanup, and focused tests.
- service/worker: N/A.
- tooling/release: `package.json` version bump only.

## Source of Truth

- `src/shared/lib/sortable/useReorderSurface.helpers.ts`
- `src/shared/lib/sortable/useReorderSurface.helpers.test.ts`
- `src/shared/lib/sortable/useReorderSurface.test.ts`
- `tests/e2e/reorderSurfaceDragSmoke.spec.ts` remains the product-level regression check and is intentionally not changed.

## State Shape / API Contract

No public app state, service, worker, router, feature, or component API changes.

Shared sortable behavior changes internally:

- acquiring reorder document selection suppression clears active document selection immediately;
- selection created while suppression is active is cleared on `selectionchange`;
- reference-counted acquisition/release remains idempotent;
- listeners/classes are installed only on depth `0 → 1` and removed only on `1 → 0`;
- existing `selectstart` prevention and CSS suppression remain in place;
- post-drag cleanup keeps clearing selection via the same helper.

## User Scenarios Preserved

- Reordering database views by drag must not leave or expose native text selection.
- Reorder click suppression after drag remains preserved.
- Touch/pointer/mouse reorder behavior remains unchanged except for stronger selection cleanup.

## Shared UI / Blast Radius

No visual UI changes. Blast radius is limited to shared sortable selection behavior used by reorder surfaces.

## Verification

Agent-reported local checks:

- `pnpm exec vitest run src/shared/lib/sortable` — passed.
- `pnpm type-check` — passed.
- `pnpm verify --profile github-actions --verbose --only e2e --files tests/e2e/reorderSurfaceDragSmoke.spec.ts` — target regression spec passed in both `chromium` and `Mobile Chrome`.
- `pnpm verify` — passed locally with CI-profile risk noted for the full e2e profile.

GitHub CI for current head `b4879368027731d82a4f582cb5e5fa22c30bf405`:

- autofix — passed.
- verify — passed.
- Validate version bump — passed.
- format — passed.
- oxlint — passed.
- eslint — passed.
- type-check — passed.
- unit tests — passed.
- e2e — passed.
- visual — passed.
- mutation — passed.
- deploy-preview — passed.

## Known Risks

No known remaining blocker for this PR. The change affects shared sortable selection behavior, so future reorder-surface regressions should be watched, but the blast radius is intentionally limited to the shared sortable lifecycle.

## Reviewer Notes

Review focus:

- `reorderSurfaceDragSmoke.spec.ts` is unchanged and remains strict;
- no Playwright retries, `failOnFlakyTests`, worker count, or CI workflow changes were made;
- selection clearing remains owned by shared sortable infrastructure;
- reference-counted suppression release behavior remains explicit;
- package version bump is the only tooling/release change.