### PR TITLE
fix(e2e): refine package.json change impact handling for e2e tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mioframe",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mioframe",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/scripts/lib/e2eRisk.mjs
+++ b/scripts/lib/e2eRisk.mjs
@@ -1,11 +1,14 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { isPackageJsonRuntimeRelevantChange } from './packageJsonImpact.mjs';
+
 const VISUAL_SPEC_PREFIX = 'tests/e2e/visual/';
 const RELEASE_SPEC_PREFIX = 'tests/e2e/release/';
 const E2E_DIR_PREFIX = 'tests/e2e/';
 const APP_E2E_SPEC_DIR = 'tests/e2e';
 const STORIES_PATTERN = /\.stories\.(ts|tsx|js|jsx|mjs|vue)$/;
+const PACKAGE_JSON_PATH = 'package.json';
 
 const LOW_LEVEL_E2E_EXACT_FILES = new Set([
   'playwright.config.ts',
@@ -15,7 +18,6 @@ const LOW_LEVEL_E2E_EXACT_FILES = new Set([
   'scripts/playwrightContainer.mjs',
   'scripts/verify.mjs',
   'vite.config.ts',
-  'package.json',
   'pnpm-lock.yaml',
 ]);
 
@@ -375,14 +377,19 @@ export function isUnmappedSourcePath(filePath) {
 /**
  * Resolve the app e2e mode for the given changed files, in priority order:
  * invalid (scenario registry failed self-validation; fail closed instead of
- * silently skipping), full (low-level/unmapped/e2e-support risk), focused
- * (scenario registry matches and/or changed app e2e specs), or skip (no app
- * e2e relevant changes). Visual specs and visual-relevant paths never feed
- * this resolver; visual selection stays independent.
+ * silently skipping), full (low-level/unmapped/e2e-support/package.json
+ * risk), focused (scenario registry matches and/or changed app e2e specs),
+ * or skip (no app e2e relevant changes). Visual specs and visual-relevant
+ * paths never feed this resolver; visual selection stays independent.
  * @param changedFiles Sorted unique list of repository-relative changed file paths.
+ * @param [options] Resolution options.
+ * @param [options.packageJsonOldRef] Git ref to compare the current
+ * `package.json` against, for the version-only e2e impact refinement. Pass
+ * `null` when no reliable base ref is known; that fails closed to
+ * runtime-relevant (full app e2e).
  * @returns Plan with `mode`, candidate `specs`, and human-readable `reasons`.
  */
-export function resolveAppE2EPlan(changedFiles) {
+export function resolveAppE2EPlan(changedFiles, { packageJsonOldRef = null } = {}) {
   const registryValidation = validateE2EScenarioRegistry();
 
   if (!registryValidation.valid) {
@@ -392,10 +399,17 @@ export function resolveAppE2EPlan(changedFiles) {
   const lowLevelHit = changedFiles.find(isLowLevelE2EPath);
   const unmappedHit = changedFiles.find(isUnmappedSourcePath);
   const supportHit = changedFiles.find(isAppE2ESupportPath);
+  const isPackageJsonRuntimeRelevant =
+    changedFiles.includes(PACKAGE_JSON_PATH) &&
+    isPackageJsonRuntimeRelevantChange({ oldRef: packageJsonOldRef });
   const fullReasons = [];
 
   if (lowLevelHit) {
     fullReasons.push(`low-level path ${lowLevelHit} -> full app e2e`);
+  }
+
+  if (isPackageJsonRuntimeRelevant) {
+    fullReasons.push(`runtime-relevant package.json change -> full app e2e`);
   }
 
   if (unmappedHit) {

--- a/scripts/lib/e2eRisk.test.mjs
+++ b/scripts/lib/e2eRisk.test.mjs
@@ -1,5 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+vi.mock('./packageJsonImpact.mjs', () => ({
+  isPackageJsonRuntimeRelevantChange: vi.fn(),
+}));
+
+import { isPackageJsonRuntimeRelevantChange } from './packageJsonImpact.mjs';
 import {
   APP_E2E_STANDALONE_SPECS,
   E2E_SCENARIO_SCOPES,
@@ -38,8 +43,12 @@ describe('isLowLevelE2EPath', () => {
     expect(isLowLevelE2EPath('scripts/playwrightContainer.mjs')).toBe(true);
     expect(isLowLevelE2EPath('scripts/verify.mjs')).toBe(true);
     expect(isLowLevelE2EPath('scripts/lib/e2eRisk.mjs')).toBe(true);
-    expect(isLowLevelE2EPath('package.json')).toBe(true);
+    expect(isLowLevelE2EPath('pnpm-lock.yaml')).toBe(true);
     expect(isLowLevelE2EPath('tsconfig.app.json')).toBe(true);
+  });
+
+  it('does not unconditionally flag package.json; its e2e impact is resolved separately', () => {
+    expect(isLowLevelE2EPath('package.json')).toBe(false);
   });
 
   it('flags app bootstrap, shared service, and shared UI prefixes', () => {
@@ -263,5 +272,55 @@ describe('resolveAppE2EPlan', () => {
     const plan = resolveAppE2EPlan(['README.md']);
 
     expect(plan.mode).toBe('skip');
+  });
+});
+
+describe('resolveAppE2EPlan package.json impact', () => {
+  beforeEach(() => {
+    isPackageJsonRuntimeRelevantChange.mockReset();
+  });
+
+  it('skips app e2e for a confirmed version-only package.json change', () => {
+    isPackageJsonRuntimeRelevantChange.mockReturnValue(false);
+
+    const plan = resolveAppE2EPlan(['package.json'], { packageJsonOldRef: 'HEAD~1' });
+
+    expect(plan.mode).toBe('skip');
+    expect(isPackageJsonRuntimeRelevantChange).toHaveBeenCalledWith({ oldRef: 'HEAD~1' });
+  });
+
+  it('runs full app e2e when the package.json change is runtime-relevant', () => {
+    isPackageJsonRuntimeRelevantChange.mockReturnValue(true);
+
+    const plan = resolveAppE2EPlan(['package.json'], { packageJsonOldRef: 'HEAD~1' });
+
+    expect(plan.mode).toBe('full');
+    expect(plan.reasons[0]).toContain('runtime-relevant package.json change');
+  });
+
+  it('runs full app e2e when the old package.json ref is missing (fails closed)', () => {
+    isPackageJsonRuntimeRelevantChange.mockReturnValue(true);
+
+    const plan = resolveAppE2EPlan(['package.json'], { packageJsonOldRef: null });
+
+    expect(plan.mode).toBe('full');
+    expect(isPackageJsonRuntimeRelevantChange).toHaveBeenCalledWith({ oldRef: null });
+  });
+
+  it('runs full app e2e for a version-only package.json change alongside another full-e2e path', () => {
+    isPackageJsonRuntimeRelevantChange.mockReturnValue(false);
+
+    const plan = resolveAppE2EPlan(['package.json', 'playwright.config.ts'], {
+      packageJsonOldRef: 'HEAD~1',
+    });
+
+    expect(plan.mode).toBe('full');
+    expect(plan.reasons[0]).toContain('low-level path playwright.config.ts');
+  });
+
+  it('does not consult the package.json impact check when package.json did not change', () => {
+    resolveAppE2EPlan(['src/app/setupApp.ts']);
+
+    expect(isPackageJsonRuntimeRelevantChange).not.toHaveBeenCalled();
   });
 });

--- a/scripts/lib/packageJsonImpact.mjs
+++ b/scripts/lib/packageJsonImpact.mjs
@@ -25,11 +25,12 @@ export function isPackageJsonVersionOnlyChange(oldContent, newContent) {
 }
 
 /**
- * Determine whether a `package.json` change is visual-relevant. The change
- * is treated as visual-relevant unless it can be positively confirmed as a
+ * Determine whether a `package.json` change is runtime-relevant, i.e. it
+ * changes anything other than the top-level `version` field. The change is
+ * treated as runtime-relevant unless it can be positively confirmed as a
  * version-only change; any failure to resolve a comparison fails closed
- * (visual-relevant), so unknown `package.json` impact never skips visual
- * checks.
+ * (runtime-relevant), so unknown `package.json` impact never skips
+ * downstream checks.
  * @param [options] Comparison inputs.
  * @param [options.oldRef] Git ref to read the prior `package.json` content
  * from, or `null` when no reliable base ref is known for the current verify
@@ -38,9 +39,10 @@ export function isPackageJsonVersionOnlyChange(oldContent, newContent) {
  * repository root.
  * @param [options.spawn] Injectable `spawnSync`, for tests.
  * @param [options.readFile] Injectable file reader, for tests.
- * @returns `true` when visual checks should still run for this change.
+ * @returns `true` when downstream checks should still treat this change as
+ * relevant.
  */
-export function isVisualRelevantPackageJsonChange({
+export function isPackageJsonRuntimeRelevantChange({
   oldRef = null,
   packageJsonPath = 'package.json',
   spawn = spawnSync,
@@ -65,6 +67,18 @@ export function isVisualRelevantPackageJsonChange({
   }
 
   return !isPackageJsonVersionOnlyChange(oldContent, newContent);
+}
+
+/**
+ * Determine whether a `package.json` change is visual-relevant. Wraps
+ * {@link isPackageJsonRuntimeRelevantChange}: the same version-only
+ * confirmation logic determines whether visual checks can be skipped.
+ * @param [options] Comparison inputs; see
+ * {@link isPackageJsonRuntimeRelevantChange} for details.
+ * @returns `true` when visual checks should still run for this change.
+ */
+export function isVisualRelevantPackageJsonChange(options = {}) {
+  return isPackageJsonRuntimeRelevantChange(options);
 }
 
 function readGitFileAtRef(ref, filePath, spawn) {

--- a/scripts/lib/packageJsonImpact.test.mjs
+++ b/scripts/lib/packageJsonImpact.test.mjs
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  isPackageJsonRuntimeRelevantChange,
   isPackageJsonVersionOnlyChange,
   isVisualRelevantPackageJsonChange,
 } from './packageJsonImpact.mjs';
@@ -122,5 +123,93 @@ describe('isVisualRelevantPackageJsonChange', () => {
       .mockReturnValue(JSON.stringify({ version: '0.1.1', dependencies: { vue: '1.0.1' } }));
 
     expect(isVisualRelevantPackageJsonChange({ oldRef: 'HEAD~1', spawn, readFile })).toBe(true);
+  });
+});
+
+describe('isPackageJsonRuntimeRelevantChange', () => {
+  it('fails closed (runtime-relevant) when no base ref is known', () => {
+    const spawn = vi.fn();
+    const readFile = vi.fn();
+
+    expect(isPackageJsonRuntimeRelevantChange({ oldRef: null, spawn, readFile })).toBe(true);
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('fails closed (runtime-relevant) when the old ref is missing (git show fails)', () => {
+    const spawn = vi.fn().mockReturnValue({ status: 1, stdout: '' });
+    const readFile = vi.fn().mockReturnValue(JSON.stringify({ version: '0.1.0' }));
+
+    expect(isPackageJsonRuntimeRelevantChange({ oldRef: 'origin/develop', spawn, readFile })).toBe(
+      true,
+    );
+  });
+
+  it('fails closed (runtime-relevant) when the current file cannot be read', () => {
+    const spawn = vi.fn().mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify({ version: '0.1.0' }),
+    });
+    const readFile = vi.fn().mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+
+    expect(isPackageJsonRuntimeRelevantChange({ oldRef: 'HEAD~1', spawn, readFile })).toBe(true);
+  });
+
+  it('fails closed (runtime-relevant) when either content cannot be parsed', () => {
+    const spawn = vi.fn().mockReturnValue({ status: 0, stdout: 'not json' });
+    const readFile = vi.fn().mockReturnValue(JSON.stringify({ version: '0.1.0' }));
+
+    expect(isPackageJsonRuntimeRelevantChange({ oldRef: 'HEAD~1', spawn, readFile })).toBe(true);
+  });
+
+  it('is not runtime-relevant for a confirmed version-only bump', () => {
+    const spawn = vi.fn().mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify({ name: 'mioframe', version: '0.1.0' }),
+    });
+    const readFile = vi
+      .fn()
+      .mockReturnValue(JSON.stringify({ name: 'mioframe', version: '0.1.1' }));
+
+    expect(isPackageJsonRuntimeRelevantChange({ oldRef: 'HEAD~1', spawn, readFile })).toBe(false);
+    expect(spawn).toHaveBeenCalledWith('git', ['show', 'HEAD~1:package.json'], expect.any(Object));
+    expect(readFile).toHaveBeenCalledWith('package.json', 'utf8');
+  });
+
+  it('is runtime-relevant when a dependency changed alongside version', () => {
+    const spawn = vi.fn().mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify({ version: '0.1.0', dependencies: { vue: '1.0.0' } }),
+    });
+    const readFile = vi
+      .fn()
+      .mockReturnValue(JSON.stringify({ version: '0.1.1', dependencies: { vue: '1.0.1' } }));
+
+    expect(isPackageJsonRuntimeRelevantChange({ oldRef: 'HEAD~1', spawn, readFile })).toBe(true);
+  });
+
+  it('is runtime-relevant when a script changed alongside version', () => {
+    const spawn = vi.fn().mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify({ version: '0.1.0', scripts: { build: 'vite build' } }),
+    });
+    const readFile = vi
+      .fn()
+      .mockReturnValue(JSON.stringify({ version: '0.1.1', scripts: { build: 'vite build --x' } }));
+
+    expect(isPackageJsonRuntimeRelevantChange({ oldRef: 'HEAD~1', spawn, readFile })).toBe(true);
+  });
+
+  it('is runtime-relevant when packageManager changed alongside version', () => {
+    const spawn = vi.fn().mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify({ version: '0.1.0', packageManager: 'pnpm@9.0.0' }),
+    });
+    const readFile = vi
+      .fn()
+      .mockReturnValue(JSON.stringify({ version: '0.1.1', packageManager: 'pnpm@9.1.0' }));
+
+    expect(isPackageJsonRuntimeRelevantChange({ oldRef: 'HEAD~1', spawn, readFile })).toBe(true);
   });
 });

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -1414,7 +1414,7 @@ export function buildCommands(
     isVisualRelevantPackageJsonChange({ oldRef: packageJsonOldRef });
   const hasVisualRelevantChanges =
     changedFiles.some(isVisualRelevantFile) || isPackageJsonVisualRelevant;
-  const appE2EPlan = resolveAppE2EPlan(changedFiles);
+  const appE2EPlan = resolveAppE2EPlan(changedFiles, { packageJsonOldRef });
   const mutationScope = getMutationScope(changedFiles);
   const commands = [];
   const eslintConcurrency = resolveEslintConcurrency();

--- a/scripts/verify.test.mjs
+++ b/scripts/verify.test.mjs
@@ -2,9 +2,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('./lib/packageJsonImpact.mjs', () => ({
   isVisualRelevantPackageJsonChange: vi.fn(),
+  isPackageJsonRuntimeRelevantChange: vi.fn(),
 }));
 
-import { isVisualRelevantPackageJsonChange } from './lib/packageJsonImpact.mjs';
+import {
+  isPackageJsonRuntimeRelevantChange,
+  isVisualRelevantPackageJsonChange,
+} from './lib/packageJsonImpact.mjs';
 import {
   buildCommandEnv,
   buildCommands,
@@ -230,6 +234,62 @@ describe('buildCommands package.json visual relevance', () => {
     buildCommands(['src/app/main.ts'], { fullMode: false });
 
     expect(isVisualRelevantPackageJsonChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('buildCommands package.json app e2e relevance', () => {
+  beforeEach(() => {
+    isPackageJsonRuntimeRelevantChange.mockReset();
+  });
+
+  it('skips app e2e for a confirmed version-only package.json change with no other e2e-relevant files', () => {
+    isPackageJsonRuntimeRelevantChange.mockReturnValue(false);
+
+    const commands = buildCommands(['package.json'], {
+      fullMode: false,
+      packageJsonOldRef: 'HEAD~1',
+    });
+    const e2eEntry = commands.find((entry) => entry.label === 'e2e');
+
+    expect(e2eEntry.kind).toBe('skipped');
+    expect(e2eEntry.reason).toBe('empty e2e scope');
+    expect(isPackageJsonRuntimeRelevantChange).toHaveBeenCalledWith({ oldRef: 'HEAD~1' });
+  });
+
+  it('runs full app e2e when the package.json impact check is runtime-relevant', () => {
+    isPackageJsonRuntimeRelevantChange.mockReturnValue(true);
+
+    const commands = buildCommands(['package.json'], {
+      fullMode: false,
+      packageJsonOldRef: 'HEAD~1',
+    });
+    const e2eEntry = commands.find((entry) => entry.label === 'e2e');
+
+    expect(e2eEntry.kind).toBe('run');
+    expect(e2eEntry.triggerReason).toContain('runtime-relevant package.json change');
+  });
+
+  it('runs full app e2e when the package.json comparison cannot be resolved', () => {
+    isPackageJsonRuntimeRelevantChange.mockReturnValue(true);
+
+    const commands = buildCommands(['package.json'], { fullMode: false, packageJsonOldRef: null });
+    const e2eEntry = commands.find((entry) => entry.label === 'e2e');
+
+    expect(e2eEntry.kind).toBe('run');
+    expect(isPackageJsonRuntimeRelevantChange).toHaveBeenCalledWith({ oldRef: null });
+  });
+
+  it('still runs full app e2e for other full-app-e2e-relevant files when package.json is version-only', () => {
+    isPackageJsonRuntimeRelevantChange.mockReturnValue(false);
+
+    const commands = buildCommands(['package.json', 'src/shared/service/serviceWorker.ts'], {
+      fullMode: false,
+      packageJsonOldRef: 'HEAD~1',
+    });
+    const e2eEntry = commands.find((entry) => entry.label === 'e2e');
+
+    expect(e2eEntry.kind).toBe('run');
+    expect(e2eEntry.triggerReason).toContain('low-level path src/shared/service/serviceWorker.ts');
   });
 });
 


### PR DESCRIPTION
## Summary

- Reuses the parsed-JSON `package.json` impact helper for e2e risk classification.
- Stops treating a confirmed top-level `version`-only `package.json` bump as full app e2e risk.
- Keeps dependency/script/packageManager/unknown `package.json` impact fail-closed to full app e2e.
- Passes `packageJsonOldRef` from `scripts/verify.mjs` into app e2e risk resolution.
- Adds package impact, e2e risk, and verify command-selection tests.
- Bumps `package.json` version from `0.1.14` to `0.1.15`.

## Architecture Decision

Keep GitHub Actions workflow unchanged. The workflow may continue invoking `pnpm verify --verbose --only e2e`; the `verify` risk layer decides whether the e2e check runs or skips.

`package.json` version-only detection must be based on parsed JSON comparison that ignores only the top-level `version` field. Regex or raw diff-line parsing is intentionally avoided.

Unknown `package.json` impact remains fail-closed and triggers full app e2e.

## Ownership Matrix

- feature: N/A
- entity: N/A
- widget: N/A
- page/pane: N/A
- shared: N/A
- service/worker: N/A
- verification tooling: `scripts/lib/packageJsonImpact.mjs`, `scripts/lib/e2eRisk.mjs`, `scripts/verify.mjs`

## Source of Truth

- `scripts/lib/packageJsonImpact.mjs` owns `package.json` diff classification.
- `scripts/lib/e2eRisk.mjs` owns app e2e risk mapping.
- `scripts/verify.mjs` owns changed-file/base-ref orchestration.

## State Shape / API Contract

- `isPackageJsonRuntimeRelevantChange(...)` returns `false` only for a confirmed top-level `version`-only change.
- `isVisualRelevantPackageJsonChange(...)` remains available as the existing public helper and delegates to the generic package impact helper.
- `resolveAppE2EPlan(changedFiles, { packageJsonOldRef })` receives package comparison context from `verify`.

## User Scenarios Preserved

- Version-only PR bump no longer runs full app e2e by itself.
- Runtime-relevant `package.json` changes still run full app e2e.
- Missing or unreadable comparison context still runs full app e2e.
- Visual package impact behavior remains unchanged.

## Shared UI / Blast Radius

N/A. No app UI or shared UI runtime code changed.

## Verification

- Focused: package impact, e2e risk, and verify command-selection tests added/updated.
- CI: verify workflow is running on the PR head.
- Note: this PR itself changes verify/e2e risk tooling, so full app e2e is still expected for this PR. The version-only skip behavior is covered by unit tests, not by expecting this PR's CI e2e step to skip.

## Known Risks

- Future confidence for the exact docs/version-only scenario should be visible on the next PR that changes only documentation plus `package.json` version.

## Reviewer Notes

Review should focus on whether `package.json` version-only detection remains fail-closed and whether no workflow-level skip was introduced.