### PR TITLE
fix(query): preserve append slot identity across query updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mioframe",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mioframe",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/src/shared/ui/Query/QueryGroup.vue
+++ b/src/shared/ui/Query/QueryGroup.vue
@@ -21,6 +21,12 @@ const slots = defineSlots<{
 
 const emptyPath: PropertyKey[] = [];
 const prependIndexToPath = (index: number, path: PropertyKey[]) => [index, ...path];
+
+// Distinct from every possible array `index` so the append slot keeps its DOM
+// identity when the keyed v-for length changes; an unkeyed trailing sibling
+// can otherwise be remounted, invalidating refs consumers (e.g. a Floating UI
+// anchor) hold into it.
+const appendSlotKey = Symbol('query-group-append');
 </script>
 
 <template>
@@ -60,6 +66,9 @@ const prependIndexToPath = (index: number, path: PropertyKey[]) => [index, ...pa
       />
     </template>
 
-    <slot name="groupAppend" :path="emptyPath" :operator="operator" />
+    <!-- @vue-expect-error `key` is a compiler-recognized vnode attribute here (verified: it keeps
+    this slot's rendered element identity stable in QueryObject.test.ts), not a real groupAppend
+    slot prop; vue-tsc still type-checks it against the defineSlots prop shape. -->
+    <slot :key="appendSlotKey" name="groupAppend" :path="emptyPath" :operator="operator" />
   </QueryContainer>
 </template>

--- a/src/shared/ui/Query/QueryObject.test.ts
+++ b/src/shared/ui/Query/QueryObject.test.ts
@@ -1,0 +1,39 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import QueryObject from './QueryObject.vue';
+import QueryGroup from './QueryGroup.vue';
+import { OPERATOR } from './constants';
+
+describe('QueryObject', () => {
+  it('keeps the objectAppend slot element identity when the query grows from empty to one entry', async () => {
+    const wrapper = mount(QueryObject, {
+      props: { query: {} },
+      slots: {
+        objectAppend: '<button class="append-marker">add</button>',
+      },
+    });
+
+    const elementBeforeGrow = wrapper.get('.append-marker').element;
+
+    await wrapper.setProps({ query: { title: 'value' } });
+
+    expect(wrapper.get('.append-marker').element).toBe(elementBeforeGrow);
+  });
+});
+
+describe('QueryGroup', () => {
+  it('keeps the groupAppend slot element identity when the array grows from empty to one entry', async () => {
+    const wrapper = mount(QueryGroup, {
+      props: { operator: OPERATOR.$and, parentOperator: OPERATOR.$eq, array: [] },
+      slots: {
+        groupAppend: '<button class="append-marker">add</button>',
+      },
+    });
+
+    const elementBeforeGrow = wrapper.get('.append-marker').element;
+
+    await wrapper.setProps({ array: ['value'] });
+
+    expect(wrapper.get('.append-marker').element).toBe(elementBeforeGrow);
+  });
+});

--- a/src/shared/ui/Query/QueryObject.vue
+++ b/src/shared/ui/Query/QueryObject.vue
@@ -26,6 +26,12 @@ const lastKey = computed(() => keyList.value.at(-1));
 
 const emptyPath: PropertyKey[] = [];
 const prependQueryKeyToPath = (queryKey: string, path: PropertyKey[]) => [queryKey, ...path];
+
+// Distinct from every possible `queryKey` so the append slot keeps its DOM
+// identity when the keyed v-for length changes; an unkeyed trailing sibling
+// can otherwise be remounted, invalidating refs consumers (e.g. a Floating UI
+// anchor) hold into it.
+const appendSlotKey = Symbol('query-object-append');
 </script>
 
 <template>
@@ -64,6 +70,9 @@ const prependQueryKeyToPath = (queryKey: string, path: PropertyKey[]) => [queryK
       />
     </template>
 
-    <slot name="objectAppend" :path="emptyPath" />
+    <!-- @vue-expect-error `key` is a compiler-recognized vnode attribute here (verified: it keeps
+    this slot's rendered element identity stable in QueryObject.test.ts), not a real objectAppend
+    slot prop; vue-tsc still type-checks it against the defineSlots prop shape. -->
+    <slot :key="appendSlotKey" name="objectAppend" :path="emptyPath" />
   </QueryContainer>
 </template>

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -546,24 +546,6 @@ export const openFilterSheet = async (page: Page) => {
 };
 
 /**
- * Wait until a locator's bounding box stops changing between polls, so the
- * following pointer interaction cannot race an ongoing scroll or transition.
- * @param target - Locator that must settle before the next pointer interaction.
- */
-const expectStablePosition = async (target: Locator) => {
-  let previousBox = '';
-
-  await expect
-    .poll(async () => {
-      const box = JSON.stringify(await target.boundingBox());
-      const isStable = box === previousBox && box !== 'null';
-      previousBox = box;
-      return isStable;
-    })
-    .toBe(true);
-};
-
-/**
  * Resolve a menuitem inside the visible menu surface that actually contains
  * it. Menus teleport to a shared overlay container, so a bare
  * `page.getByRole('menu')` could also match a stale, hidden, or unrelated
@@ -588,11 +570,8 @@ export const openEqualFilterDialog = async (page: Page, propertyName: string) =>
   const propertyItemName = new RegExp(`^${escapeRegex(propertyName)}$`, 'i');
   const propertyItem = findActiveMenuItem(page, propertyItemName);
 
-  if (!(await propertyItem.isVisible())) {
-    await addFilterButton.click();
-  }
+  await addFilterButton.click();
   await expect(propertyItem).toBeVisible();
-  await expectStablePosition(propertyItem);
   await propertyItem.click();
 
   // Selecting a property opens its operator submenu as a nested menu surface
@@ -600,7 +579,6 @@ export const openEqualFilterDialog = async (page: Page, propertyName: string) =>
   // item without positional guessing.
   const equalOperatorItem = findActiveMenuItem(page, /^(=|equal)$/i);
   await expect(equalOperatorItem).toBeVisible();
-  await expectStablePosition(equalOperatorItem);
   await equalOperatorItem.click();
 
   const dialog = page.getByRole('dialog', { name: /filter settings/i });

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -586,38 +586,21 @@ export const openEqualFilterDialog = async (page: Page, propertyName: string) =>
   const sheet = await openFilterSheet(page);
   const addFilterButton = sheet.getByRole('button', { name: /^and$/i });
   const propertyItemName = new RegExp(`^${escapeRegex(propertyName)}$`, 'i');
+  const propertyItem = findActiveMenuItem(page, propertyItemName);
+
+  if (!(await propertyItem.isVisible())) {
+    await addFilterButton.click();
+  }
+  await expect(propertyItem).toBeVisible();
+  await expectStablePosition(propertyItem);
+  await propertyItem.click();
 
   // Selecting a property opens its operator submenu as a nested menu surface
   // inside the same active menu, so the same scoped lookup resolves the `=`
   // item without positional guessing.
   const equalOperatorItem = findActiveMenuItem(page, /^(=|equal)$/i);
-
-  // The bottom sheet positions its content with smooth scrolling and scroll
-  // snapping, so on small mobile viewports the add-filter button can still be
-  // moving right after the sheet reports visible. A click dispatched during
-  // that movement can land beside the button and no menu opens.
-  await expect(addFilterButton).toBeVisible();
-  await expectStablePosition(addFilterButton);
-
-  // Floating UI positioning, focus-trap activation, or nested-menu rendering
-  // can replace or detach the property menuitem between a readiness
-  // assertion and a later click, so the item is re-resolved and clicked
-  // inside one retried attempt, and the attempt only succeeds once the
-  // resulting operator submenu is visible.
-  await expect(async () => {
-    const propertyItem = findActiveMenuItem(page, propertyItemName);
-
-    // Only re-click when the active menu with the target property item really
-    // failed to appear; the add-filter button is in the menu's outside-ignore
-    // list, so a repeated click keeps an already-open menu open.
-    if (!(await propertyItem.isVisible())) {
-      await addFilterButton.click();
-    }
-    await expect(propertyItem).toBeVisible({ timeout: 2_000 });
-    await propertyItem.click();
-    await expect(equalOperatorItem).toBeVisible({ timeout: 2_000 });
-  }).toPass({ timeout: 15_000 });
-
+  await expect(equalOperatorItem).toBeVisible();
+  await expectStablePosition(equalOperatorItem);
   await equalOperatorItem.click();
 
   const dialog = page.getByRole('dialog', { name: /filter settings/i });

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -585,7 +585,12 @@ const findActiveMenuItem = (page: Page, itemName: RegExp) =>
 export const openEqualFilterDialog = async (page: Page, propertyName: string) => {
   const sheet = await openFilterSheet(page);
   const addFilterButton = sheet.getByRole('button', { name: /^and$/i });
-  const propertyItem = findActiveMenuItem(page, new RegExp(`^${escapeRegex(propertyName)}$`, 'i'));
+  const propertyItemName = new RegExp(`^${escapeRegex(propertyName)}$`, 'i');
+
+  // Selecting a property opens its operator submenu as a nested menu surface
+  // inside the same active menu, so the same scoped lookup resolves the `=`
+  // item without positional guessing.
+  const equalOperatorItem = findActiveMenuItem(page, /^(=|equal)$/i);
 
   // The bottom sheet positions its content with smooth scrolling and scroll
   // snapping, so on small mobile viewports the add-filter button can still be
@@ -594,23 +599,25 @@ export const openEqualFilterDialog = async (page: Page, propertyName: string) =>
   await expect(addFilterButton).toBeVisible();
   await expectStablePosition(addFilterButton);
 
-  // Only re-click when the active menu with the target property item really
-  // failed to appear; the add-filter button is in the menu's outside-ignore
-  // list, so a repeated click keeps an already-open menu open.
+  // Floating UI positioning, focus-trap activation, or nested-menu rendering
+  // can replace or detach the property menuitem between a readiness
+  // assertion and a later click, so the item is re-resolved and clicked
+  // inside one retried attempt, and the attempt only succeeds once the
+  // resulting operator submenu is visible.
   await expect(async () => {
+    const propertyItem = findActiveMenuItem(page, propertyItemName);
+
+    // Only re-click when the active menu with the target property item really
+    // failed to appear; the add-filter button is in the menu's outside-ignore
+    // list, so a repeated click keeps an already-open menu open.
     if (!(await propertyItem.isVisible())) {
       await addFilterButton.click();
     }
     await expect(propertyItem).toBeVisible({ timeout: 2_000 });
+    await propertyItem.click();
+    await expect(equalOperatorItem).toBeVisible({ timeout: 2_000 });
   }).toPass({ timeout: 15_000 });
 
-  await propertyItem.click();
-
-  // Selecting a property opens its operator submenu as a nested menu surface
-  // inside the same active menu, so the same scoped lookup resolves the `=`
-  // item without positional guessing.
-  const equalOperatorItem = findActiveMenuItem(page, /^(=|equal)$/i);
-  await expect(equalOperatorItem).toBeVisible();
   await equalOperatorItem.click();
 
   const dialog = page.getByRole('dialog', { name: /filter settings/i });


### PR DESCRIPTION
## Summary

Preserve the rendered identity of Query append slots when object or group entries change, preventing consumers such as Floating UI anchors from retaining detached DOM references. Keep the database-filter E2E flow linear, with one ordinary click per user action.

## Architecture Decision

The defect is owned by the shared Query renderer: an unkeyed trailing append slot could be remounted when the preceding keyed collection changed length. Give each append slot a collision-free stable key rather than compensating in E2E with retries or repeated clicks.

## Ownership Matrix

- feature: database filter composition remains unchanged
- entity: N/A
- widget: database filter sheet remains a consumer only
- page/pane: N/A
- shared: QueryObject and QueryGroup own stable append-slot render identity
- service/worker: N/A

## Source of Truth

The rendered Query hierarchy and its public append slots are the source of truth. E2E verification observes the public menu interaction and must not recover through repeated actions.

## State Shape / API Contract

No state-shape or public slot API changes. The existing append slot element now retains identity across collection growth.

## User Scenarios Preserved

- open the database filter menu
- select a property once
- select an operator once
- add successive filters without detaching the menu anchor
- render object and group append controls as before

## Shared UI / Blast Radius

Touches shared QueryObject and QueryGroup rendering. No new wrapper, dependency, or domain coupling. Regression coverage checks both object and group append-slot identity.

## Verification

- Version bump, format, Oxlint, ESLint, type-check, unit, E2E, Storybook behavior, visual, and mutation stages passed in CI run #1170.
- The database filter E2E completed without a flaky retry.
- PR preview build and publication passed.

## Known Risks

Shared Query rendering affects all consumers. The change is limited to stable VNode keys and is covered for both object and group collection shapes, plus the real database-filter browser flow.

## Reviewer Notes

The E2E flow uses one ordinary click per action. It contains no action retry, forced click, fixed delay, or layout polling.